### PR TITLE
Added Collision Settings and Exclusion Zones

### DIFF
--- a/Source/CesiumRuntime/Public/CesiumExclusionZone.h
+++ b/Source/CesiumRuntime/Public/CesiumExclusionZone.h
@@ -1,0 +1,31 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "CesiumExclusionZone.generated.h"
+
+/**
+ * 
+ */
+USTRUCT()
+struct FCesiumExclusionZone
+{
+	GENERATED_BODY()
+
+
+	UPROPERTY(EditAnywhere, Category = "Cesium")
+		double East = 0.0;
+
+
+	UPROPERTY(EditAnywhere, Category = "Cesium")
+		double West = 0.0;
+
+	UPROPERTY(EditAnywhere, Category = "Cesium")
+		double South = 0.0;
+
+	UPROPERTY(EditAnywhere, Category = "Cesium")
+		double North = 0.0;
+
+};


### PR DESCRIPTION
Added Bodyinstance Property to define tiles collision settings on a per-actor basis
Added ExclusionZones concept to cull OSM Buildings when displaying photogrammetry assets
Added BueprintReadOnly flag to CesiumIonToken to be able to check that tokens have been set...