### PR TITLE
Fixed Georeference nullptr crash when creating a new Tileset 

### DIFF
--- a/Source/Cesium/Private/Cesium3DTilesetRoot.cpp
+++ b/Source/Cesium/Private/Cesium3DTilesetRoot.cpp
@@ -77,6 +77,9 @@ void UCesium3DTilesetRoot::_updateAbsoluteLocation() {
 
 void UCesium3DTilesetRoot::_updateTilesetToUnrealRelativeWorldTransform() {	
 	ACesium3DTileset* pTileset = this->GetOwner<ACesium3DTileset>();
+	if (!pTileset->Georeference) {
+		return;
+	}
 	glm::dmat4 ellipsoidCenteredToGeoreferencedTransform = pTileset->Georeference->GetEllipsoidCenteredToGeoreferencedTransform();
 	_updateTilesetToUnrealRelativeWorldTransform(ellipsoidCenteredToGeoreferencedTransform);
 }


### PR DESCRIPTION
Fixes #118 

I think it's this simple, adding a tileset seems to work very smoothly now!