### PR TITLE
Property change checks improved for watermask

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,6 @@
 
 ##### Additions :tada:
 
-- Updated to use the new `Cesium3DTiles::TilesetStreamingOptions` and `Cesium3DTiles::TilesetContentOptions`.
 - Improved property change checks in `Cesium3DTileset::LoadTileset`. 
 - Added macOS support.
 - Added support for the legacy `gltfUpAxis` property in a tileset `asset` dictionary. Although this property is **not** part of the specification, there are many existing assets that use this property and had been shown with a wrong rotation otherwise.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 ##### Additions :tada:
 
+- Updated to use the new `Cesium3DTiles::TilesetStreamingOptions` and `Cesium3DTiles::TilesetContentOptions`.
+- Improved property change checks in `Cesium3DTileset::LoadTileset`. 
 - Added macOS support.
 - Added support for the legacy `gltfUpAxis` property in a tileset `asset` dictionary. Although this property is **not** part of the specification, there are many existing assets that use this property and had been shown with a wrong rotation otherwise.
 - Changed the log level for the tile selection output from `Display` to `Verbose`. With default settings, the output will no longer be displayed in the console, but only written to the log file.

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -7,6 +7,7 @@
 #include "Cesium3DTiles/GltfContent.h"
 #include "Cesium3DTiles/IPrepareRendererResources.h"
 #include "Cesium3DTiles/Tileset.h"
+#include "Cesium3DTiles/TilesetOptions.h"
 #include "Cesium3DTilesetRoot.h"
 #include "CesiumAsync/CachingAssetAccessor.h"
 #include "CesiumAsync/SqliteCache.h"
@@ -609,7 +610,8 @@ void ACesium3DTileset::LoadTileset() {
     }
 
     bool waterMaskEnabledChanged =
-        this->EnableWaterMask != pTileset->getContentOptions().enableWaterMask;
+        this->EnableWaterMask !=
+        pTileset->getOptions().contentOptions.enableWaterMask;
 
     bool materialChanged = this->Material != this->_lastMaterial;
     this->_lastMaterial = this->Material;
@@ -639,22 +641,22 @@ void ACesium3DTileset::LoadTileset() {
                          : nullptr,
       spdlog::default_logger()};
 
-  Cesium3DTiles::TilesetContentOptions contentOptions;
-  contentOptions.enableWaterMask = this->EnableWaterMask;
+  Cesium3DTiles::TilesetOptions options;
+  options.contentOptions.enableWaterMask = this->EnableWaterMask;
 
   switch (this->TilesetSource) {
   case ETilesetSource::FromUrl:
     pTileset = new Cesium3DTiles::Tileset(
         externals,
         TCHAR_TO_UTF8(*this->Url),
-        contentOptions);
+        options);
     break;
   case ETilesetSource::FromCesiumIon:
     pTileset = new Cesium3DTiles::Tileset(
         externals,
         this->IonAssetID,
         TCHAR_TO_UTF8(*this->IonAccessToken),
-        contentOptions);
+        options);
     break;
   }
 
@@ -865,22 +867,19 @@ void ACesium3DTileset::Tick(float DeltaTime) {
     return;
   }
 
-  Cesium3DTiles::TilesetStreamingOptions& streamingOptions =
-      this->_pTileset->getStreamingOptions();
-  streamingOptions.maximumScreenSpaceError = this->MaximumScreenSpaceError;
+  Cesium3DTiles::TilesetOptions& options = this->_pTileset->getOptions();
+  options.maximumScreenSpaceError = this->MaximumScreenSpaceError;
 
-  streamingOptions.preloadAncestors = this->PreloadAncestors;
-  streamingOptions.preloadSiblings = this->PreloadSiblings;
-  streamingOptions.forbidHoles = this->ForbidHoles;
-  streamingOptions.maximumSimultaneousTileLoads =
-      this->MaximumSimultaneousTileLoads;
-  streamingOptions.loadingDescendantLimit = this->LoadingDescendantLimit;
+  options.preloadAncestors = this->PreloadAncestors;
+  options.preloadSiblings = this->PreloadSiblings;
+  options.forbidHoles = this->ForbidHoles;
+  options.maximumSimultaneousTileLoads = this->MaximumSimultaneousTileLoads;
+  options.loadingDescendantLimit = this->LoadingDescendantLimit;
 
-  streamingOptions.enableFrustumCulling = this->EnableFrustumCulling;
-  streamingOptions.enableFogCulling = this->EnableFogCulling;
-  streamingOptions.enforceCulledScreenSpaceError =
-      this->EnforceCulledScreenSpaceError;
-  streamingOptions.culledScreenSpaceError = this->CulledScreenSpaceError;
+  options.enableFrustumCulling = this->EnableFrustumCulling;
+  options.enableFogCulling = this->EnableFogCulling;
+  options.enforceCulledScreenSpaceError = this->EnforceCulledScreenSpaceError;
+  options.culledScreenSpaceError = this->CulledScreenSpaceError;
 
   std::optional<UnrealCameraParameters> camera = this->GetCamera();
   if (!camera) {

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -610,7 +610,7 @@ void ACesium3DTileset::LoadTileset() {
     }
 
     bool waterMaskEnabledChanged =
-        this->EnableWaterMask != pTileset->getOptions().enableWaterMask;
+        this->EnableWaterMask != pTileset->getContentOptions().enableWaterMask;
 
     bool materialChanged = this->Material != this->_lastMaterial;
     this->_lastMaterial = this->Material;
@@ -640,22 +640,22 @@ void ACesium3DTileset::LoadTileset() {
                          : nullptr,
       spdlog::default_logger()};
 
-  Cesium3DTiles::TilesetOptions options;
-  options.enableWaterMask = this->EnableWaterMask;
+  Cesium3DTiles::TilesetContentOptions contentOptions;
+  contentOptions.enableWaterMask = this->EnableWaterMask;
 
   switch (this->TilesetSource) {
   case ETilesetSource::FromUrl:
     pTileset = new Cesium3DTiles::Tileset(
         externals,
         TCHAR_TO_UTF8(*this->Url),
-        options);
+        contentOptions);
     break;
   case ETilesetSource::FromCesiumIon:
     pTileset = new Cesium3DTiles::Tileset(
         externals,
         this->IonAssetID,
         TCHAR_TO_UTF8(*this->IonAccessToken),
-        options);
+        contentOptions);
     break;
   }
 
@@ -866,22 +866,19 @@ void ACesium3DTileset::Tick(float DeltaTime) {
     return;
   }
 
-  // TODO: updating the options should probably happen in OnConstruction or
-  // PostEditChangeProperty, no need to have it happen every frame when the
-  // options haven't been changed
-  Cesium3DTiles::TilesetOptions& options = this->_pTileset->getOptions();
-  options.maximumScreenSpaceError = this->MaximumScreenSpaceError;
+  Cesium3DTiles::TilesetStreamingOptions& streamingOptions = this->_pTileset->getStreamingOptions();
+  streamingOptions.maximumScreenSpaceError = this->MaximumScreenSpaceError;
 
-  options.preloadAncestors = this->PreloadAncestors;
-  options.preloadSiblings = this->PreloadSiblings;
-  options.forbidHoles = this->ForbidHoles;
-  options.maximumSimultaneousTileLoads = this->MaximumSimultaneousTileLoads;
-  options.loadingDescendantLimit = this->LoadingDescendantLimit;
+  streamingOptions.preloadAncestors = this->PreloadAncestors;
+  streamingOptions.preloadSiblings = this->PreloadSiblings;
+  streamingOptions.forbidHoles = this->ForbidHoles;
+  streamingOptions.maximumSimultaneousTileLoads = this->MaximumSimultaneousTileLoads;
+  streamingOptions.loadingDescendantLimit = this->LoadingDescendantLimit;
 
-  options.enableFrustumCulling = this->EnableFrustumCulling;
-  options.enableFogCulling = this->EnableFogCulling;
-  options.enforceCulledScreenSpaceError = this->EnforceCulledScreenSpaceError;
-  options.culledScreenSpaceError = this->CulledScreenSpaceError;
+  streamingOptions.enableFrustumCulling = this->EnableFrustumCulling;
+  streamingOptions.enableFogCulling = this->EnableFogCulling;
+  streamingOptions.enforceCulledScreenSpaceError = this->EnforceCulledScreenSpaceError;
+  streamingOptions.culledScreenSpaceError = this->CulledScreenSpaceError;
 
   std::optional<UnrealCameraParameters> camera = this->GetCamera();
   if (!camera) {

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -50,7 +50,6 @@ ACesium3DTileset::ACesium3DTileset()
       _pTileset(nullptr),
 
       _lastTilesetSource(ETilesetSource::FromCesiumIon),
-      _lastEnableWaterMask(false),
       _lastMaterial(nullptr),
 
       _lastTilesRendered(0),

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -591,28 +591,24 @@ void ACesium3DTileset::LoadTileset() {
     // the tileset to be destroyed and recreated when changed.
 
     // check if the tileset source selection itself changed
-    bool tilesetSourceChanged = 
-      this->TilesetSource != this->_lastTilesetSource;
+    bool tilesetSourceChanged = this->TilesetSource != this->_lastTilesetSource;
     this->_lastTilesetSource = this->TilesetSource;
 
     // check if the current tileset changed
     switch (this->TilesetSource) {
-      case ETilesetSource::FromUrl:
-        tilesetSourceChanged = 
-            pTileset->getUrl() ? 
-            TCHAR_TO_UTF8(*this->Url) != pTileset->getUrl() :
-            this->Url.Len() > 0;
-        break;
-      case ETilesetSource::FromCesiumIon:
-        tilesetSourceChanged =
-            !pTileset->getIonAssetID() || 
-            !pTileset->getIonAccessToken() ||
-            this->IonAssetID != pTileset->getIonAssetID() || 
-            TCHAR_TO_UTF8(*this->IonAccessToken) != 
-              pTileset->getIonAccessToken();
-        break;
+    case ETilesetSource::FromUrl:
+      tilesetSourceChanged =
+          pTileset->getUrl() ? TCHAR_TO_UTF8(*this->Url) != pTileset->getUrl()
+                             : this->Url.Len() > 0;
+      break;
+    case ETilesetSource::FromCesiumIon:
+      tilesetSourceChanged =
+          !pTileset->getIonAssetID() || !pTileset->getIonAccessToken() ||
+          this->IonAssetID != pTileset->getIonAssetID() ||
+          TCHAR_TO_UTF8(*this->IonAccessToken) != pTileset->getIonAccessToken();
+      break;
     }
-    
+
     bool waterMaskEnabledChanged =
         this->EnableWaterMask != pTileset->getOptions().enableWaterMask;
 
@@ -648,19 +644,19 @@ void ACesium3DTileset::LoadTileset() {
   options.enableWaterMask = this->EnableWaterMask;
 
   switch (this->TilesetSource) {
-    case ETilesetSource::FromUrl:
-      pTileset = new Cesium3DTiles::Tileset(
-          externals,
-          TCHAR_TO_UTF8(*this->Url),
-          options);
-      break;
-    case ETilesetSource::FromCesiumIon:
-      pTileset = new Cesium3DTiles::Tileset(
-          externals,
-          this->IonAssetID,
-          TCHAR_TO_UTF8(*this->IonAccessToken),
-          options);
-      break;
+  case ETilesetSource::FromUrl:
+    pTileset = new Cesium3DTiles::Tileset(
+        externals,
+        TCHAR_TO_UTF8(*this->Url),
+        options);
+    break;
+  case ETilesetSource::FromCesiumIon:
+    pTileset = new Cesium3DTiles::Tileset(
+        externals,
+        this->IonAssetID,
+        TCHAR_TO_UTF8(*this->IonAccessToken),
+        options);
+    break;
   }
 
   this->_pTileset = pTileset;

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -866,18 +866,21 @@ void ACesium3DTileset::Tick(float DeltaTime) {
     return;
   }
 
-  Cesium3DTiles::TilesetStreamingOptions& streamingOptions = this->_pTileset->getStreamingOptions();
+  Cesium3DTiles::TilesetStreamingOptions& streamingOptions =
+      this->_pTileset->getStreamingOptions();
   streamingOptions.maximumScreenSpaceError = this->MaximumScreenSpaceError;
 
   streamingOptions.preloadAncestors = this->PreloadAncestors;
   streamingOptions.preloadSiblings = this->PreloadSiblings;
   streamingOptions.forbidHoles = this->ForbidHoles;
-  streamingOptions.maximumSimultaneousTileLoads = this->MaximumSimultaneousTileLoads;
+  streamingOptions.maximumSimultaneousTileLoads =
+      this->MaximumSimultaneousTileLoads;
   streamingOptions.loadingDescendantLimit = this->LoadingDescendantLimit;
 
   streamingOptions.enableFrustumCulling = this->EnableFrustumCulling;
   streamingOptions.enableFogCulling = this->EnableFogCulling;
-  streamingOptions.enforceCulledScreenSpaceError = this->EnforceCulledScreenSpaceError;
+  streamingOptions.enforceCulledScreenSpaceError =
+      this->EnforceCulledScreenSpaceError;
   streamingOptions.culledScreenSpaceError = this->CulledScreenSpaceError;
 
   std::optional<UnrealCameraParameters> camera = this->GetCamera();

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -865,7 +865,6 @@ static void loadPrimitive(
           rasterOverlay1,
           textureCoordinateMap);
 
-  // TODO: add option to disable this
   // Initialize water mask if needed.
   auto onlyWaterIt = primitive.extras.find("OnlyWater");
   auto onlyLandIt = primitive.extras.find("OnlyLand");

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -22,6 +22,20 @@ class Tileset;
 class TilesetView;
 } // namespace Cesium3DTiles
 
+UENUM()
+enum class ETilesetSource : uint8 {
+  /**
+   * The tileset will be loaded from Cesium Ion using the provided IonAssetID 
+   * and IonAccessToken. 
+   */
+  FromCesiumIon UMETA(DisplayName = "From Cesium Ion"),
+
+  /**
+   * The tileset will be loaded from the specified Url. 
+   */
+  FromUrl UMETA(DisplayName = "From Url")
+};
+
 UCLASS()
 class CESIUMRUNTIME_API ACesium3DTileset : public AActor,
                                            public ICesiumGeoreferenceable {
@@ -32,11 +46,17 @@ public:
   virtual ~ACesium3DTileset();
 
   /**
+   * The type of source from which to load this tileset.
+   */
+  UPROPERTY(EditAnywhere, Category = "Cesium", meta = (DisplayName = "Source"))
+  ETilesetSource TilesetSource = ETilesetSource::FromCesiumIon;
+
+  /**
    * The URL of this tileset's "tileset.json" file.
    *
    * If this property is specified, the ion asset ID and token are ignored.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium")
+  UPROPERTY(EditAnywhere, Category = "Cesium", meta = (EditCondition = "TilesetSource==ETilesetSource::FromUrl"))
   FString Url;
 
   /**
@@ -44,7 +64,7 @@ public:
    *
    * This property is ignored if the Url is specified.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium")
+  UPROPERTY(EditAnywhere, Category = "Cesium", meta = (EditCondition = "TilesetSource==ETilesetSource::FromCesiumIon"))
   uint32 IonAssetID;
 
   /**
@@ -54,7 +74,7 @@ public:
       EditAnywhere,
       BlueprintReadOnly,
       Category = "Cesium",
-      meta = (EditCondition = "IonAssetID"))
+      meta = (EditCondition = "TilesetSource==ETilesetSource::FromCesiumIon"))
   FString IonAccessToken;
 
   /**
@@ -255,7 +275,7 @@ public:
    * water mask extension.
    */
   UPROPERTY(EditAnywhere, Category = "Cesium|Rendering")
-  bool EnableWaterMask = true;
+  bool EnableWaterMask = false;
 
   /**
    * Pauses level-of-detail and culling updates of this tileset.
@@ -353,7 +373,9 @@ private:
 private:
   Cesium3DTiles::Tileset* _pTileset;
 
-  UMaterialInterface* _lastMaterial = nullptr;
+  ETilesetSource _lastTilesetSource;
+  bool _lastEnableWaterMask;
+  UMaterialInterface* _lastMaterial;
 
   uint32_t _lastTilesRendered;
   uint32_t _lastTilesLoadingLowPriority;

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -25,13 +25,13 @@ class TilesetView;
 UENUM()
 enum class ETilesetSource : uint8 {
   /**
-   * The tileset will be loaded from Cesium Ion using the provided IonAssetID 
-   * and IonAccessToken. 
+   * The tileset will be loaded from Cesium Ion using the provided IonAssetID
+   * and IonAccessToken.
    */
   FromCesiumIon UMETA(DisplayName = "From Cesium Ion"),
 
   /**
-   * The tileset will be loaded from the specified Url. 
+   * The tileset will be loaded from the specified Url.
    */
   FromUrl UMETA(DisplayName = "From Url")
 };
@@ -56,7 +56,10 @@ public:
    *
    * If this property is specified, the ion asset ID and token are ignored.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium", meta = (EditCondition = "TilesetSource==ETilesetSource::FromUrl"))
+  UPROPERTY(
+      EditAnywhere,
+      Category = "Cesium",
+      meta = (EditCondition = "TilesetSource==ETilesetSource::FromUrl"))
   FString Url;
 
   /**
@@ -64,7 +67,10 @@ public:
    *
    * This property is ignored if the Url is specified.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium", meta = (EditCondition = "TilesetSource==ETilesetSource::FromCesiumIon"))
+  UPROPERTY(
+      EditAnywhere,
+      Category = "Cesium",
+      meta = (EditCondition = "TilesetSource==ETilesetSource::FromCesiumIon"))
   uint32 IonAssetID;
 
   /**

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -380,7 +380,6 @@ private:
   Cesium3DTiles::Tileset* _pTileset;
 
   ETilesetSource _lastTilesetSource;
-  bool _lastEnableWaterMask;
   UMaterialInterface* _lastMaterial;
 
   uint32_t _lastTilesRendered;


### PR DESCRIPTION
Small clean up of the checks for property changes in `Cesium3DTileset::LoadTileset`. 