### PR TITLE
Log selection stats at Verbose instead of Display level.

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -877,7 +877,7 @@ void ACesium3DTileset::Tick(float DeltaTime) {
 
     UE_LOG(
         LogCesium,
-        Display,
+        Verbose,
         TEXT(
             "%s: %d ms, Visited %d, Culled Visited %d, Rendered %d, Culled %d, Max Depth Visited: %d, Loading-Low %d, Loading-Medium %d, Loading-High %d"),
         *this->GetName(),


### PR DESCRIPTION
Combined with CesiumGS/cesium-native#193, this greatly reduces the amount of information written to the Output window by default, making it more likely that we (and users) notice real problems.