### PR TITLE
Fix truncation of ECEF values to float.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v1.1.1 - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that caused `ACesiumGeoreference::TransformEcefToUe` to be much less precise than expected.
+
 ### v1.1.0 - 2021-04-19
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -622,7 +622,7 @@ FVector ACesiumGeoreference::InaccurateTransformUeToLongitudeLatitudeHeight(
 
 glm::dvec3
 ACesiumGeoreference::TransformEcefToUe(const glm::dvec3& ecef) const {
-  glm::dvec3 ueAbs = this->_ecefToUeAbs * glm::vec4(ecef, 1.0);
+  glm::dvec3 ueAbs = this->_ecefToUeAbs * glm::dvec4(ecef, 1.0);
 
   const FIntVector& originLocation = this->GetWorld()->OriginLocation;
   return ueAbs -


### PR DESCRIPTION
This can cause round-trip errors on the order of tens of centimeters, when it should be many orders of magnitude less than that. Reported here:
https://community.cesium.com/t/solved-about-transform-location/13255/7
