### PR TITLE
Tick the AsyncSystem from the CesiumIonPanel.

### DIFF
--- a/Source/CesiumEditor/CesiumIonPanel.cpp
+++ b/Source/CesiumEditor/CesiumIonPanel.cpp
@@ -295,6 +295,11 @@ void CesiumIonPanel::Refresh() {
     this->_pListView->RequestListRefresh();
 }
 
+void CesiumIonPanel::Tick(const FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime) {
+    FCesiumEditorModule::ion().getAsyncSystem().dispatchMainThreadTasks();
+    SCompoundWidget::Tick(AllottedGeometry, InCurrentTime, InDeltaTime);
+}
+
 void CesiumIonPanel::AssetSelected(TSharedPtr<CesiumIonClient::Asset> item, ESelectInfo::Type selectionType)
 {
     this->_pSelection = item;

--- a/Source/CesiumEditor/CesiumIonPanel.h
+++ b/Source/CesiumEditor/CesiumIonPanel.h
@@ -26,6 +26,8 @@ class CesiumIonPanel : public SCompoundWidget {
 
     void Refresh();
 
+    virtual void Tick(const FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime) override;
+
 private:
     TSharedRef<SWidget> AssetDetails();
     TSharedRef<ITableRow> CreateAssetRow(TSharedPtr<CesiumIonClient::Asset> item, const TSharedRef<STableViewBase>& list);


### PR DESCRIPTION
Without something dispatch the AsyncSystem's main thread events, some network operations will never complete. Previously only the main Cesium panel did the dispatching, so if that panel was closed, the Cesium ion Assets panel wouldn't update.

Fixes #147 
