### PR TITLE
Fixed inconsistent nullptr crash when destroying tilesets 

### DIFF
--- a/Source/Cesium/Private/ACesium3DTileset.cpp
+++ b/Source/Cesium/Private/ACesium3DTileset.cpp
@@ -181,9 +181,7 @@ public:
 			delete pHalf;
 		} else if (pMainThreadResult) {
 			UCesiumGltfComponent* pGltf = reinterpret_cast<UCesiumGltfComponent*>(pMainThreadResult);
-			if (pGltf) {
-				this->destroyRecursively(pGltf);
-			}
+			this->destroyRecursively(pGltf);
 		}
 	}
 
@@ -282,7 +280,11 @@ private:
 	// 	return ReferredToObjects.Num();
 	// }
 
-	void destroyRecursively(USceneComponent* pComponent) {
+	void destroyRecursively(USceneComponent* pComponent) {	
+		if (!pComponent) {
+			return;
+		}
+
 		// FString newName = TEXT("Destroyed_") + pComponent->GetName();
 		// pComponent->Rename(*newName);
 
@@ -293,7 +295,6 @@ private:
 			pComponent->UnregisterComponent();
 		}
 
-		// TODO: occasional nullptr crashes seem to happen here, check if pChild == null ??
 		TArray<USceneComponent*> children = pComponent->GetAttachChildren();
 		for (USceneComponent* pChild : children) {
 			this->destroyRecursively(pChild);


### PR DESCRIPTION
There was an inconsistent crash happening usually on level change or exit that seemed to be caused by pointers to `ACesiumGltfComponent` being null in `UnrealResourcePreparer::destroyRecursively(...)`. After Kevin's fix of [the old crash](https://github.com/CesiumGS/cesium-unreal/pull/129) on shutdown, this one became a little easier to reproduce (the other one wasn't overshadowing it hahah), but it still does not always happen. I think this fix is simple enough, but maybe it's worth checking why certain gltf children components exist in the childrens list but are null, in case there's a slightly deeper issue behind this.