### PR TITLE
Disable collision for tiles that are not visible.

### DIFF
--- a/Source/Cesium/Private/ACesium3DTileset.cpp
+++ b/Source/Cesium/Private/ACesium3DTileset.cpp
@@ -533,6 +533,7 @@ void ACesium3DTileset::Tick(float DeltaTime)
 		UCesiumGltfComponent* Gltf = static_cast<UCesiumGltfComponent*>(pTile->getRendererResources());
 		if (Gltf && Gltf->IsVisible()) {
 			Gltf->SetVisibility(false, true);
+			Gltf->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 		} else {
 			// TODO: why is this happening?
 		}
@@ -561,6 +562,7 @@ void ACesium3DTileset::Tick(float DeltaTime)
 
 		if (!Gltf->IsVisible()) {
 			Gltf->SetVisibility(true, true);
+			Gltf->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
 		}
 	}
 }

--- a/Source/Cesium/Private/CesiumGltfComponent.cpp
+++ b/Source/Cesium/Private/CesiumGltfComponent.cpp
@@ -811,6 +811,7 @@ UCesiumGltfComponent::CreateOnGameThread(
 		loadModelGameThreadPart(Gltf, model, cesiumToUnrealTransform);
 	}
 	Gltf->SetVisibility(false, true);
+	Gltf->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 	return Gltf;
 }
 
@@ -924,6 +925,16 @@ void UCesiumGltfComponent::DetachRasterTile(
 	});
 
 	this->updateRasterOverlays();
+}
+
+void UCesiumGltfComponent::SetCollisionEnabled(ECollisionEnabled::Type NewType)
+{
+	for (USceneComponent* pSceneComponent : this->GetAttachChildren()) {
+		UCesiumGltfPrimitiveComponent* pPrimitive = Cast<UCesiumGltfPrimitiveComponent>(pSceneComponent);
+		if (pPrimitive) {
+			pPrimitive->SetCollisionEnabled(NewType);
+		}
+	}
 }
 
 void UCesiumGltfComponent::ModelRequestComplete(FHttpRequestPtr request, FHttpResponsePtr response, bool x)

--- a/Source/Cesium/Public/CesiumGltfComponent.h
+++ b/Source/Cesium/Public/CesiumGltfComponent.h
@@ -90,6 +90,9 @@ public:
 		const CesiumGeometry::Rectangle& textureCoordinateRectangle
 	);
 
+	UFUNCTION(BlueprintCallable, Category = "Collision")
+	virtual void SetCollisionEnabled(ECollisionEnabled::Type NewType);
+
 protected:
 	//virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;


### PR DESCRIPTION
Setting an ActorComponent's Visibility to false does not automatically disable collisions with that ActorComponent. So we were colliding with low-detail tiles that were loaded by not visibile.