### PR TITLE
Fixing GeoreferenceComponent properties update 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 
 ##### Fixes :wrench:
 
+* Fixed issue where displayed longitude-latitude-height in `CesiumGeoreferenceComponent` wasn't updating in certain cases.
 * `FEditorDelegates::OnFocusViewportOnActors` is no longer unnecessarily subscribed to multiple times.
 * `Loading tileset ...` is now only written to the output log when the tileset actually needs to be reloaded.
 

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -82,7 +82,6 @@ void UCesiumGeoreferenceComponent::MoveToLongitudeLatitudeHeight(
           targetLongitudeLatitudeHeight.z));
 
   this->_setECEF(ecef, maintainRelativeOrientation);
-  this->_updateDisplayECEF();
 }
 
 void UCesiumGeoreferenceComponent::InaccurateMoveToLongitudeLatitudeHeight(
@@ -100,7 +99,6 @@ void UCesiumGeoreferenceComponent::MoveToECEF(
     const glm::dvec3& targetEcef,
     bool maintainRelativeOrientation) {
   this->_setECEF(targetEcef, maintainRelativeOrientation);
-  this->_updateDisplayLongitudeLatitudeHeight();
 }
 
 void UCesiumGeoreferenceComponent::InaccurateMoveToECEF(
@@ -451,6 +449,10 @@ void UCesiumGeoreferenceComponent::_setECEF(
   if (this->_autoSnapToEastSouthUp) {
     this->SnapToEastSouthUp();
   }
+
+  // Update component properties
+  this->_updateDisplayECEF();
+  this->_updateDisplayLongitudeLatitudeHeight();
 }
 
 void UCesiumGeoreferenceComponent::_updateDisplayLongitudeLatitudeHeight() {


### PR DESCRIPTION
When using 'MoveToLongitudeLatitudeHeight' function, only ECEF properties are updated.
When using 'InaccurateMoveToLongitudeLatitudeHeight', only "geographics" (lat/long/height) properties are updated.
Fixing this by updating both types of properties regardless of the called function.