### PR TITLE
Added some verbose logging for lifecycle methods

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -64,7 +64,32 @@ ACesiumGeoreference::ACesiumGeoreference()
       _ueAbsToEcef(1.0),
       _ecefToUeAbs(1.0),
       _insideSublevel(false) {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called CesiumGeoreference constructor on actor %s"),
+      *this->GetName());
   PrimaryActorTick.bCanEverTick = true;
+}
+
+void ACesiumGeoreference::PostActorCreated() {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called PostActorCreated on actor %s"),
+      *this->GetName());
+
+  Super::PostActorCreated();
+}
+
+void ACesiumGeoreference::PostLoad() {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called PostLoad on actor %s"),
+      *this->GetName());
+
+  Super::PostLoad();
 }
 
 void ACesiumGeoreference::PlaceGeoreferenceOriginHere() {
@@ -255,6 +280,12 @@ void ACesiumGeoreference::AddGeoreferencedObject(
 
 // Called when the game starts or when spawned
 void ACesiumGeoreference::BeginPlay() {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called BeginPlay on actor %s"),
+      *this->GetName());
+
   Super::BeginPlay();
 
   if (!this->WorldOriginCamera) {
@@ -272,7 +303,14 @@ void ACesiumGeoreference::BeginPlay() {
   }
 }
 
-void ACesiumGeoreference::OnConstruction(const FTransform& Transform) {}
+void ACesiumGeoreference::OnConstruction(const FTransform& Transform) {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called OnConstruction on actor %s"),
+      *this->GetName());
+  Super::OnConstruction(Transform);
+}
 
 void ACesiumGeoreference::UpdateGeoreference() {
   // update georeferenced -> ECEF

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -6,6 +6,7 @@
 #include "CesiumGeoreferenceComponent.h"
 #include "CesiumGeospatial/Ellipsoid.h"
 #include "CesiumGeospatial/Transforms.h"
+#include "CesiumRuntime.h"
 #include "CesiumTransforms.h"
 #include "CesiumUtility/Math.h"
 #include "Engine/World.h"
@@ -21,7 +22,56 @@
 #include <glm/ext/vector_double3.hpp>
 
 AGlobeAwareDefaultPawn::AGlobeAwareDefaultPawn() : ADefaultPawn() {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called GlobeAwareDefaultPawn constructor on actor %s"),
+      *this->GetName());
   PrimaryActorTick.bCanEverTick = true;
+}
+
+void AGlobeAwareDefaultPawn::PostActorCreated() {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called PostActorCreated on actor %s"),
+      *this->GetName());
+
+  Super::PostActorCreated();
+  /*/
+  if (!this->Georeference) {
+    this->Georeference = ACesiumGeoreference::GetDefaultForActor(this);
+  }
+  this->_currentEcef = this->GetECEFCameraLocation();
+  this->Georeference->AddGeoreferencedObject(this);
+  //*/
+}
+
+void AGlobeAwareDefaultPawn::PostLoad() {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called PostLoad on actor %s"),
+      *this->GetName());
+
+  Super::PostLoad();
+  /*/
+  if (!this->Georeference) {
+    this->Georeference = ACesiumGeoreference::GetDefaultForActor(this);
+  }
+  this->_currentEcef = this->GetECEFCameraLocation();
+  this->Georeference->AddGeoreferencedObject(this);
+  //*/
+}
+
+void AGlobeAwareDefaultPawn::PostInitProperties() {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called PostInitProperties on actor %s"),
+      *this->GetName());
+
+  Super::PostInitProperties();
 }
 
 void AGlobeAwareDefaultPawn::MoveRight(float Val) {
@@ -397,15 +447,31 @@ void AGlobeAwareDefaultPawn::Tick(float DeltaSeconds) {
 }
 
 void AGlobeAwareDefaultPawn::OnConstruction(const FTransform& Transform) {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called OnConstruction on actor %s"),
+      *this->GetName());
+
+  Super::OnConstruction(Transform);
+
+  //*/
   if (!this->Georeference) {
     this->Georeference = ACesiumGeoreference::GetDefaultForActor(this);
   }
 
   this->_currentEcef = this->GetECEFCameraLocation();
   this->Georeference->AddGeoreferencedObject(this);
+  //*/
 }
 
 void AGlobeAwareDefaultPawn::BeginPlay() {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called BeginPlay on actor %s"),
+      *this->GetName());
+
   Super::BeginPlay();
 
   if (!this->Georeference) {

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -300,12 +300,33 @@ public:
   virtual void BeginDestroy() override;
   virtual void Destroyed() override;
   virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+  /**
+   * Called by serialized Actor after they have finished loading from disk.
+   */
   virtual void PostLoad() override;
 
 protected:
+  /**
+   * Called for spawned Actors after its creation. Constructor like behavior
+   * should go here.
+   */
+  virtual void PostActorCreated() override;
+
+  /**
+   * Called when an instance of this class is placed (in editor) or spawned,
+   * AND when any property of this instance changes.
+   */
+  virtual void OnConstruction(const FTransform& Transform) override;
+
   // Called when the game starts or when spawned
   virtual void BeginPlay() override;
-  virtual void OnConstruction(const FTransform& Transform) override;
+
+  /**
+   * Called after the C++ constructor and after the properties have
+   * been initialized, including those loaded from config.
+   */
+  virtual void PostInitProperties() override;
 
   virtual void NotifyHit(
       class UPrimitiveComponent* MyComp,
@@ -336,9 +357,26 @@ private:
   std::optional<UnrealCameraParameters> GetCamera() const;
   std::optional<UnrealCameraParameters> GetPlayerCamera() const;
 
+  /**
+   * Will be called after the tileset is loaded or spawned, to register
+   * a delegate that calls OnFocusEditorViewportOnThis when this
+   * tileset is double-clicked
+   */
+  void AddFocusViewportDelegate();
+
 #if WITH_EDITOR
   std::optional<UnrealCameraParameters> GetEditorCamera() const;
-  void OnFocusEditorViewportOnActors(const AActor* actor);
+
+  /**
+   * Will focus all viewports on this tileset.
+   *
+   * This is called when double-clicking the tileset in the World Outliner.
+   * It will move the tileset into the center of the view, *even if* the
+   * tileset was not visible before, and no geometry has been created yet
+   * for the tileset: It solely operates on the tile bounding volume that
+   * was given in the root tile.
+   */
+  void OnFocusEditorViewportOnThis();
 #endif
 
 private:

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -535,6 +535,19 @@ protected:
   virtual void BeginPlay() override;
   virtual void OnConstruction(const FTransform& Transform) override;
 
+  /**
+   * Called for spawned Actors after its creation. Constructor like behavior
+   * should go here.
+   */
+  virtual void PostActorCreated() override;
+
+  /**
+   * Called by serialized Actor after they have finished loading from disk. Any
+   * custom versioning and fixup behavior should go here. PostLoad is mutually
+   * exclusive with PostActorCreated.
+   */
+  virtual void PostLoad() override;
+
 #if WITH_EDITOR
   virtual void
   PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;

--- a/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
+++ b/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
@@ -203,6 +203,26 @@ public:
 
 protected:
   virtual void OnConstruction(const FTransform& Transform) override;
+
+  /**
+   * Called for spawned Actors after its creation. Constructor like behavior
+   * should go here.
+   */
+  virtual void PostActorCreated() override;
+
+  /**
+   * Called by serialized Actor after they have finished loading from disk. Any
+   * custom versioning and fixup behavior should go here. PostLoad is mutually
+   * exclusive with PostActorCreated.
+   */
+  virtual void PostLoad() override;
+
+  /**
+   * Called after the C++ constructor and after the properties have been
+   * initialized, including those loaded from config.
+   */
+  virtual void PostInitProperties() override;
+
   virtual void BeginPlay() override;
 
 private:


### PR DESCRIPTION
This is not supposed to be merged yet (and maybe not to be merged at all). 

I have added some log outputs to some (few) of the most important lifecycle elements

- Constructor
- `PostInitProperties`
- `PostActorCreated`/`PostLoad`
- `OnConstruction`
- `BeginPlay`

of our actor classes, `Cesium3DTileset`, `CesiumGeoreference` (some methods only) and `GlobeAwareDefaultPawn`.

The main goal (for me) was to better understand what's happening there, at which point in time, and in which order.

Some of the resulting log outputs for certain actions:

### Opening the Editor with a blank (!) level:

```
LogCesium: Verbose: Called Cesium3DTileset constructor on actor Default__Cesium3DTileset
LogCesium: Verbose: Called PostInitProperties on actor Default__Cesium3DTileset
LogCesium: Verbose: Called CesiumGeoreference constructor on actor Default__CesiumGeoreference
LogCesium: Verbose: Called GlobeAwareDefaultPawn constructor on actor Default__GlobeAwareDefaultPawn
LogCesium: Verbose: Called PostInitProperties on actor Default__GlobeAwareDefaultPawn
```

Yes, the constructors are called "just so", without an apparent reason. That's interesting.


### Browsing into the `CesiumRuntime/Public` directory in the Content Browser:
```
LogCesium: Verbose: Called GlobeAwareDefaultPawn constructor on actor GlobeAwareDefaultPawn_0
LogCesium: Verbose: Called PostInitProperties on actor GlobeAwareDefaultPawn_0
LogCesium: Verbose: Called PostActorCreated on actor GlobeAwareDefaultPawn_0
LogCesium: Verbose: Called OnConstruction on actor GlobeAwareDefaultPawn_0
LogCesium: Verbose: Creating default Georeference for actor GlobeAwareDefaultPawn_0
LogCesium: Verbose: Called CesiumGeoreference constructor on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called PostActorCreated on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called OnConstruction on actor CesiumGeoreferenceDefault
```

OK, *just browsing in the content browser* (while still looking at an empty level) causes quite some of the lifecycle methods to be called. It's probably not bad to be aware of that...


### Opening the `02_Cesium Melbourne` map:
```
LogCesium: Verbose: Called GlobeAwareDefaultPawn constructor on actor Default__FloatingPawn_C
LogCesium: Verbose: Called PostInitProperties on actor Default__FloatingPawn_C
LogCesium: Verbose: Called GlobeAwareDefaultPawn constructor on actor Default__SKEL_FloatingPawn_C
LogCesium: Verbose: Called PostInitProperties on actor Default__SKEL_FloatingPawn_C
LogCesium: Verbose: Called GlobeAwareDefaultPawn constructor on actor Default__FloatingPawn_C
LogCesium: Verbose: Called PostInitProperties on actor Default__FloatingPawn_C
LogCesium: Verbose: Called GlobeAwareDefaultPawn constructor on actor FloatingPawn_2
LogCesium: Verbose: Called PostInitProperties on actor FloatingPawn_2
LogCesium: Verbose: Called Cesium3DTileset constructor on actor CesiumWorldTerrain
LogCesium: Verbose: Called PostInitProperties on actor CesiumWorldTerrain
LogCesium: Verbose: Called Cesium3DTileset constructor on actor MelbournePhotogrammetry
LogCesium: Verbose: Called PostInitProperties on actor MelbournePhotogrammetry
LogCesium: Verbose: Called CesiumGeoreference constructor on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called PostLoad on actor Default__FloatingPawn_C
LogCesium: Verbose: Called PostLoad on actor FloatingPawn_2
LogCesium: Verbose: Called PostLoad on actor CesiumWorldTerrain
LogCesium: Verbose: Called PostLoad on actor MelbournePhotogrammetry
LogCesium: Verbose: Called PostLoad on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called OnConstruction on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called OnConstruction on actor CesiumWorldTerrain
LogCesium: Loading tileset for asset ID 1
LogCesium: Loading tileset for asset ID 1 done
LogCesium: Verbose: Called OnConstruction on actor MelbournePhotogrammetry
LogCesium: Loading tileset for asset ID 69380
LogCesium: Loading tileset for asset ID 69380 done
LogCesium: Verbose: Called OnConstruction on actor FloatingPawn_2
LogCesium: Verbose: Called OnConstruction on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called OnConstruction on actor CesiumWorldTerrain
LogCesium: Verbose: Called OnConstruction on actor MelbournePhotogrammetry
LogCesium: Verbose: Called OnConstruction on actor FloatingPawn_2
```

Now we're talking. Some insights can be derived from that:

- `OnConstruction` is called several times
- `PostInitProperties` is called shortly after each constructor *individually*
- `PostLoad` is called on all actors, but in a "bulk" fashion, **after** all constructors/`PostInitProperties` calls have been made

(Note: Of course, this is some "black box" analysis. These are just *observations* for now, based on the log. *Verifying* these claims could be a next step. **Relying** on them is a different story: Much of this is probably not "specified" in the strictest sense, and might change subtly between releases...)


### Hitting "Play in Editor":
```
LogCesium: Verbose: Called CesiumGeoreference constructor on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called Cesium3DTileset constructor on actor CesiumWorldTerrain
LogCesium: Verbose: Called PostInitProperties on actor CesiumWorldTerrain
LogCesium: Verbose: Called Cesium3DTileset constructor on actor MelbournePhotogrammetry
LogCesium: Verbose: Called PostInitProperties on actor MelbournePhotogrammetry
LogCesium: Verbose: Called GlobeAwareDefaultPawn constructor on actor FloatingPawn_2
LogCesium: Verbose: Called PostInitProperties on actor FloatingPawn_2
LogCesium: Verbose: Called PostLoad on actor FloatingPawn_2
LogCesium: Verbose: Called PostLoad on actor MelbournePhotogrammetry
LogCesium: Verbose: Called PostLoad on actor CesiumWorldTerrain
LogCesium: Verbose: Called PostLoad on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called BeginPlay on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called BeginPlay on actor CesiumWorldTerrain
LogCesium: Loading tileset for asset ID 1
LogCesium: Loading tileset for asset ID 1 done
LogCesium: Verbose: Called BeginPlay on actor MelbournePhotogrammetry
LogCesium: Loading tileset for asset ID 69380
LogCesium: Loading tileset for asset ID 69380 done
LogCesium: Verbose: Called BeginPlay on actor FloatingPawn_2
```

The constructors are called again. And `PostLoad` is called again. One (albeit shallow) answer to the obvious question "Why?" can be found by setting some breakpoints and reading through the Unreal code that does all this: When hitting "Play", then **the world is duplicated**. This roughly means that the actual objects that are used while playing are true **copies** of the objects that are present in the editor. 

In hindsight, this makes sense, of course. But really being *aware* of that, and taking it into account while designing the classes is a different story. For example, one "corollary" from that could be: **Every** part of the *state* of an object that should be retained while switching into "Play" mode **either** has to be serialized/deserialized as `UPROPERTY` values, **or** has to be derived from `UPROPERTY` values. (This *might* happen in `PostInitProperties` or `PostLoad`, or maybe in `BeginPlay`... but that has to be analyzed/verified). 

### Hitting "Play (Standalone)"
```
LogCesium: Verbose: Called Cesium3DTileset constructor on actor Default__Cesium3DTileset
LogCesium: Verbose: Called PostInitProperties on actor Default__Cesium3DTileset
LogCesium: Verbose: Called CesiumGeoreference constructor on actor Default__CesiumGeoreference
LogCesium: Verbose: Called GlobeAwareDefaultPawn constructor on actor Default__GlobeAwareDefaultPawn
LogCesium: Verbose: Called PostInitProperties on actor Default__GlobeAwareDefaultPawn
LogCesium: Verbose: Called GlobeAwareDefaultPawn constructor on actor Default__FloatingPawn_C
LogCesium: Verbose: Called PostInitProperties on actor Default__FloatingPawn_C
LogCesium: Verbose: Called GlobeAwareDefaultPawn constructor on actor Default__SKEL_FloatingPawn_C
LogCesium: Verbose: Called PostInitProperties on actor Default__SKEL_FloatingPawn_C
LogCesium: Verbose: Called GlobeAwareDefaultPawn constructor on actor Default__FloatingPawn_C
LogCesium: Verbose: Called PostInitProperties on actor Default__FloatingPawn_C
LogCesium: Verbose: Called GlobeAwareDefaultPawn constructor on actor FloatingPawn_2
LogCesium: Verbose: Called PostInitProperties on actor FloatingPawn_2
LogCesium: Verbose: Called Cesium3DTileset constructor on actor CesiumWorldTerrain
LogCesium: Verbose: Called PostInitProperties on actor CesiumWorldTerrain
LogCesium: Verbose: Called Cesium3DTileset constructor on actor MelbournePhotogrammetry
LogCesium: Verbose: Called PostInitProperties on actor MelbournePhotogrammetry
LogCesium: Verbose: Called CesiumGeoreference constructor on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called PostLoad on actor Default__FloatingPawn_C
LogCesium: Verbose: Called PostLoad on actor FloatingPawn_2
LogCesium: Verbose: Called PostLoad on actor CesiumWorldTerrain
LogCesium: Verbose: Called PostLoad on actor MelbournePhotogrammetry
LogCesium: Verbose: Called PostLoad on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called OnConstruction on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called OnConstruction on actor CesiumWorldTerrain
LogCesium: Loading tileset for asset ID 1
LogCesium: Loading tileset for asset ID 1 done
LogCesium: Verbose: Called OnConstruction on actor MelbournePhotogrammetry
LogCesium: Loading tileset for asset ID 69380
LogCesium: Loading tileset for asset ID 69380 done
LogCesium: Verbose: Called OnConstruction on actor FloatingPawn_2
LogCesium: Verbose: Called BeginPlay on actor CesiumGeoreferenceDefault
LogCesium: Verbose: Called BeginPlay on actor CesiumWorldTerrain
LogCesium: Verbose: Called BeginPlay on actor MelbournePhotogrammetry
LogCesium: Verbose: Called BeginPlay on actor FloatingPawn_2
```
This looks similar to "Play in Editor", but ... ehrm... with more constructors being called. I was just curious about the differences. There certainly are lifecycle methods that are called in "Play in Editor" but **not** in "Play Standalone", and vice versa, but **if** this becomes relevant, some further analysis may be necessary. For now, a relevant insight might be that the general structure of "Constructor"+`PostInitProperties`, followed by a bulk `PostLoad` for all actors, appears to be the same.












