### PR TITLE
Add Marketplace URL to the plugin file

### DIFF
--- a/CesiumForUnreal.uplugin
+++ b/CesiumForUnreal.uplugin
@@ -8,7 +8,7 @@
 	"CreatedBy": "Cesium GS, Inc.",
 	"CreatedByURL": "https://cesium.com",
 	"DocsURL": "https://cesium.com/docs",
-	"MarketplaceURL": "",
+	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/87b0d05800a545d49bf858ef3458c4f7",
 	"SupportURL": "https://community.cesium.com",
 	"EngineVersion":  "4.26.0",
 	"CanContainContent": true,


### PR DESCRIPTION
Based on Epic's requirements, adding the marketplace URL to the uplugin file after submission for approval.

I'm going to self merge this.