### PR TITLE
Get Unreal Engine from Google Cloud Storage instead of S3.

### DIFF
--- a/travis/travis-get-ue.sh
+++ b/travis/travis-get-ue.sh
@@ -1,9 +1,9 @@
 if [ ! -d "/c/Program Files/Epic Games/UE_4.26" ]
 then
-    aws s3 cp s3://cesium-unreal-engine/2021-03-16/UE_4.26.zip .
+    AWS_ACCESS_KEY_ID=${GOOGLE_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${GOOGLE_SECRET_ACCESS_KEY} aws s3 --endpoint-url https://storage.googleapis.com cp s3://cesium-unreal-engine/2021-03-16/UE_4.26.zip .
     7z x UE_4.26.zip "-oC:\Program Files\Epic Games"
     rm UE_4.26.zip
-    aws s3 cp s3://cesium-unreal-engine/2021-03-16/Launcher.zip .
+    AWS_ACCESS_KEY_ID=${GOOGLE_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${GOOGLE_SECRET_ACCESS_KEY} aws s3 --endpoint-url https://storage.googleapis.com cp s3://cesium-unreal-engine/2021-03-16/Launcher.zip .
     7z x Launcher.zip "-oC:\Program Files (x86)\Epic Games"
     rm Launcher.zip
 fi


### PR DESCRIPTION
But still using the AWS CLI via Google's S3 interop because I'm a rebel like that.

This should save about 72 cents per CI build in data transfer costs by putting the Unreal Engine package in Google Cloud with Travis, taking advantage of free data transfer within GCP.