### PR TITLE
Fixes FlyTo not respecting Progress Curve

### DIFF
--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -327,9 +327,9 @@ void AGlobeAwareDefaultPawn::Tick(float DeltaSeconds) {
       }
 
       // Find the keypoint indexes corresponding to the current percentage
-      int lastIndex = glm::floor(rawPercentage * (this->_keypoints.size() - 1));
+      int lastIndex = glm::floor(flyPercentage * (this->_keypoints.size() - 1));
       double segmentPercentage =
-          rawPercentage * (this->_keypoints.size() - 1) - lastIndex;
+          flyPercentage * (this->_keypoints.size() - 1) - lastIndex;
       int nextIndex = lastIndex + 1;
 
       // Get the current position by interpolating between those two points


### PR DESCRIPTION
Fixes slight mistake in the original FlyTo implementation that got copied into my implementation. This was probably what was originally intended. The camera respects the FlyTo Progress Curve now and is much nicer when an "S" shape progress curve is used (this slows the camera at the beginning and end of the flight). It's much easier to get a sense of where the camera is flying from/to.