### PR TITLE
Change UMaterial references to UMaterialInterface

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1416,7 +1416,7 @@ UCesiumGltfComponent::CreateOffGameThread(
     AActor* pParentActor,
     std::unique_ptr<HalfConstructed> pHalfConstructed,
     const glm::dmat4x4& cesiumToUnrealTransform,
-    UMaterial* pBaseMaterial) {
+    UMaterialInterface* pBaseMaterial) {
   HalfConstructedReal* pReal =
       static_cast<HalfConstructedReal*>(pHalfConstructed.get());
   std::vector<LoadModelResult>& result = pReal->loadModelResult;

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.h
@@ -9,7 +9,7 @@
 #include <memory>
 #include "CesiumGltfComponent.generated.h"
 
-class UMaterial;
+class UMaterialInterface;
 class UTexture2D;
 class UStaticMeshComponent;
 
@@ -64,16 +64,16 @@ public:
       AActor* ParentActor,
       std::unique_ptr<HalfConstructed> HalfConstructed,
       const glm::dmat4x4& CesiumToUnrealTransform,
-      UMaterial* BaseMaterial);
+      UMaterialInterface* BaseMaterial);
 
   UCesiumGltfComponent();
   virtual ~UCesiumGltfComponent();
 
   UPROPERTY(EditAnywhere, Category = "Cesium")
-  UMaterial* BaseMaterial;
+  UMaterialInterface* BaseMaterial;
 
   UPROPERTY(EditAnywhere, Category = "Cesium")
-  UMaterial* OpacityMaskMaterial;
+  UMaterialInterface* OpacityMaskMaterial;
 
   void UpdateTransformFromCesium(const glm::dmat4& CesiumToUnrealTransform);
 

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -13,7 +13,7 @@
 #include <glm/mat4x4.hpp>
 #include "Cesium3DTileset.generated.h"
 
-class UMaterial;
+class UMaterialInterface;
 
 namespace Cesium3DTiles {
 class Tileset;
@@ -224,7 +224,7 @@ public:
    * "GltfMaterialWithOverlays" material and customizing it as desired.
    */
   UPROPERTY(EditAnywhere, Category = "Cesium|Rendering")
-  UMaterial* Material = nullptr;
+  UMaterialInterface* Material = nullptr;
 
   /**
    * Pauses level-of-detail and culling updates of this tileset.
@@ -310,7 +310,7 @@ private:
 private:
   Cesium3DTiles::Tileset* _pTileset;
 
-  UMaterial* _lastMaterial = nullptr;
+  UMaterialInterface* _lastMaterial = nullptr;
 
   uint32_t _lastTilesRendered;
   uint32_t _lastTilesLoadingLowPriority;


### PR DESCRIPTION
Closing #317 

@argallegos I quickly checked this by creating a material instance of `GltfMaterialWithOverlays` and setting that as the Material in CesiumWorldTerrain, and the terrain rendered normally (same as if there was no reference set there). Are there other tests to make sure this is working correctly?