### PR TITLE
Put all our blueprints props/funcs in a category.

### DIFF
--- a/Source/CesiumEditor/Private/CesiumEditorSettings.h
+++ b/Source/CesiumEditor/Private/CesiumEditorSettings.h
@@ -18,6 +18,6 @@ public:
    * The token used to access Cesium ion. If this is blank or invalid, the
    * Cesium panel will prompt you to log in to Cesium ion with OAuth2.
    */
-  UPROPERTY(Config, EditAnywhere)
+  UPROPERTY(Config, EditAnywhere, Category = "Cesium")
   FString CesiumIonAccessToken;
 };

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.h
@@ -69,10 +69,10 @@ public:
   UCesiumGltfComponent();
   virtual ~UCesiumGltfComponent();
 
-  UPROPERTY(EditAnywhere)
+  UPROPERTY(EditAnywhere, Category = "Cesium")
   UMaterial* BaseMaterial;
 
-  UPROPERTY(EditAnywhere)
+  UPROPERTY(EditAnywhere, Category = "Cesium")
   UMaterial* OpacityMaskMaterial;
 
   void UpdateTransformFromCesium(const glm::dmat4& CesiumToUnrealTransform);

--- a/Source/CesiumRuntime/Public/CesiumCreditSystem.h
+++ b/Source/CesiumRuntime/Public/CesiumCreditSystem.h
@@ -31,13 +31,13 @@ public:
   /**
    * The credits text to display.
    */
-  UPROPERTY(BlueprintReadOnly)
+  UPROPERTY(BlueprintReadOnly, Category = "Cesium")
   FString Credits = "";
 
   /**
    * Whether the credit string has changed since last frame.
    */
-  UPROPERTY(BlueprintReadOnly)
+  UPROPERTY(BlueprintReadOnly, Category = "Cesium")
   bool CreditsUpdated = false;
 
   // Called every frame

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -47,33 +47,33 @@ struct FCesiumSubLevel {
   /**
    * The plain name of the sub level, without any prefixes.
    */
-  UPROPERTY(EditAnywhere)
+  UPROPERTY(EditAnywhere, Category = "Cesium")
   FString LevelName;
 
   /**
    * The WGS84 longitude in degrees of where this level should sit on the
    * globe.
    */
-  UPROPERTY(EditAnywhere)
+  UPROPERTY(EditAnywhere, Category = "Cesium")
   double LevelLongitude = 0.0;
 
   /**
    * The WGS84 latitude in degrees of where this level should sit on the globe.
    */
-  UPROPERTY(EditAnywhere)
+  UPROPERTY(EditAnywhere, Category = "Cesium")
   double LevelLatitude = 0.0;
 
   /**
    * The height in meters above the WGS84 globe this level should sit.
    */
-  UPROPERTY(EditAnywhere)
+  UPROPERTY(EditAnywhere, Category = "Cesium")
   double LevelHeight = 0.0;
 
   /**
    * How far in meters from the sublevel local origin the camera needs to be to
    * load the level.
    */
-  UPROPERTY(EditAnywhere)
+  UPROPERTY(EditAnywhere, Category = "Cesium")
   double LoadRadius = 0.0;
 
   /**
@@ -101,7 +101,7 @@ class CESIUMRUNTIME_API ACesiumGeoreference : public AActor {
   GENERATED_BODY()
 
 public:
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   static ACesiumGeoreference* GetDefaultForActor(AActor* Actor);
 
   ACesiumGeoreference();
@@ -288,7 +288,7 @@ public:
    * degrees (y), and height in meters (z) to Unreal's world origin. I.e. it
    * rotates the globe so that these coordinates exactly fall on the origin.
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   void
   InaccurateSetGeoreferenceOrigin(const FVector& TargetLongitudeLatitudeHeight);
 
@@ -309,7 +309,7 @@ public:
    * degrees (y), and height in meters (z) into Earth-Centered, Earth-Fixed
    * (ECEF) coordinates.
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateTransformLongitudeLatitudeHeightToEcef(
       const FVector& LongitudeLatitudeHeight) const;
 
@@ -326,7 +326,7 @@ public:
    * WGS84 longitude in degrees (x), latitude in degrees (y), and height in
    * meters (z).
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector
   InaccurateTransformEcefToLongitudeLatitudeHeight(const FVector& Ecef) const;
 
@@ -343,7 +343,7 @@ public:
    * degrees (y), and height in meters (z) into Unreal world coordinates
    * (relative to the floating origin).
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateTransformLongitudeLatitudeHeightToUe(
       const FVector& LongitudeLatitudeHeight) const;
 
@@ -359,7 +359,7 @@ public:
    * WGS84 longitude in degrees (x), latitude in degrees (y), and height in
    * meters (z).
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector
   InaccurateTransformUeToLongitudeLatitudeHeight(const FVector& Ue) const;
 
@@ -373,7 +373,7 @@ public:
    * Transforms the given point from Earth-Centered, Earth-Fixed (ECEF) into
    * Unreal relative world (relative to the floating origin).
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateTransformEcefToUe(const FVector& Ecef) const;
 
   /**
@@ -386,7 +386,7 @@ public:
    * Transforms the given point from Unreal relative world (relative to the
    * floating origin) to Earth-Centered, Earth-Fixed (ECEF).
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateTransformUeToEcef(const FVector& Ue) const;
 
   /**
@@ -401,7 +401,7 @@ public:
    * Transforms a rotator from Unreal world to East-North-Up at the given
    * Unreal relative world location (relative to the floating origin).
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   FRotator InaccurateTransformRotatorUeToEnu(
       const FRotator& UeRotator,
       const FVector& UeLocation) const;
@@ -418,7 +418,7 @@ public:
    * Transforms a rotator from East-North-Up to Unreal world at the given
    * Unreal relative world location (relative to the floating origin).
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   FRotator InaccurateTransformRotatorEnuToUe(
       const FRotator& EnuRotator,
       const FVector& UeLocation) const;
@@ -437,7 +437,7 @@ public:
    * origin). The returned transformation works in Unreal's left-handed
    * coordinate system.
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   FMatrix InaccurateComputeEastNorthUpToUnreal(const FVector& Ue) const;
 
   /**
@@ -450,7 +450,7 @@ public:
    * Computes the rotation matrix from the local East-North-Up to
    * Earth-Centered, Earth-Fixed (ECEF) at the specified ECEF location.
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   FMatrix InaccurateComputeEastNorthUpToEcef(const FVector& Ecef) const;
 
   /*

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -112,7 +112,7 @@ public:
    * Move the actor to the specified WGS84 longitude in degrees (x), latitude
    * in degrees (y), and height in meters (z).
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   void InaccurateMoveToLongitudeLatitudeHeight(
       const FVector& TargetLongitudeLatitudeHeight,
       bool MaintainRelativeOrientation = true);
@@ -129,7 +129,7 @@ public:
    * Move the actor to the specified Earth-Centered, Earth-Fixed (ECEF)
    * coordinates.
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   void InaccurateMoveToECEF(
       const FVector& TargetEcef,
       bool MaintainRelativeOrientation = true);

--- a/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
+++ b/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
@@ -151,7 +151,7 @@ public:
    * {@see FlyToMaximumAltitudeCurve}, {@see FlyToDuration}, and
    * {@see FlyToGranularityDegrees}.
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   void InaccurateFlyToLocationECEF(
       const FVector& ECEFDestination,
       float YawAtDestination,
@@ -180,7 +180,7 @@ public:
    * {@see FlyToProgressCurve}, {@see FlyToMaximumAltitudeCurve},
    * {@see FlyToDuration}, and {@see FlyToGranularityDegrees}.
    */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   void InaccurateFlyToLocationLongitudeLatitudeHeight(
       const FVector& LongitudeLatitudeHeightDestination,
       float YawAtDestination,


### PR DESCRIPTION
This is required for engine modules, and avoids compile errors like this:

```
CompilerResultsLog: Error: C:/Program Files/Epic Games/UE_4.26/Engine/Plugins/CesiumForUnreal/Source/CesiumRuntime/Public/CesiumCreditSystem.h(35)  : LogCompile: Error: An explicit Category specifier is required for any property exposed to the editor or Blueprints in an Engine module.
```

I'm currently testing this by packing the plugin and installing it as an engine plugin. Will add a note once I confirm it works.