### PR TITLE
Always use the glTF primitive component's collision, not the static mesh's.

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -311,7 +311,8 @@ void ACesium3DTileset::OnConstruction(const FTransform& Transform) {
   this->LoadTileset();
 
   // Hide all existing tiles. The still-visible ones will be shown next time we
-  // tick. But if update is suspended, leave the components in their current state.
+  // tick. But if update is suspended, leave the components in their current
+  // state.
   if (!this->SuspendUpdate) {
     TArray<UCesiumGltfComponent*> gltfComponents;
     this->GetComponents<UCesiumGltfComponent>(gltfComponents);

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -311,14 +311,16 @@ void ACesium3DTileset::OnConstruction(const FTransform& Transform) {
   this->LoadTileset();
 
   // Hide all existing tiles. The still-visible ones will be shown next time we
-  // tick.
-  TArray<UCesiumGltfComponent*> gltfComponents;
-  this->GetComponents<UCesiumGltfComponent>(gltfComponents);
+  // tick. But if update is suspended, leave the components in their current state.
+  if (!this->SuspendUpdate) {
+    TArray<UCesiumGltfComponent*> gltfComponents;
+    this->GetComponents<UCesiumGltfComponent>(gltfComponents);
 
-  for (UCesiumGltfComponent* pGltf : gltfComponents) {
-    if (pGltf && IsValid(pGltf) && pGltf->IsVisible()) {
-      pGltf->SetVisibility(false, true);
-      pGltf->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+    for (UCesiumGltfComponent* pGltf : gltfComponents) {
+      if (pGltf && IsValid(pGltf) && pGltf->IsVisible()) {
+        pGltf->SetVisibility(false, true);
+        pGltf->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+      }
     }
   }
 }

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1319,12 +1319,11 @@ static void loadModelGameThreadPart(
   pMesh->HighPrecisionNodeTransform = loadResult.transform;
   pMesh->UpdateTransformFromCesium(cesiumToUnrealTransform);
 
-  pMesh->SetCollisionEnabled(ECollisionEnabled::QueryAndPhysics);
-  pMesh->bUseDefaultCollision = true;
-  // pMesh->SetCollisionProfileName(UCollisionProfile::BlockAll_ProfileName);
+  pMesh->bUseDefaultCollision = false;
   pMesh->SetFlags(RF_Transient);
 
-  UStaticMesh* pStaticMesh = NewObject<UStaticMesh>();
+  UStaticMesh* pStaticMesh =
+      NewObject<UStaticMesh>(pMesh, FName(loadResult.name.c_str()));
   pMesh->SetStaticMesh(pStaticMesh);
 
   pStaticMesh->bIsBuiltAtRuntime = true;


### PR DESCRIPTION
Fixes #313 

Also fixes a bug where all the tiles would disappear if you turned on "Suspend Update". And gives our UStaticMeshes a name (the tile URL) so they're easier to identify.

Here come a lot of words about the cause and solution of this issue...

When creating the UStaticMeshComponent instances, we set `bUseDefaultCollision=true` on it. Why? Well, probably because I saw the DataSmith glTF loader code doing something similar and didn't know any better.

Anyway, it turns out that what that property actually means is that the collision profiles should come from the `BodySetup` of the  `UStaticMesh` attached to the component, rather than from the CesiumGltfPrimitiveComponent's `BodyInstance`. That's a problem because we're turning collision on and off (e.g. when the tile isn't visible) and setting its collision profiles by setting properties on the `CesiumGltfPrimitiveComponent`.

You may be wondering how collision was working at all, then. Me too. Well, it turns out just setting that property doesn't do anything. You also have to call `UpdateCollisionFromStaticMesh`. That will get called automatically when the component is registered (i.e. when we call `RegisterComponent`). But that _still_ won't copy the static mesh's profile over unless the component's BodyInstance reports `DoesUseCollisionProfile() == false`. At the time we call `RegisterComponent`, it's true. But once we call `SetCollisionEnabled(ECollisionEnabled::NoCollision)` (which we do for all newly-constructed tiles shortly _after_ registering them), it flips to false. But that doesn't matter, because we're already registered, and so that `UpdateCollisionFromStaticMesh` doesn't get called and nothing breaks our collision setup. 👍 

So that's all well and good until we edit a property of the Cesium3DTileset in the editor. Property editing in UE is an impressively complicated process and I don't understand it at all, but what I now know is that every time a property is edited, (some? all?) components are unregistered and then re-registered. So now we have all the necessary conditions for disaster: `bUseDefaultCollision` is true, `DoesUseCollisionProfile()` is false, and we've just (re-)registered the component, which calls `UpdateCollisionFromStaticMesh`. UE happily copies the collision settings from the static mesh to our component, thereby enabling collision on a tile that isn't (and never was) visible.

The camera doesn't collide with things in the editor, and when we Play-in-Editor we'll get all new tiles anyway, so the main effect of this that we've seen is that we can no longer properly place foliage on terrain after we change any property of the terrain tileset.

If you're still with me (🥱), here are some notes on how I tracked this down. Even though it's basically a one line change it took way too many hours to figure out. So maybe these notes will help someone else spend a few less hours on a similar problem in the future. I'll skip over all the false starts and dead ends.

Alex had noted in #313 that the "Player Collision" view mode showed wrong collision meshes. So I searched the engine source code for "Player Collision", and found that the engine calls this "CollisionPawn" internally so I searched for that instead. That's used all over the code base, but the one that jumped out at me was `FStaticMeshSceneProxy` (StaticMeshRender.cpp), cause we're dealing with static meshes here. There was clearly logic that was deciding whether or not to draw something in the "Player Collision" view for a particular static mesh.

I set a breakpoint in `IsCollisionView` and its caller (`GetDynamicMeshElements`) and started trying to understand why it was deciding to show the collision meshes that I expected to be disabled. It was a huge hassle because the engine is optimized, so the debugger lies and refuses to evaluate things and generally misbehaves. In retrospect it may have been worthwhile to do a proper debug build of Unreal Engine,  but it seemed like a lot of trouble at the time.

Ok so it was showing the mesh because `CollisionResponse.GetResponse(ECC_Pawn)` was indicating it should respond to collision with the pawn. Why? Well, the FStaticMeshSceneProxy` is constructed from a `UStaticMeshComponent` (specifically our `CesiumGltfPrimitiveComponent`. And with another breakpoint, I could see the CollisionResponse was wrong at that point.

So I went back to where we construct the CesiumGltfPrimitiveComponent, and confirmed that collision response was correct there for a particular tile I knew shouldn't be shown in the collision view, but was. Somewhere later, during the incredibly complex process of editing a property, it was getting changed. But where?

The pawn collision response is a simple one-byte enum, and I could easily inspect it and see its address at the point of CesiumGltfPrimitiveComponent construction. So I set a data breakpoint on that field:

![data-breakpoint](https://user-images.githubusercontent.com/924374/116690837-543c7380-a9fd-11eb-9184-9f4bb69f855e.gif)

Then I changed a property and the debugger immediately stopped where it was changed! Hurray! It was in the `UpdateCollisionFromStaticMesh` mentioned above (actually a couple function calls down from there).

From there it only took a couple more hours (😆) to trace through all logic that got us there in order to figure out what to change to... not get there.

Cool story right? No? Ok well I thought that "Break When Value Changes" thing was pretty cool. I haven't used a data breakpoint in a long time and I was impressed how well it worked. Maybe someone else will find that useful.