### PR TITLE
Custom editor-mode

### DIFF
--- a/Source/CesiumEditor/Private/CesiumEditor.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditor.cpp
@@ -7,6 +7,7 @@
 #include "CesiumIonPanel.h"
 #include "CesiumIonRasterOverlay.h"
 #include "CesiumPanel.h"
+#include "CesiumGeoreferenceModeTool.h"
 #include "ClassIconFinder.h"
 #include "Editor.h"
 #include "Editor/WorkspaceMenuStructure/Public/WorkspaceMenuStructure.h"
@@ -53,6 +54,11 @@ void FCesiumEditorModule::StartupModule() {
   this->_pIonSession =
       std::make_shared<CesiumIonSession>(asyncSystem, pAssetAccessor);
   this->_pIonSession->resume();
+
+  this->AddModuleListeners();
+  for (int32 i = 0; i < this->_moduleListeners.Num(); ++i) {
+    this->_moduleListeners[i]->OnStartupModule();
+  }
 
   // Only register style once
   if (!StyleSet.IsValid()) {
@@ -212,6 +218,10 @@ void FCesiumEditorModule::ShutdownModule() {
   FCesiumCommands::Unregister();
   IModuleInterface::ShutdownModule();
 
+  for (int32 i = 0; i < this->_moduleListeners.Num(); ++i) {
+    this->_moduleListeners[i]->OnShutdownModule();
+  }
+
   _pModule = nullptr;
 }
 
@@ -316,4 +326,9 @@ UCesiumIonRasterOverlay* FCesiumEditorModule::AddOverlay(
   pTilesetActor->AddInstanceComponent(pOverlay);
 
   return pOverlay;
+}
+
+
+void FCesiumEditorModule::AddModuleListeners() {
+  this->_moduleListeners.Add(MakeShareable(new CesiumGeoreferenceModeTool));
 }

--- a/Source/CesiumEditor/Private/CesiumEditor.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditor.cpp
@@ -4,10 +4,10 @@
 #include "Cesium3DTiles/Tileset.h"
 #include "Cesium3DTileset.h"
 #include "CesiumCommands.h"
+#include "CesiumGeoreferenceModeTool.h"
 #include "CesiumIonPanel.h"
 #include "CesiumIonRasterOverlay.h"
 #include "CesiumPanel.h"
-#include "CesiumGeoreferenceModeTool.h"
 #include "ClassIconFinder.h"
 #include "Editor.h"
 #include "Editor/WorkspaceMenuStructure/Public/WorkspaceMenuStructure.h"
@@ -327,7 +327,6 @@ UCesiumIonRasterOverlay* FCesiumEditorModule::AddOverlay(
 
   return pOverlay;
 }
-
 
 void FCesiumEditorModule::AddModuleListeners() {
   this->_moduleListeners.Add(MakeShareable(new CesiumGeoreferenceModeTool));

--- a/Source/CesiumEditor/Private/CesiumEditor.h
+++ b/Source/CesiumEditor/Private/CesiumEditor.h
@@ -7,6 +7,7 @@
 #include "Modules/ModuleManager.h"
 #include "Styling/SlateStyle.h"
 #include "Widgets/Docking/SDockTab.h"
+#include "CesiumModuleListener.h"
 #include <optional>
 
 class FSpawnTabArgs;
@@ -47,6 +48,10 @@ private:
   TSharedRef<SDockTab> SpawnCesiumTab(const FSpawnTabArgs& TabSpawnArgs);
   TSharedRef<SDockTab>
   SpawnCesiumIonAssetBrowserTab(const FSpawnTabArgs& TabSpawnArgs);
+
+  void AddModuleListeners();
+
+  TArray<TSharedRef<ICesiumModuleListener>> _moduleListeners;
 
   std::shared_ptr<CesiumIonSession> _pIonSession;
 

--- a/Source/CesiumEditor/Private/CesiumEditor.h
+++ b/Source/CesiumEditor/Private/CesiumEditor.h
@@ -3,11 +3,11 @@
 #pragma once
 
 #include "CesiumIonSession.h"
+#include "CesiumModuleListener.h"
 #include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"
 #include "Styling/SlateStyle.h"
 #include "Widgets/Docking/SDockTab.h"
-#include "CesiumModuleListener.h"
 #include <optional>
 
 class FSpawnTabArgs;

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceMode.cpp
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceMode.cpp
@@ -2,62 +2,62 @@
 
 #include "CesiumGeoreferenceMode.h"
 
+#include "CesiumEditor.h"
+#include "CesiumGeoreference.h"
+#include "CesiumGeoreferenceModeToolkit.h"
 #include "Editor/UnrealEd/Public/Toolkits/ToolkitManager.h"
-#include "ScopedTransaction.h"
 #include "EditorViewportClient.h"
-#include "UnrealClient.h"
+#include "Engine/EngineBaseTypes.h"
+#include "InputCoreTypes.h"
 #include "Math/Rotator.h"
 #include "Math/Vector.h"
+#include "ScopedTransaction.h"
+#include "UnrealClient.h"
 #include <glm/mat3x3.hpp>
-#include "InputCoreTypes.h"
-#include "Engine/EngineBaseTypes.h"
-#include "CesiumEditor.h"
-#include "CesiumGeoreferenceModeToolkit.h"
-#include "CesiumGeoreference.h"
 
 const FEditorModeID FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode(
     TEXT("EM_CesiumGeoreferenceMode"));
 
 void FCesiumGeoreferenceMode::Enter() {
-    FEdMode::Enter();
+  FEdMode::Enter();
 
-    if (!Toolkit.IsValid()) {
-        Toolkit = MakeShareable(new FCesiumGeoreferenceModeToolkit);
-        Toolkit->Init(Owner->GetToolkitHost());
-    }
+  if (!Toolkit.IsValid()) {
+    Toolkit = MakeShareable(new FCesiumGeoreferenceModeToolkit);
+    Toolkit->Init(Owner->GetToolkitHost());
+  }
 
-    if (!this->Georeference) {
-      this->Georeference = ACesiumGeoreference::GetDefaultForLevel(
-          this->GetWorld()->PersistentLevel);
-    }
+  if (!this->Georeference) {
+    this->Georeference = ACesiumGeoreference::GetDefaultForLevel(
+        this->GetWorld()->PersistentLevel);
+  }
 }
 
 void FCesiumGeoreferenceMode::Exit() {
-    FToolkitManager::Get().CloseToolkit(Toolkit.ToSharedRef());
-    Toolkit.Reset();
-    
-    FEdMode::Exit();
+  FToolkitManager::Get().CloseToolkit(Toolkit.ToSharedRef());
+  Toolkit.Reset();
+
+  FEdMode::Exit();
 }
 
 bool FCesiumGeoreferenceMode::InputDelta(
-        FEditorViewportClient* InViewportClient,
-        FViewport* InViewport,
-        FVector& InDrag,
-        FRotator& InRot,
-        FVector& InScale) {
-    return false;
+    FEditorViewportClient* InViewportClient,
+    FViewport* InViewport,
+    FVector& InDrag,
+    FRotator& InRot,
+    FVector& InScale) {
+  return false;
 }
 
 bool FCesiumGeoreferenceMode::InputKey(
-        FEditorViewportClient* InViewportClient,
-        FViewport* InViewport,
-        FKey Key,
-        EInputEvent Event) {
-  
+    FEditorViewportClient* InViewportClient,
+    FViewport* InViewport,
+    FKey Key,
+    EInputEvent Event) {
+
   if (!this->Georeference) {
     return false;
   }
-  
+
   FVector cameraLocation = InViewportClient->GetViewLocation();
 
   glm::dmat3 enuToUnreal = this->Georeference->ComputeEastNorthUpToUnreal(
@@ -68,7 +68,7 @@ bool FCesiumGeoreferenceMode::InputKey(
 
   UE_LOG(LogTemp, Warning, TEXT("Pressed: %s"), *Key.ToString());
 
-  if (Key == EKeys::W) { 
+  if (Key == EKeys::W) {
     delta = enuToUnreal * glm::dvec3(0.0, speed, 0.0);
   } else if (Key == EKeys::A) {
     delta = enuToUnreal * glm::dvec3(-speed, 0.0, 0.0);
@@ -81,11 +81,11 @@ bool FCesiumGeoreferenceMode::InputKey(
   } else if (Key == EKeys::Q) {
     delta = enuToUnreal * glm::dvec3(0.0, 0.0, -speed);
   } else {
-    //return false;
+    // return false;
   }
 
   InViewportClient->SetViewLocation(
-    cameraLocation + FVector(delta.x, delta.y, delta.z));
+      cameraLocation + FVector(delta.x, delta.y, delta.z));
 
   return true;
 }

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceMode.cpp
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceMode.cpp
@@ -4,8 +4,16 @@
 
 #include "Editor/UnrealEd/Public/Toolkits/ToolkitManager.h"
 #include "ScopedTransaction.h"
+#include "EditorViewportClient.h"
+#include "UnrealClient.h"
+#include "Math/Rotator.h"
+#include "Math/Vector.h"
+#include <glm/mat3x3.hpp>
+#include "InputCoreTypes.h"
+#include "Engine/EngineBaseTypes.h"
 #include "CesiumEditor.h"
 #include "CesiumGeoreferenceModeToolkit.h"
+#include "CesiumGeoreference.h"
 
 const FEditorModeID FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode(
     TEXT("EM_CesiumGeoreferenceMode"));
@@ -17,6 +25,11 @@ void FCesiumGeoreferenceMode::Enter() {
         Toolkit = MakeShareable(new FCesiumGeoreferenceModeToolkit);
         Toolkit->Init(Owner->GetToolkitHost());
     }
+
+    if (!this->Georeference) {
+      this->Georeference = ACesiumGeoreference::GetDefaultForLevel(
+          this->GetWorld()->PersistentLevel);
+    }
 }
 
 void FCesiumGeoreferenceMode::Exit() {
@@ -24,4 +37,55 @@ void FCesiumGeoreferenceMode::Exit() {
     Toolkit.Reset();
     
     FEdMode::Exit();
+}
+
+bool FCesiumGeoreferenceMode::InputDelta(
+        FEditorViewportClient* InViewportClient,
+        FViewport* InViewport,
+        FVector& InDrag,
+        FRotator& InRot,
+        FVector& InScale) {
+    return false;
+}
+
+bool FCesiumGeoreferenceMode::InputKey(
+        FEditorViewportClient* InViewportClient,
+        FViewport* InViewport,
+        FKey Key,
+        EInputEvent Event) {
+  
+  if (!this->Georeference || 1) {
+    return false;
+  }
+  
+  FVector cameraLocation = InViewportClient->GetViewLocation();
+
+  glm::dmat3 enuToUnreal = this->Georeference->ComputeEastNorthUpToUnreal(
+      glm::dvec3(cameraLocation.X, cameraLocation.Y, cameraLocation.Z));
+
+  double speed = 1000.0;
+  glm::dvec3 delta(0.0, 0.0, 0.0);
+
+  UE_LOG(LogTemp, Warning, TEXT("Pressed: %s"), *Key.ToString());
+
+  if (Key == EKeys::W) { 
+    delta = enuToUnreal * glm::dvec3(0.0, speed, 0.0);
+  } else if (Key == EKeys::A) {
+    delta = enuToUnreal * glm::dvec3(-speed, 0.0, 0.0);
+  } else if (Key == EKeys::S) {
+    delta = enuToUnreal * glm::dvec3(0.0, -speed, 0.0);
+  } else if (Key == EKeys::D) {
+    delta = enuToUnreal * glm::dvec3(speed, 0.0, 0.0);
+  } else if (Key == EKeys::E) {
+    delta = enuToUnreal * glm::dvec3(0.0, 0.0, speed);
+  } else if (Key == EKeys::Q) {
+    delta = enuToUnreal * glm::dvec3(0.0, 0.0, -speed);
+  } else {
+    //return false;
+  }
+
+  InViewportClient->SetViewLocation(
+    cameraLocation + FVector(delta.x, delta.y, delta.z));
+
+  return true;
 }

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceMode.cpp
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceMode.cpp
@@ -54,7 +54,7 @@ bool FCesiumGeoreferenceMode::InputKey(
         FKey Key,
         EInputEvent Event) {
   
-  if (!this->Georeference || 1) {
+  if (!this->Georeference) {
     return false;
   }
   

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceMode.cpp
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceMode.cpp
@@ -1,0 +1,27 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#include "CesiumGeoreferenceMode.h"
+
+#include "Editor/UnrealEd/Public/Toolkits/ToolkitManager.h"
+#include "ScopedTransaction.h"
+#include "CesiumEditor.h"
+#include "CesiumGeoreferenceModeToolkit.h"
+
+const FEditorModeID FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode(
+    TEXT("EM_CesiumGeoreferenceMode"));
+
+void FCesiumGeoreferenceMode::Enter() {
+    FEdMode::Enter();
+
+    if (!Toolkit.IsValid()) {
+        Toolkit = MakeShareable(new FCesiumGeoreferenceModeToolkit);
+        Toolkit->Init(Owner->GetToolkitHost());
+    }
+}
+
+void FCesiumGeoreferenceMode::Exit() {
+    FToolkitManager::Get().CloseToolkit(Toolkit.ToSharedRef());
+    Toolkit.Reset();
+    
+    FEdMode::Exit();
+}

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceMode.h
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceMode.h
@@ -1,0 +1,14 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "Editor.h"
+#include "EdMode.h"
+
+class FCesiumGeoreferenceMode : public FEdMode {
+public:
+    const static FEditorModeID EM_CesiumGeoreferenceMode;
+
+    virtual void Enter() override;
+    virtual void Exit() override;
+};

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceMode.h
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceMode.h
@@ -2,29 +2,29 @@
 
 #pragma once
 
-#include "Editor.h"
 #include "EdMode.h"
+#include "Editor.h"
 
 class FCesiumGeoreferenceMode : public FEdMode {
 public:
-    const static FEditorModeID EM_CesiumGeoreferenceMode;
+  const static FEditorModeID EM_CesiumGeoreferenceMode;
 
-    virtual void Enter() override;
-    virtual void Exit() override;
+  virtual void Enter() override;
+  virtual void Exit() override;
 
-    virtual bool InputDelta(
-        FEditorViewportClient* InViewportClient,
-        FViewport* InViewport,
-        FVector& InDrag,
-        FRotator& InRot,
-        FVector& InScale) override;
-    
-    virtual bool InputKey(
-        FEditorViewportClient* InViewportClient,
-        FViewport* InViewport,
-        FKey Key,
-        EInputEvent Event) override;
+  virtual bool InputDelta(
+      FEditorViewportClient* InViewportClient,
+      FViewport* InViewport,
+      FVector& InDrag,
+      FRotator& InRot,
+      FVector& InScale) override;
 
-  private:
-    ACesiumGeoreference* Georeference;
+  virtual bool InputKey(
+      FEditorViewportClient* InViewportClient,
+      FViewport* InViewport,
+      FKey Key,
+      EInputEvent Event) override;
+
+private:
+  ACesiumGeoreference* Georeference;
 };

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceMode.h
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceMode.h
@@ -11,4 +11,20 @@ public:
 
     virtual void Enter() override;
     virtual void Exit() override;
+
+    virtual bool InputDelta(
+        FEditorViewportClient* InViewportClient,
+        FViewport* InViewport,
+        FVector& InDrag,
+        FRotator& InRot,
+        FVector& InScale) override;
+    
+    virtual bool InputKey(
+        FEditorViewportClient* InViewportClient,
+        FViewport* InViewport,
+        FKey Key,
+        EInputEvent Event) override;
+
+  private:
+    ACesiumGeoreference* Georeference;
 };

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceMode.h
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceMode.h
@@ -26,5 +26,5 @@ public:
       EInputEvent Event) override;
 
 private:
-  ACesiumGeoreference* Georeference;
+  class ACesiumGeoreference* Georeference;
 };

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceModeTool.cpp
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceModeTool.cpp
@@ -7,7 +7,7 @@
 #include "Misc/Paths.h"
 
 //#define IMAGE_BRUSH(RelativePath, ...)
-//FSlateImageBrush(StyleSet->RootToContentDir(RelativePath, TEXT(".png")),
+// FSlateImageBrush(StyleSet->RootToContentDir(RelativePath, TEXT(".png")),
 //__VA_ARGS__)
 
 TSharedPtr<FSlateStyleSet> CesiumGeoreferenceModeTool::StyleSet = nullptr;

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceModeTool.cpp
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceModeTool.cpp
@@ -6,7 +6,7 @@
 #include "CesiumEditor.h"
 #include "CesiumGeoreferenceMode.h"
 
-#define IMAGE_BRUSH(RelativePath, ...) FSlateImageBrush(StyleSet->RootToContentDir(RelativePath, TEXT(".png")), __VA_ARGS__)
+//#define IMAGE_BRUSH(RelativePath, ...) FSlateImageBrush(StyleSet->RootToContentDir(RelativePath, TEXT(".png")), __VA_ARGS__)
 
 TSharedPtr< FSlateStyleSet > CesiumGeoreferenceModeTool::StyleSet = nullptr;
 
@@ -72,4 +72,4 @@ void CesiumGeoreferenceModeTool::UnregisterEditorMode()
     FEditorModeRegistry::Get().UnregisterMode(FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode);
 }
 
-#undef IMAGE_BRUSH
+//#undef IMAGE_BRUSH

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceModeTool.cpp
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceModeTool.cpp
@@ -2,74 +2,79 @@
 
 #include "CesiumGeoreferenceModeTool.h"
 
-#include "Misc/Paths.h"
 #include "CesiumEditor.h"
 #include "CesiumGeoreferenceMode.h"
+#include "Misc/Paths.h"
 
-//#define IMAGE_BRUSH(RelativePath, ...) FSlateImageBrush(StyleSet->RootToContentDir(RelativePath, TEXT(".png")), __VA_ARGS__)
+//#define IMAGE_BRUSH(RelativePath, ...)
+//FSlateImageBrush(StyleSet->RootToContentDir(RelativePath, TEXT(".png")),
+//__VA_ARGS__)
 
-TSharedPtr< FSlateStyleSet > CesiumGeoreferenceModeTool::StyleSet = nullptr;
+TSharedPtr<FSlateStyleSet> CesiumGeoreferenceModeTool::StyleSet = nullptr;
 
-void CesiumGeoreferenceModeTool::OnStartupModule()
-{
-    RegisterStyleSet();
-    RegisterEditorMode();
+void CesiumGeoreferenceModeTool::OnStartupModule() {
+  RegisterStyleSet();
+  RegisterEditorMode();
 }
 
-void CesiumGeoreferenceModeTool::OnShutdownModule()
-{
-    UnregisterStyleSet();
-    UnregisterEditorMode();
+void CesiumGeoreferenceModeTool::OnShutdownModule() {
+  UnregisterStyleSet();
+  UnregisterEditorMode();
 }
 
-void CesiumGeoreferenceModeTool::RegisterStyleSet()
-{
-    // Const icon sizes
-    const FVector2D Icon20x20(20.0f, 20.0f);
-    const FVector2D Icon40x40(40.0f, 40.0f);
+void CesiumGeoreferenceModeTool::RegisterStyleSet() {
+  // Const icon sizes
+  const FVector2D Icon20x20(20.0f, 20.0f);
+  const FVector2D Icon40x40(40.0f, 40.0f);
 
-    // Only register once
-    if (StyleSet.IsValid())
-    {
-        return;
-    }
+  // Only register once
+  if (StyleSet.IsValid()) {
+    return;
+  }
 
-    StyleSet = MakeShareable(new FSlateStyleSet("CesiumGeoreferenceModeToolStyle"));
-    StyleSet->SetContentRoot(FPaths::ProjectDir() / TEXT("Content/EditorResources"));
-    StyleSet->SetCoreContentRoot(FPaths::ProjectDir() / TEXT("Content/EditorResources"));
+  StyleSet =
+      MakeShareable(new FSlateStyleSet("CesiumGeoreferenceModeToolStyle"));
+  StyleSet->SetContentRoot(
+      FPaths::ProjectDir() / TEXT("Content/EditorResources"));
+  StyleSet->SetCoreContentRoot(
+      FPaths::ProjectDir() / TEXT("Content/EditorResources"));
 
-    // Spline editor
-    {
-        StyleSet->Set("ExampleEdMode", new IMAGE_BRUSH(TEXT("IconExampleEditorMode"), Icon40x40));
-        StyleSet->Set("ExampleEdMode.Small", new IMAGE_BRUSH(TEXT("IconExampleEditorMode"), Icon20x20));
-    }
+  // Spline editor
+  {
+    StyleSet->Set(
+        "ExampleEdMode",
+        new IMAGE_BRUSH(TEXT("IconExampleEditorMode"), Icon40x40));
+    StyleSet->Set(
+        "ExampleEdMode.Small",
+        new IMAGE_BRUSH(TEXT("IconExampleEditorMode"), Icon20x20));
+  }
 
-    FSlateStyleRegistry::RegisterSlateStyle(*StyleSet.Get());
+  FSlateStyleRegistry::RegisterSlateStyle(*StyleSet.Get());
 }
 
-void CesiumGeoreferenceModeTool::UnregisterStyleSet()
-{
-    if (StyleSet.IsValid())
-    {
-        FSlateStyleRegistry::UnRegisterSlateStyle(*StyleSet.Get());
-        ensure(StyleSet.IsUnique());
-        StyleSet.Reset();
-    }
+void CesiumGeoreferenceModeTool::UnregisterStyleSet() {
+  if (StyleSet.IsValid()) {
+    FSlateStyleRegistry::UnRegisterSlateStyle(*StyleSet.Get());
+    ensure(StyleSet.IsUnique());
+    StyleSet.Reset();
+  }
 }
 
-void CesiumGeoreferenceModeTool::RegisterEditorMode()
-{
-    FEditorModeRegistry::Get().RegisterMode<FCesiumGeoreferenceMode>(
-        FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode,
-        FText::FromString("Cesium Georeference Mode"),
-        FSlateIcon(StyleSet->GetStyleSetName(), "ExampleEdMode", "ExampleEdMode.Small"),
-        true, 500
-        );
+void CesiumGeoreferenceModeTool::RegisterEditorMode() {
+  FEditorModeRegistry::Get().RegisterMode<FCesiumGeoreferenceMode>(
+      FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode,
+      FText::FromString("Cesium Georeference Mode"),
+      FSlateIcon(
+          StyleSet->GetStyleSetName(),
+          "ExampleEdMode",
+          "ExampleEdMode.Small"),
+      true,
+      500);
 }
 
-void CesiumGeoreferenceModeTool::UnregisterEditorMode()
-{
-    FEditorModeRegistry::Get().UnregisterMode(FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode);
+void CesiumGeoreferenceModeTool::UnregisterEditorMode() {
+  FEditorModeRegistry::Get().UnregisterMode(
+      FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode);
 }
 
 //#undef IMAGE_BRUSH

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceModeTool.cpp
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceModeTool.cpp
@@ -1,0 +1,75 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#include "CesiumGeoreferenceModeTool.h"
+
+#include "Misc/Paths.h"
+#include "CesiumEditor.h"
+#include "CesiumGeoreferenceMode.h"
+
+#define IMAGE_BRUSH(RelativePath, ...) FSlateImageBrush(StyleSet->RootToContentDir(RelativePath, TEXT(".png")), __VA_ARGS__)
+
+TSharedPtr< FSlateStyleSet > CesiumGeoreferenceModeTool::StyleSet = nullptr;
+
+void CesiumGeoreferenceModeTool::OnStartupModule()
+{
+    RegisterStyleSet();
+    RegisterEditorMode();
+}
+
+void CesiumGeoreferenceModeTool::OnShutdownModule()
+{
+    UnregisterStyleSet();
+    UnregisterEditorMode();
+}
+
+void CesiumGeoreferenceModeTool::RegisterStyleSet()
+{
+    // Const icon sizes
+    const FVector2D Icon20x20(20.0f, 20.0f);
+    const FVector2D Icon40x40(40.0f, 40.0f);
+
+    // Only register once
+    if (StyleSet.IsValid())
+    {
+        return;
+    }
+
+    StyleSet = MakeShareable(new FSlateStyleSet("CesiumGeoreferenceModeToolStyle"));
+    StyleSet->SetContentRoot(FPaths::ProjectDir() / TEXT("Content/EditorResources"));
+    StyleSet->SetCoreContentRoot(FPaths::ProjectDir() / TEXT("Content/EditorResources"));
+
+    // Spline editor
+    {
+        StyleSet->Set("ExampleEdMode", new IMAGE_BRUSH(TEXT("IconExampleEditorMode"), Icon40x40));
+        StyleSet->Set("ExampleEdMode.Small", new IMAGE_BRUSH(TEXT("IconExampleEditorMode"), Icon20x20));
+    }
+
+    FSlateStyleRegistry::RegisterSlateStyle(*StyleSet.Get());
+}
+
+void CesiumGeoreferenceModeTool::UnregisterStyleSet()
+{
+    if (StyleSet.IsValid())
+    {
+        FSlateStyleRegistry::UnRegisterSlateStyle(*StyleSet.Get());
+        ensure(StyleSet.IsUnique());
+        StyleSet.Reset();
+    }
+}
+
+void CesiumGeoreferenceModeTool::RegisterEditorMode()
+{
+    FEditorModeRegistry::Get().RegisterMode<FCesiumGeoreferenceMode>(
+        FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode,
+        FText::FromString("Cesium Georeference Mode"),
+        FSlateIcon(StyleSet->GetStyleSetName(), "ExampleEdMode", "ExampleEdMode.Small"),
+        true, 500
+        );
+}
+
+void CesiumGeoreferenceModeTool::UnregisterEditorMode()
+{
+    FEditorModeRegistry::Get().UnregisterMode(FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode);
+}
+
+#undef IMAGE_BRUSH

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceModeTool.h
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceModeTool.h
@@ -1,22 +1,22 @@
 // Copyright 2020-2021 CesiumGS, Inc. and Contributors
 
 #pragma once
-#include "Modules/ModuleManager.h"
 #include "CesiumModuleListener.h"
+#include "Modules/ModuleManager.h"
 
 class CesiumGeoreferenceModeTool : public ICesiumModuleListener {
 public:
-    virtual void OnStartupModule() override;
-    virtual void OnShutdownModule() override;
+  virtual void OnStartupModule() override;
+  virtual void OnShutdownModule() override;
 
-    virtual ~CesiumGeoreferenceModeTool() {}
+  virtual ~CesiumGeoreferenceModeTool() {}
 
 private:
-    static TSharedPtr<class FSlateStyleSet> StyleSet;
+  static TSharedPtr<class FSlateStyleSet> StyleSet;
 
-    void RegisterStyleSet();
-    void UnregisterStyleSet();
+  void RegisterStyleSet();
+  void UnregisterStyleSet();
 
-    void RegisterEditorMode();
-    void UnregisterEditorMode();
+  void RegisterEditorMode();
+  void UnregisterEditorMode();
 };

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceModeTool.h
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceModeTool.h
@@ -1,0 +1,22 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#pragma once
+#include "Modules/ModuleManager.h"
+#include "CesiumModuleListener.h"
+
+class CesiumGeoreferenceModeTool : public ICesiumModuleListener {
+public:
+    virtual void OnStartupModule() override;
+    virtual void OnShutdownModule() override;
+
+    virtual ~CesiumGeoreferenceModeTool() {}
+
+private:
+    static TSharedPtr<class FSlateStyleSet> StyleSet;
+
+    void RegisterStyleSet();
+    void UnregisterStyleSet();
+
+    void RegisterEditorMode();
+    void UnregisterEditorMode();
+};

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceModeToolkit.h
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceModeToolkit.h
@@ -1,0 +1,34 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#pragma once
+#include "Toolkits/BaseToolkit.h"
+#include "EditorModeManager.h"
+#include "CesiumGeoreferenceMode.h"
+#include "CesiumGeoreferenceModeWidget.h"
+
+class FCesiumGeoreferenceModeToolkit : public FModeToolkit {
+public:
+    FCesiumGeoreferenceModeToolkit() {
+        SAssignNew(CesiumGeoreferenceModeWidget, SCesiumGeoreferenceModeWidget);
+    }
+
+    virtual FName GetToolkitFName() const override { 
+        return FName("CesiumGeoreferenceMode"); 
+    }
+
+    virtual FText GetBaseToolkitName() const override {
+        return NSLOCTEXT("BuilderModeToolkit", "DisplayName", "Builder");
+    }
+
+    virtual class FEdMode* GetEditorMode() const override {
+        return GLevelEditorModeTools()
+            .GetActiveMode(FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode);
+    }
+
+    virtual TSharedPtr<class SWidget> GetInlineContent() const override {
+        return CesiumGeoreferenceModeWidget;
+    }
+
+private:
+    TSharedPtr<SCesiumGeoreferenceModeWidget> CesiumGeoreferenceModeWidget;
+};

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceModeToolkit.h
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceModeToolkit.h
@@ -1,34 +1,34 @@
 // Copyright 2020-2021 CesiumGS, Inc. and Contributors
 
 #pragma once
-#include "Toolkits/BaseToolkit.h"
-#include "EditorModeManager.h"
 #include "CesiumGeoreferenceMode.h"
 #include "CesiumGeoreferenceModeWidget.h"
+#include "EditorModeManager.h"
+#include "Toolkits/BaseToolkit.h"
 
 class FCesiumGeoreferenceModeToolkit : public FModeToolkit {
 public:
-    FCesiumGeoreferenceModeToolkit() {
-        SAssignNew(CesiumGeoreferenceModeWidget, SCesiumGeoreferenceModeWidget);
-    }
+  FCesiumGeoreferenceModeToolkit() {
+    SAssignNew(CesiumGeoreferenceModeWidget, SCesiumGeoreferenceModeWidget);
+  }
 
-    virtual FName GetToolkitFName() const override { 
-        return FName("CesiumGeoreferenceMode"); 
-    }
+  virtual FName GetToolkitFName() const override {
+    return FName("CesiumGeoreferenceMode");
+  }
 
-    virtual FText GetBaseToolkitName() const override {
-        return NSLOCTEXT("BuilderModeToolkit", "DisplayName", "Builder");
-    }
+  virtual FText GetBaseToolkitName() const override {
+    return NSLOCTEXT("BuilderModeToolkit", "DisplayName", "Builder");
+  }
 
-    virtual class FEdMode* GetEditorMode() const override {
-        return GLevelEditorModeTools()
-            .GetActiveMode(FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode);
-    }
+  virtual class FEdMode* GetEditorMode() const override {
+    return GLevelEditorModeTools().GetActiveMode(
+        FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode);
+  }
 
-    virtual TSharedPtr<class SWidget> GetInlineContent() const override {
-        return CesiumGeoreferenceModeWidget;
-    }
+  virtual TSharedPtr<class SWidget> GetInlineContent() const override {
+    return CesiumGeoreferenceModeWidget;
+  }
 
 private:
-    TSharedPtr<SCesiumGeoreferenceModeWidget> CesiumGeoreferenceModeWidget;
+  TSharedPtr<SCesiumGeoreferenceModeWidget> CesiumGeoreferenceModeWidget;
 };

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceModeWidget.cpp
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceModeWidget.cpp
@@ -1,28 +1,24 @@
 // Copyright 2020-2021 CesiumGS, Inc. and Contributors
 
 #include "CesiumGeoreferenceModeWidget.h"
-#include "CesiumGeoreferenceMode.h" 
 #include "CesiumEditor.h"
+#include "CesiumGeoreferenceMode.h"
+#include "Framework/Application/SlateApplication.h"
 #include "Widgets/Layout/SScrollBox.h"
 #include "Widgets/Text/STextBlock.h"
-#include "Framework/Application/SlateApplication.h"
 
 void SCesiumGeoreferenceModeWidget::Construct(const FArguments& InArgs) {
-    
-    ChildSlot
-    [
-        SNew(SScrollBox)
-        + SScrollBox::Slot()
-        .VAlign(VAlign_Top)
-        .Padding(5.f)
-        [
-            SNew(STextBlock)
-            .Text(FText::FromString(TEXT("This is a editor mode example.")))
-        ]
-    ];
+
+  ChildSlot
+      [SNew(SScrollBox) +
+       SScrollBox::Slot()
+           .VAlign(VAlign_Top)
+           .Padding(5.f)[SNew(STextBlock)
+                             .Text(FText::FromString(
+                                 TEXT("This is a editor mode example.")))]];
 }
 
 FCesiumGeoreferenceMode* SCesiumGeoreferenceModeWidget::GetEdMode() const {
-    return (FCesiumGeoreferenceMode*)GLevelEditorModeTools()
-        .GetActiveMode(FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode);
+  return (FCesiumGeoreferenceMode*)GLevelEditorModeTools().GetActiveMode(
+      FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode);
 }

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceModeWidget.cpp
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceModeWidget.cpp
@@ -1,0 +1,28 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#include "CesiumGeoreferenceModeWidget.h"
+#include "CesiumGeoreferenceMode.h" 
+#include "CesiumEditor.h"
+#include "Widgets/Layout/SScrollBox.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Framework/Application/SlateApplication.h"
+
+void SCesiumGeoreferenceModeWidget::Construct(const FArguments& InArgs) {
+    
+    ChildSlot
+    [
+        SNew(SScrollBox)
+        + SScrollBox::Slot()
+        .VAlign(VAlign_Top)
+        .Padding(5.f)
+        [
+            SNew(STextBlock)
+            .Text(FText::FromString(TEXT("This is a editor mode example.")))
+        ]
+    ];
+}
+
+FCesiumGeoreferenceMode* SCesiumGeoreferenceModeWidget::GetEdMode() const {
+    return (FCesiumGeoreferenceMode*)GLevelEditorModeTools()
+        .GetActiveMode(FCesiumGeoreferenceMode::EM_CesiumGeoreferenceMode);
+}

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceModeWidget.h
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceModeWidget.h
@@ -6,10 +6,10 @@
 
 class SCesiumGeoreferenceModeWidget : public SCompoundWidget {
 public:
-    SLATE_BEGIN_ARGS(SCesiumGeoreferenceModeWidget) {}
-    SLATE_END_ARGS();
+  SLATE_BEGIN_ARGS(SCesiumGeoreferenceModeWidget) {}
+  SLATE_END_ARGS();
 
-    void Construct(const FArguments& InArgs);
+  void Construct(const FArguments& InArgs);
 
-    class FCesiumGeoreferenceMode* GetEdMode() const;
+  class FCesiumGeoreferenceMode* GetEdMode() const;
 };

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceModeWidget.h
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceModeWidget.h
@@ -1,0 +1,15 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "Framework/Application/SlateApplication.h"
+
+class SCesiumGeoreferenceModeWidget : public SCompoundWidget {
+public:
+    SLATE_BEGIN_ARGS(SCesiumGeoreferenceModeWidget) {}
+    SLATE_END_ARGS();
+
+    void Construct(const FArguments& InArgs);
+
+    class FCesiumGeoreferenceMode* GetEdMode() const;
+};

--- a/Source/CesiumEditor/Private/CesiumModuleListener.h
+++ b/Source/CesiumEditor/Private/CesiumModuleListener.h
@@ -1,0 +1,9 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+class ICesiumModuleListener {
+public:
+    virtual void OnStartupModule() {};
+    virtual void OnShutdownModule() {};
+};

--- a/Source/CesiumEditor/Private/CesiumModuleListener.h
+++ b/Source/CesiumEditor/Private/CesiumModuleListener.h
@@ -4,6 +4,6 @@
 
 class ICesiumModuleListener {
 public:
-    virtual void OnStartupModule() {};
-    virtual void OnShutdownModule() {};
+  virtual void OnStartupModule(){};
+  virtual void OnShutdownModule(){};
 };

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -8,6 +8,7 @@
 #include "CesiumUtility/Math.h"
 #include "Engine/LevelStreaming.h"
 #include "Engine/World.h"
+#include "Engine/Level.h"
 #include "GameFramework/PlayerController.h"
 #include "Math/Matrix.h"
 #include "Math/RotationTranslationMatrix.h"
@@ -29,15 +30,21 @@
 
 /*static*/ ACesiumGeoreference*
 ACesiumGeoreference::GetDefaultForActor(AActor* Actor) {
-  ACesiumGeoreference* pGeoreference = FindObject<ACesiumGeoreference>(
-      Actor->GetLevel(),
+  return ACesiumGeoreference::GetDefaultForLevel(
+      Actor->GetWorld()->PersistentLevel);
+}
+
+// TODO: should do this in CesiumCreditSystem too
+/*static*/ ACesiumGeoreference*
+ACesiumGeoreference::GetDefaultForLevel(ULevel* Level) {
+  ACesiumGeoreference* pGeoreference = FindObject<ACesiumGeoreference>(Level,
       TEXT("CesiumGeoreferenceDefault"));
   if (!pGeoreference) {
     FActorSpawnParameters spawnParameters;
     spawnParameters.Name = TEXT("CesiumGeoreferenceDefault");
-    spawnParameters.OverrideLevel = Actor->GetLevel();
+    spawnParameters.OverrideLevel = Level;
     pGeoreference =
-        Actor->GetWorld()->SpawnActor<ACesiumGeoreference>(spawnParameters);
+        Level->GetWorld()->SpawnActor<ACesiumGeoreference>(spawnParameters);
   }
   return pGeoreference;
 }

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -6,9 +6,9 @@
 #include "CesiumGeospatial/Transforms.h"
 #include "CesiumTransforms.h"
 #include "CesiumUtility/Math.h"
+#include "Engine/Level.h"
 #include "Engine/LevelStreaming.h"
 #include "Engine/World.h"
-#include "Engine/Level.h"
 #include "GameFramework/PlayerController.h"
 #include "Math/Matrix.h"
 #include "Math/RotationTranslationMatrix.h"
@@ -37,8 +37,8 @@ ACesiumGeoreference::GetDefaultForActor(AActor* Actor) {
 // TODO: should do this in CesiumCreditSystem too
 /*static*/ ACesiumGeoreference*
 ACesiumGeoreference::GetDefaultForLevel(ULevel* Level) {
-  ACesiumGeoreference* pGeoreference = FindObject<ACesiumGeoreference>(Level,
-      TEXT("CesiumGeoreferenceDefault"));
+  ACesiumGeoreference* pGeoreference =
+      FindObject<ACesiumGeoreference>(Level, TEXT("CesiumGeoreferenceDefault"));
   if (!pGeoreference) {
     FActorSpawnParameters spawnParameters;
     spawnParameters.Name = TEXT("CesiumGeoreferenceDefault");

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -104,6 +104,9 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   static ACesiumGeoreference* GetDefaultForActor(AActor* Actor);
 
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  static ACesiumGeoreference* GetDefaultForLevel(ULevel* Level);
+
   ACesiumGeoreference();
 
   /*


### PR DESCRIPTION
So far this is just the skeleton for a custom editor-mode. In order of priority, these are the things that need to be added to it:
- Globe aware camera controls when in the editor mode: https://github.com/CesiumGS/cesium-unreal/issues/325
- More convenient controls and UI for georeference placement. Although I'm not a big fan of the CesiumJS camera, something along those lines could be useful for placing the georeference or placing sublevels. Mainly the click-and-drag to rotate the globe would be nice to have. This does not necessarily have to be the same as the above camera, but it can be.  
- A straightforward UI for georeferenced sublevels: https://github.com/CesiumGS/cesium-unreal/issues/326