### PR TITLE
Fix crash on shutdown / level change.

### DIFF
--- a/Source/Cesium/Private/CesiumGltfComponent.cpp
+++ b/Source/Cesium/Private/CesiumGltfComponent.cpp
@@ -1273,6 +1273,13 @@ void UCesiumGltfComponent::updateRasterOverlays() {
 		if (pPrimitive) {
 			UMaterialInstanceDynamic* pMaterial = Cast<UMaterialInstanceDynamic>(pPrimitive->GetMaterial(0));
 
+			if (pMaterial->IsPendingKillOrUnreachable()) {
+				// Don't try to update the material while it's in the process of being destroyed.
+				// This can lead to the render thread freaking out when it's asked to update a parameter for
+				// a material that has been marked for garbage collection.
+				continue;
+			}
+
 			for (size_t i = 0; i < this->_overlayTiles.Num(); ++i) {
 				FRasterOverlayTile& overlayTile = this->_overlayTiles[i];
 				std::string is = std::to_string(i + 1);

--- a/Source/Cesium/Public/CesiumGltfComponent.h
+++ b/Source/Cesium/Public/CesiumGltfComponent.h
@@ -31,7 +31,10 @@ namespace CesiumGeometry {
 USTRUCT()
 struct FRasterOverlayTile {
 	GENERATED_BODY()
+
+	UPROPERTY()
 	UTexture2D* pTexture;
+
 	FLinearColor textureCoordinateRectangle;
 	FLinearColor translationAndScale;
 };


### PR DESCRIPTION
This builds on #122 so merge that first. After it's merged, I'll change this branch to target master instead of `cmpt`.

This fixes a crash that frequently occurrs at shutdown or when changing levels, with the UE render thread complaining of a material, "Cannot queue the Expression Cache when it is about to be deleted."

At shutdown / level change, the UCesiumRasterOverlay component and the UMaterials attached to various glTFs would become unreachable (and therefore eligible for garbage collection) at pretty much the same time. When we destroy an overlay, we detach any overlay tiles, which requires updating material parameters. If we did that while the material was also eligible for GC, then UE would happily queue a task to the render thread to update material's render proxy, but then crash when it noticed that the material was marked for garbage collection.

The fix was to add an `IsPendingKillOrUnreachable` check around attempts to set material parameters when detaching raster overlays, so we don't try to update parameters of materials that are already on their way out.

Also marked `FRasterOverlayTile::pTexture` as a `UPROPERTY` so it participates in GC reference tracking. I don't think this fixed anything, but it's the correct thing to do.

Fixes #108

