### PR TITLE
Fix tileset Actor transformations, and other small improvements

### DIFF
--- a/Documentation/reference-frames.md
+++ b/Documentation/reference-frames.md
@@ -1,0 +1,72 @@
+# Reference Frames
+
+This is an inventory of the most important reference frames used in Cesium for Unreal.
+
+## Ellipsoid-centered
+
+This is the "native" reference frame of Cesium.
+
+|  |  |
+|----------|----------|
+| *Handedness* | Right |
+| *Units* | Meters |
+| *Origin* | Center of the ellipsoid (Earth) |
+| *Orientation* | <ul><li>+X passes through the intersection of the equator and prime meridian (0 degrees latitude, 0 degrees longitude)</li><li>+Y passes through the intersection of the equator and +90 degrees longitude (0 degrees latitude, 90 degrees longitude)</li><li>+Z is up through the North Pole</li></ul> |
+
+## Georeferenced
+
+A reference frame defined by the `ACesiumGeoreference` actor.
+
+|  |  |
+|----------|----------|
+| *Handedness* | Right |
+| *Units* | Meters |
+| *Origin* | The origin defined by the `ACesiumGeoreference::OriginPlacement` and possibly `OriginLongitude`, `OriginLatitude`, and `OriginHeight` properties. |
+| *Orientation* | <ul><li>If `ACesiumGeoreference::AlignTilesetUpWithZ` is _true_: <ul><li>+X points East at the origin</li><li>+Y points North at the origin</li><li>+Z is in the direction of the ellipsoid surface normal at the origin (up)</li></ul> </li><li>If `ACesiumGeoreference::AlignTilesetUpWithZ` is _false_: <ul><li>Same as Ellipsoid-centered above.</li></ul> </li></ul> |
+
+## Cesium Tileset
+
+The reference frame of a Cesium 3D Tiles tileset, as defined by the tileset.json. Usually, tilesets are georeferenced and this reference frame is identical to the `Ellipsoid-centered` frame described above, but this is not strictly required by 3D Tiles. A non-georeferenced model of a building, for example, may have an origin at the center of the building and axes aligned with the principal sides of the building.
+
+|  |  |
+|----------|----------|
+| *Handedness* | Right |
+| *Units* | Meters |
+| *Origin* | Specified by tileset.json, often the center of the Earth. |
+| *Orientation* | Specified by tileset.json, often ECEF. |
+
+
+## Unreal Tileset
+
+The same as the Cesium Tileset, but expressed in Unreal Engine terms: the coordinates are in centimeters (multiplied by 100.0) and left-handed (have an inverted Y component) relative to Cesium Tileset coordinates.
+
+Please note that the transformation from Unreal Tileset coordinates to Unreal Absolute/Relative World (below) is affected by the ACesium3DTileset Actor's Location and Orientation properties. However, these should almost always be set to identity.
+
+|  |  |
+|----------|----------|
+| *Handedness* | Left |
+| *Units* | Centimeters |
+| *Origin* | Specified by tileset.json, often the center of the Earth. |
+| *Orientation* | Specified by tileset.json, often ECEF. |
+
+## Unreal Absolute World
+
+Vectors and matrices in Unreal Engine are expressed using single-precision floating-point numbers. In order to maintain precision, these coordinate values must remain relatively small. To support this, the Unreal absolute world origin can be moved by setting the `OriginLocation` property of `UWorld`. Coordinates that are said to be in the "Unreal Absolute World" reference frame are expressed relative to the absolute origin (0,0,0) and are not affected by the value of the `OriginLocation` property.
+
+|  |  |
+|----------|----------|
+| *Handedness* | Left |
+| *Units* | Centimeters |
+| *Origin* | No fixed meaning. |
+| *Orientation* | No fixed meaning. |
+
+## Unreal Relative World
+
+This reference frame has the same orientation as "Unreal Absolute World", but is offset from it by the `UWorld`'s `OriginLocation`. Coordinates are expressed relative to the floating origin.
+
+|  |  |
+|----------|----------|
+| *Handedness* | Left |
+| *Units* | Centimeters |
+| *Origin* | No fixed meaning. |
+| *Orientation* | No fixed meaning. |

--- a/Source/Cesium/Private/Cesium3DTilesetRoot.cpp
+++ b/Source/Cesium/Private/Cesium3DTilesetRoot.cpp
@@ -4,30 +4,43 @@
 #include "Cesium3DTilesetRoot.h"
 #include "Engine/World.h"
 #include "CesiumUtility/Math.h"
+#include "ACesium3DTileset.h"
 
-// Sets default values for this component's properties
 UCesium3DTilesetRoot::UCesium3DTilesetRoot() :
-	_originIsRebasing(false),
+	_worldOriginLocation(0.0),
 	_absoluteLocation(0.0, 0.0, 0.0),
+	_tilesetToUnrealRelativeWorld(),
 	_isDirty(false)
 {
-	// Set this component to be initialized when the game starts, and to be ticked every frame.  You can turn these features
-	// off to improve performance if you don't need them.
 	PrimaryComponentTick.bCanEverTick = false;
-
-	// ...
 }
 
-void UCesium3DTilesetRoot::BeginOriginRebase() {
-	this->_originIsRebasing = true;
+void UCesium3DTilesetRoot::ApplyWorldOffset(const FVector& InOffset, bool bWorldShift) {
+	USceneComponent::ApplyWorldOffset(InOffset, bWorldShift);
+
+	const FIntVector& oldOrigin = this->GetWorld()->OriginLocation;
+	this->_worldOriginLocation = glm::dvec3(
+		static_cast<double>(oldOrigin.X) - static_cast<double>(InOffset.X),
+		static_cast<double>(oldOrigin.Y) - static_cast<double>(InOffset.Y),
+		static_cast<double>(oldOrigin.Z) - static_cast<double>(InOffset.Z)
+	);
+
+	// Do _not_ call _updateAbsoluteLocation. The absolute position doesn't change with
+	// an origin rebase, and we'll lose precision if we update the absolute location here.
+
+	this->_updateTilesetToUnrealRelativeWorldTransform();
 }
 
-void UCesium3DTilesetRoot::EndOriginRebase() {
-	this->_originIsRebasing = false;
-}
-
-void UCesium3DTilesetRoot::MarkClean() {
+void UCesium3DTilesetRoot::MarkTransformUnchanged() {
 	this->_isDirty = false;
+}
+
+void UCesium3DTilesetRoot::RecalculateTransform() {
+	this->_updateTilesetToUnrealRelativeWorldTransform();
+}
+
+const glm::dmat4& UCesium3DTilesetRoot::GetCesiumTilesetToUnrealRelativeWorldTransform() const {
+	return this->_tilesetToUnrealRelativeWorld;
 }
 
 // Called when the game starts
@@ -35,33 +48,46 @@ void UCesium3DTilesetRoot::BeginPlay()
 {
 	Super::BeginPlay();
 
-	const FVector& newLocation = this->GetRelativeLocation();
-	this->_absoluteLocation = glm::dvec3(
-		static_cast<double>(this->GetWorld()->OriginLocation.X) + static_cast<double>(newLocation.X),
-		static_cast<double>(this->GetWorld()->OriginLocation.Y) + static_cast<double>(newLocation.Y),
-		static_cast<double>(this->GetWorld()->OriginLocation.Z) + static_cast<double>(newLocation.Z)
-	);
-	this->_isDirty = true;
+	this->_updateAbsoluteLocation();
+	this->_updateTilesetToUnrealRelativeWorldTransform();
 }
 
 bool UCesium3DTilesetRoot::MoveComponentImpl(const FVector& Delta, const FQuat& NewRotation, bool bSweep, FHitResult* OutHit, EMoveComponentFlags MoveFlags, ETeleportType Teleport) {
 	bool result = USceneComponent::MoveComponentImpl(Delta, NewRotation, bSweep, OutHit, MoveFlags, Teleport);
 
-	if (this->_originIsRebasing) {
-		return result;
-	}
-
-	const FVector& newLocation = this->GetRelativeLocation();
-	glm::dvec3 newLocationAbsolute(
-		static_cast<double>(this->GetWorld()->OriginLocation.X) + static_cast<double>(newLocation.X),
-		static_cast<double>(this->GetWorld()->OriginLocation.Y) + static_cast<double>(newLocation.Y),
-		static_cast<double>(this->GetWorld()->OriginLocation.Z) + static_cast<double>(newLocation.Z)
-	);
-	
-	// Dirty if the position changes by more than a millimeter.
-	this->_isDirty = CesiumUtility::Math::equalsEpsilon(this->_absoluteLocation, newLocationAbsolute, 0.0, 0.001);
-
-	this->_absoluteLocation = newLocationAbsolute;
+	this->_updateAbsoluteLocation();
+	this->_updateTilesetToUnrealRelativeWorldTransform();
 
 	return result;
+}
+
+void UCesium3DTilesetRoot::_updateAbsoluteLocation() {
+	const FVector& newLocation = this->GetRelativeLocation();
+	const FIntVector& originLocation = this->GetWorld()->OriginLocation;
+	this->_absoluteLocation = glm::dvec3(
+		static_cast<double>(originLocation.X) + static_cast<double>(newLocation.X),
+		static_cast<double>(originLocation.Y) + static_cast<double>(newLocation.Y),
+		static_cast<double>(originLocation.Z) + static_cast<double>(newLocation.Z)
+	);
+}
+
+void UCesium3DTilesetRoot::_updateTilesetToUnrealRelativeWorldTransform() {
+	glm::dvec3 relativeLocation = this->_absoluteLocation - this->_worldOriginLocation;
+
+	ACesium3DTileset* pTileset = this->GetOwner<ACesium3DTileset>();
+	glm::dmat4 ellipsoidToGeoreferenced = pTileset->Georeference->GetEllipsoidCenteredToGeoreferencedTransform();
+
+	FMatrix tilesetActorToUeLocal = this->GetComponentToWorld().ToMatrixWithScale();
+	glm::dmat4 ueAbsoluteToUeLocal = glm::dmat4(
+		glm::dvec4(tilesetActorToUeLocal.M[0][0], tilesetActorToUeLocal.M[0][1], tilesetActorToUeLocal.M[0][2], tilesetActorToUeLocal.M[0][3]),
+		glm::dvec4(tilesetActorToUeLocal.M[1][0], tilesetActorToUeLocal.M[1][1], tilesetActorToUeLocal.M[1][2], tilesetActorToUeLocal.M[1][3]),
+		glm::dvec4(tilesetActorToUeLocal.M[2][0], tilesetActorToUeLocal.M[2][1], tilesetActorToUeLocal.M[2][2], tilesetActorToUeLocal.M[2][3]),
+		glm::dvec4(relativeLocation, 1.0)
+	);
+
+	glm::dmat4 transform = ueAbsoluteToUeLocal * CesiumTransforms::unrealToOrFromCesium * CesiumTransforms::scaleToUnrealWorld * ellipsoidToGeoreferenced;
+
+	this->_tilesetToUnrealRelativeWorld = transform;
+
+	this->_isDirty = true;
 }

--- a/Source/Cesium/Private/Cesium3DTilesetRoot.h
+++ b/Source/Cesium/Private/Cesium3DTilesetRoot.h
@@ -5,33 +5,72 @@
 #include "CoreMinimal.h"
 #include "Components/SceneComponent.h"
 #include <glm/vec3.hpp>
+#include <optional>
 #include "Cesium3DTilesetRoot.generated.h"
 
 
-UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+UCLASS()
 class UCesium3DTilesetRoot : public USceneComponent
 {
 	GENERATED_BODY()
 
 public:	
-	// Sets default values for this component's properties
 	UCesium3DTilesetRoot();
 
-	void BeginOriginRebase();
-	void EndOriginRebase();
+	/**
+	 * @brief Determines if {@link GetCesiumTilesetToUnrealRelativeWorldTransform} has changed.
+	 * 
+	 * Returns true if the value returned by {@link GetCesiumTilesetToUnrealRelativeWorldTransform} has
+	 * changed since the last time {@link MarkTransformUnchanged} was called.
+	 */
+	bool IsTransformChanged() const { return this->_isDirty; }
 
-	const glm::dvec3& GetAbsoluteLocation() const { return this->_absoluteLocation; }
-	bool IsDirty() const { return this->_isDirty; }
-	void MarkClean();
+	/**
+	 * @brief Marks {@link GetCesiumTilesetToUnrealRelativeWorldTransform} unchanged.
+	 * 
+	 * After calling this function, {@link IsTransformChanged} will return false until the next
+	 * time that the transform changes.
+	 */
+	void MarkTransformUnchanged();
+
+	/**
+	 * @brief Recalculates {@link GetCesiumTilesetToUnrealRelativeWorldTransform} and marks it changed.
+	 * 
+	 * It is not usually necessary to call this method directly.
+	 */
+	void RecalculateTransform();
+
+	/**
+	 * @brief Gets the transform from the "Cesium Tileset" reference frame to the "Unreal Relative World" reference frame.
+	 * 
+	 * Gets a matrix that transforms coordinates from the "Cesium Tileset" reference frame (which is _usually_
+	 * Earth-centered, Earth-fixed) to Unreal Engine's relative world coordinates (i.e. relative to the world OriginLocation).
+	 * 
+	 * See {@link reference-frames.md}.
+	 * 
+	 * This transformation is a function of :
+	 *   * The location of the Tileset in "Unreal Absolute World" coordinates.
+	 *   * The rotation and scale of the tileset relative to the Unreal World.
+	 *   * `UWorld::OriginLocation`
+	 *   * The transformation from ellipsoid-centered to georeferenced coordinates, as provided by `CesiumGeoreference`.
+	 * 
+	 * @param newOriginLocation The updated World `OriginLocation`. If this is `std::nullopt`, the `OriginLocation` is obtained
+	 *        directly from the `UWorld`.
+	 */
+	const glm::dmat4& GetCesiumTilesetToUnrealRelativeWorldTransform() const;
+
+	virtual void ApplyWorldOffset(const FVector& InOffset, bool bWorldShift) override;
 
 protected:
-	// Called when the game starts
 	virtual void BeginPlay() override;
-
 	virtual bool MoveComponentImpl(const FVector& Delta, const FQuat& NewRotation, bool bSweep, FHitResult* OutHit = NULL, EMoveComponentFlags MoveFlags = MOVECOMP_NoFlags, ETeleportType Teleport = ETeleportType::None) override;
 
 private:
-	bool _originIsRebasing;
+	void _updateAbsoluteLocation();
+	void _updateTilesetToUnrealRelativeWorldTransform();
+
+	glm::dvec3 _worldOriginLocation;
 	glm::dvec3 _absoluteLocation;
+	glm::dmat4 _tilesetToUnrealRelativeWorld;
 	bool _isDirty;
 };

--- a/Source/Cesium/Private/CesiumGeoreference.cpp
+++ b/Source/Cesium/Private/CesiumGeoreference.cpp
@@ -27,7 +27,7 @@ ACesiumGeoreference::ACesiumGeoreference()
 	PrimaryActorTick.bCanEverTick = true;
 }
 
-glm::dmat4x4 ACesiumGeoreference::GetGeoreferencedOriginToEllipsoidCenteredTransform() const {
+glm::dmat4x4 ACesiumGeoreference::GetGeoreferencedToEllipsoidCenteredTransform() const {
 	if (this->OriginPlacement == EOriginPlacement::TrueOrigin) {
 		return glm::dmat4(1.0);
 	}
@@ -65,8 +65,8 @@ glm::dmat4x4 ACesiumGeoreference::GetGeoreferencedOriginToEllipsoidCenteredTrans
 	}
 }
 
-glm::dmat4x4 ACesiumGeoreference::GetEllipsoidCenteredToGeoreferencedOriginTransform() const {
-	return glm::affineInverse(this->GetGeoreferencedOriginToEllipsoidCenteredTransform());
+glm::dmat4x4 ACesiumGeoreference::GetEllipsoidCenteredToGeoreferencedTransform() const {
+	return glm::affineInverse(this->GetGeoreferencedToEllipsoidCenteredTransform());
 }
 
 void ACesiumGeoreference::AddGeoreferencedObject(ICesiumGeoreferenceable* Object)
@@ -101,7 +101,7 @@ void ACesiumGeoreference::OnConstruction(const FTransform& Transform)
 
 void ACesiumGeoreference::UpdateGeoreference()
 {
-	glm::dmat4 transform = this->GetEllipsoidCenteredToGeoreferencedOriginTransform();
+	glm::dmat4 transform = this->GetEllipsoidCenteredToGeoreferencedTransform();
 	for (TWeakInterfacePtr<ICesiumGeoreferenceable> pObject : this->_georeferencedObjects) {
 		if (pObject.IsValid()) {
 			pObject->UpdateGeoreferenceTransform(transform);

--- a/Source/Cesium/Private/CesiumGltfComponent.cpp
+++ b/Source/Cesium/Private/CesiumGltfComponent.cpp
@@ -893,17 +893,6 @@ void UCesiumGltfComponent::LoadModel(const FString& Url)
 	request->ProcessRequest();
 }
 
-void UCesiumGltfComponent::ApplyWorldOffset(const FVector& InOffset, bool bWorldShift) {
-	USceneComponent::ApplyWorldOffset(InOffset, bWorldShift);
-
-	const FIntVector& originLocation = this->GetWorld()->OriginLocation;
-	glm::dvec3 offset = glm::dvec3(InOffset.X, InOffset.Y, InOffset.Z);
-	glm::dvec3 newOrigin = glm::dvec3(originLocation.X, originLocation.Y, originLocation.Z);
-	newOrigin -= offset;
-
-
-}
-
 void UCesiumGltfComponent::UpdateTransformFromCesium(const glm::dmat4& cesiumToUnrealTransform) {
 	for (USceneComponent* pSceneComponent : this->GetAttachChildren()) {
 		UCesiumGltfPrimitiveComponent* pPrimitive = Cast<UCesiumGltfPrimitiveComponent>(pSceneComponent);

--- a/Source/Cesium/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/Cesium/Private/GlobeAwareDefaultPawn.cpp
@@ -147,7 +147,7 @@ void AGlobeAwareDefaultPawn::AccurateTransformUEToECEF(double X, double Y, doubl
 		-(Y + static_cast<double>(ueOrigin.Y)), // ? TBC
 		Z + static_cast<double>(ueOrigin.Z)
 	) / 100.0;
-	glm::dmat4 unrealToEcef = this->Georeference->GetGeoreferencedOriginToEllipsoidCenteredTransform();
+	glm::dmat4 unrealToEcef = this->Georeference->GetGeoreferencedToEllipsoidCenteredTransform();
 	glm::dvec3 locationEcef = unrealToEcef * glm::dvec4(location, 1.0);
 
 	ResultX = locationEcef.x;
@@ -348,7 +348,7 @@ void AGlobeAwareDefaultPawn::BeginPlay()
 void AGlobeAwareDefaultPawn::RefreshMatricesCache()
 {
 	// Optim - Refresh is needed only when CesiumGeoReference actor is changed...
-	ecefToUnreal = this->Georeference->GetEllipsoidCenteredToGeoreferencedOriginTransform();
+	ecefToUnreal = this->Georeference->GetEllipsoidCenteredToGeoreferencedTransform();
 }
 
 glm::dmat3 AGlobeAwareDefaultPawn::computeEastNorthUpToFixedFrame() const {
@@ -364,7 +364,7 @@ glm::dmat3 AGlobeAwareDefaultPawn::computeEastNorthUpToFixedFrame() const {
 		static_cast<double>(ueLocation.Z) + static_cast<double>(ueOrigin.Z)
 	) / 100.0;
 
-	glm::dmat4 unrealToEcef = this->Georeference->GetGeoreferencedOriginToEllipsoidCenteredTransform();
+	glm::dmat4 unrealToEcef = this->Georeference->GetGeoreferencedToEllipsoidCenteredTransform();
 	glm::dvec3 cameraEcef = unrealToEcef * glm::dvec4(location, 1.0);
 	glm::dmat4 enuToEcefAtCamera = CesiumGeospatial::Transforms::eastNorthUpToFixedFrame(cameraEcef);
 	glm::dmat4 ecefToUnrealTmp = glm::affineInverse(unrealToEcef);

--- a/Source/Cesium/Public/ACesium3DTileset.h
+++ b/Source/Cesium/Public/ACesium3DTileset.h
@@ -79,45 +79,15 @@ public:
 	UPROPERTY(EditAnywhere, Category = "Cesium|Debug")
 	bool ShowInEditor = true;
 
-	/**
-	 * Gets a 4x4 matrix that transforms coordinates in the global Unreal world coordinate system
-	 * (that is, accounting for the world's OriginLocation) and transforms them to the tileset's
-	 * coordinate system.
-	 */
-	glm::dmat4x4 GetWorldToTilesetTransform() const;
-	
-	/**
-	 * Gets a 4x4 matrix that transforms coordinates in the tileset's coordinate system to the
-	 * global Unreal coordinate system (that is, accounting for the world's OriginLocation).
-	 * TODO: does it really? no
-	 */
-	glm::dmat4x4 GetTilesetToWorldTransform() const;
-
-	/**
-	 * Gets a 4x4 matrix that transforms coordinates in the global world coordinate system (that is,
-	 * the one that accounts for the world's OriginLocation) and transforms them to the local world
-	 * coordinate system (that is, relative to the floating OriginLocation).
-	 */
-	glm::dmat4x4 GetGlobalWorldToLocalWorldTransform() const;
-
-	/**
-	 * Gets a 4x4 matrix that transforms coordinate in the local world coordinate system (that is,
-	 * relative to the floating OriginLocation) and transforms them to the global world coordinate
-	 * system (that is, account for the world's OriginLocation).
-	 */
-	glm::dmat4x4 GetLocalWorldToGlobalWorldTransform() const;
-
-	glm::dmat4x4 GetTilesetToUnrealWorldTransform(const std::optional<glm::dvec3>& newOriginLocation = std::nullopt) const;
+	const glm::dmat4& GetCesiumTilesetToUnrealRelativeWorldTransform() const;
 
 	Cesium3DTiles::Tileset* GetTileset() { return this->_pTileset; }
 	const Cesium3DTiles::Tileset* GetTileset() const { return this->_pTileset; }
 
-	virtual void ApplyWorldOffset(const FVector& InOffset, bool bWorldShift) override;
-
 	virtual bool IsBoundingVolumeReady() const override;
 	virtual std::optional<Cesium3DTiles::BoundingVolume> GetBoundingVolume() const override;
 	void UpdateTransformFromCesium(const glm::dmat4& cesiumToUnreal);
-	virtual void UpdateGeoreferenceTransform(const glm::dmat4& ellipsoidCenteredToGeoreferencedOriginTransform);
+	virtual void UpdateGeoreferenceTransform(const glm::dmat4& ellipsoidCenteredToGeoreferencedTransform);
 
 protected:
 	// Called when the game starts or when spawned

--- a/Source/Cesium/Public/CesiumBingMapsOverlay.h
+++ b/Source/Cesium/Public/CesiumBingMapsOverlay.h
@@ -21,7 +21,7 @@ enum class EBingMapsStyle : uint8 {
 /**
  * 
  */
-UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
+UCLASS(ClassGroup = (Cesium), meta = (BlueprintSpawnableComponent))
 class CESIUM_API UCesiumBingMapsOverlay : public UCesiumRasterOverlay
 {
 	GENERATED_BODY()

--- a/Source/Cesium/Public/CesiumGeoreference.h
+++ b/Source/Cesium/Public/CesiumGeoreference.h
@@ -85,8 +85,8 @@ public:
 	double OriginHeight = 0.0;
 
 	/**
-	 * If true, the tileset is rotated so that the local up at the center of the tileset's bounding
-	 * volume is aligned with the usual Unreal Engine up direction, +Z. This is useful because
+	 * If true, the tileset is rotated so that the local up at the origin position
+	 * is aligned with the usual Unreal Engine up direction, +Z. This is useful because
 	 * 3D Tiles tilesets often use Earth-centered, Earth-fixed coordinates in which the local
 	 * up direction depends on where you are on the Earth. If false, the tileset's true rotation
 	 * is used.
@@ -118,20 +118,20 @@ public:
 	// TODO: Allow user to select/configure the ellipsoid.
 
 	/**
-	 * @brief Gets the transformation from the georeferenced origin coordinate system to the standard ellipsoid-centered coordinate system (i.e. ECEF).
+	 * @brief Gets the transformation from the "Georeferenced" reference frame defined by this instance to the "Ellipsoid-centered" reference frame (i.e. ECEF).
 	 * 
-	 * Gets a matrix that transforms coordinates from the local coordinate system defined by this instance to the ellipsoid-centered
-	 * coordinate system, which is usually Earth-centered, Earth-fixed.
+	 * Gets a matrix that transforms coordinates from the "Georeference" reference frame defined by this instance to the "Ellipsoid-centered"
+	 * reference frame, which is usually Earth-centered, Earth-fixed. See {@link reference-frames.md}.
 	 */
-	glm::dmat4x4 GetGeoreferencedOriginToEllipsoidCenteredTransform() const;
+	glm::dmat4x4 GetGeoreferencedToEllipsoidCenteredTransform() const;
 
 	/**
-	 * @brief Gets the transformation from the standard ellipsoid-centered coordinate system (i.e. ECEF) to georeferenced origin coordinate system.
+	 * @brief Gets the transformation from the "Ellipsoid-centered" reference frame (i.e. ECEF) to the georeferenced reference frame defined by this instance.
 	 *
-	 * Gets a matrix that transforms coordinates from the ellipsoid-centered coordinate system (which is usually Earth-centered, Earth-fixed) to
-	 * the local coordinate system defined by this instance.
+	 * Gets a matrix that transforms coordinates from the "Ellipsoid-centered" reference frame (which is usually Earth-centered, Earth-fixed) to
+	 * the "Georeferenced" reference frame defined by this instance. See {@link reference-frames.md}.
 	 */
-	glm::dmat4x4 GetEllipsoidCenteredToGeoreferencedOriginTransform() const;
+	glm::dmat4x4 GetEllipsoidCenteredToGeoreferencedTransform() const;
 
 	void AddGeoreferencedObject(ICesiumGeoreferenceable* Object);
 

--- a/Source/Cesium/Public/CesiumGeoreferenceable.h
+++ b/Source/Cesium/Public/CesiumGeoreferenceable.h
@@ -39,5 +39,5 @@ public:
 	 * Updates this object with a new transformation from the ellipsoid-centered coordinate system to
 	 * the local coordinates of the georeferenced origin.
 	 */
-	virtual void UpdateGeoreferenceTransform(const glm::dmat4& ellipsoidCenteredToGeoreferencedOriginTransform) = 0;
+	virtual void UpdateGeoreferenceTransform(const glm::dmat4& ellipsoidCenteredToGeoreferencedTransform) = 0;
 };

--- a/Source/Cesium/Public/CesiumGltfComponent.h
+++ b/Source/Cesium/Public/CesiumGltfComponent.h
@@ -36,7 +36,7 @@ struct FRasterOverlayTile {
 	FLinearColor translationAndScale;
 };
 
-UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+UCLASS()
 class CESIUM_API UCesiumGltfComponent : public USceneComponent
 {
 	GENERATED_BODY()
@@ -77,7 +77,6 @@ public:
 	UFUNCTION(BlueprintCallable)
 	void LoadModel(const FString& Url);
 
-	virtual void ApplyWorldOffset(const FVector& InOffset, bool bWorldShift) override;
 	void UpdateTransformFromCesium(const glm::dmat4& cesiumToUnrealTransform);
 
 	void AttachRasterTile(

--- a/Source/Cesium/Public/CesiumIonRasterOverlay.h
+++ b/Source/Cesium/Public/CesiumIonRasterOverlay.h
@@ -9,7 +9,7 @@
 /**
  * 
  */
-UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
+UCLASS(ClassGroup = (Cesium), meta = (BlueprintSpawnableComponent))
 class CESIUM_API UCesiumIonRasterOverlay : public UCesiumRasterOverlay
 {
 	GENERATED_BODY()

--- a/Source/Cesium/Public/UCesiumGltfPrimitiveComponent.h
+++ b/Source/Cesium/Public/UCesiumGltfPrimitiveComponent.h
@@ -7,7 +7,7 @@
 #include <glm/mat4x4.hpp>
 #include "UCesiumGltfPrimitiveComponent.generated.h"
 
-UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+UCLASS()
 class CESIUM_API UCesiumGltfPrimitiveComponent : public UStaticMeshComponent
 {
 	GENERATED_BODY()


### PR DESCRIPTION
* Fix the computation of transformation matrices when a Cesium3DTileset Actor has a non-zero location.
* Add `Documentation/reference-frames.md` to inventory some of the many confusing reference frames we need to deal with.
* Remove call to deprecated `DetachFromParent` method when destroying tiles.
* Put raster overlay ActorComponents in the "Cesium" group instead of "Custom".
* Don't expose internal-use-only ActorComponents, `CesiumGltfComponent` and `CesiumGltfPrimitiveComponent`, to Blueprints, so they don't show up in the UI.

Fixes #105.
