### PR TITLE
Remove raster overlay clipping code

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
@@ -58,15 +58,6 @@ void UCesiumRasterOverlay::AddToTileset() {
       this->CreateOverlay();
   this->_pOverlay = pOverlay.get();
 
-  for (const FRectangularCutout& cutout : this->Cutouts) {
-    pOverlay->getCutouts().push_back(
-        CesiumGeospatial::GlobeRectangle::fromDegrees(
-            cutout.west,
-            cutout.south,
-            cutout.east,
-            cutout.north));
-  }
-
   pTileset->getOverlays().add(std::move(pOverlay));
 }
 

--- a/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
@@ -12,23 +12,6 @@ namespace Cesium3DTiles {
 class Tileset;
 }
 
-USTRUCT()
-struct FRectangularCutout {
-  GENERATED_BODY()
-
-  UPROPERTY(EditAnywhere, Category = "Cesium")
-  double west;
-
-  UPROPERTY(EditAnywhere, Category = "Cesium")
-  double south;
-
-  UPROPERTY(EditAnywhere, Category = "Cesium")
-  double east;
-
-  UPROPERTY(EditAnywhere, Category = "Cesium")
-  double north;
-};
-
 UCLASS(Abstract)
 class CESIUMRUNTIME_API UCesiumRasterOverlay : public UActorComponent {
   GENERATED_BODY()
@@ -36,13 +19,6 @@ class CESIUMRUNTIME_API UCesiumRasterOverlay : public UActorComponent {
 public:
   // Sets default values for this component's properties
   UCesiumRasterOverlay();
-
-  /**
-   * Rectangular cutouts where this tileset should not be drawn. Each cutout is
-   * specified as "west,south,east,north" in decimal degrees.
-   */
-  UPROPERTY(EditAnywhere, Category = "Cesium|Experimental")
-  TArray<FRectangularCutout> Cutouts;
 
 protected:
   // Called when the game starts


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium-native/issues/113. 

https://github.com/CesiumGS/cesium-native/pull/170 needs to be merged before this one

The original code is moved to https://github.com/CesiumGS/cesium-unreal/tree/clip-rectangle branch