### PR TITLE
Fix zooming limit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 * `Loading tileset ...` is now only written to the output log when the tileset actually needs to be reloaded.
 * Fixed a bug where collision does not update correctly when changing properties of a tileset in the editor.
 * Fixed a bug that caused tiles to disappear when "Suspend Update" was enabled.
+* Fixed a bug that caused rendering- and navigation problems when zooming too far away from the globe when origin rebasing is enabled.
 
 ### v1.1.1 - 2021-04-23
 

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -576,23 +576,9 @@ void ACesiumGeoreference::_performOriginRebasing() {
     // Camera has moved too far from the origin, move the origin,
     // but make sure that no component exceeds the maximum value
     // that can be represented as a 32bit signed integer.
-
     int64 newX = clampedAdd(cameraLocation.X, originLocation.X);
     int64 newY = clampedAdd(cameraLocation.Y, originLocation.Y);
     int64 newZ = clampedAdd(cameraLocation.Z, originLocation.Z);
-    UE_LOG(
-        LogCesium,
-        Warning,
-        TEXT("Camera at %f %f %f origin at %d %d %d move to %d %d %d"),
-        cameraLocation.X,
-        cameraLocation.Y,
-        cameraLocation.Z,
-        originLocation.X,
-        originLocation.Y,
-        originLocation.Z,
-        newX,
-        newY,
-        newZ);
     this->GetWorld()->SetNewWorldOrigin(FIntVector(newX, newY, newZ));
   }
 }

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -526,8 +526,19 @@ public:
    */
   void UpdateGeoreference();
 
-  // Called every frame
+  /**
+   * @brief Returns whether `Tìck` should be called in viewports-only mode.
+   *
+   * "If `true`, actor is ticked even if TickType==LEVELTICK_ViewportsOnly."
+   * (The TickType is determined by the unreal engine internally).
+   */
   virtual bool ShouldTickIfViewportsOnly() const override;
+
+  /**
+   * @brief Function called every frame on this Actor.
+   * 
+   * @param DeltaTime Game time elapsed during last frame modified by the time dilation
+   */
   virtual void Tick(float DeltaTime) override;
 
 protected:
@@ -571,7 +582,37 @@ private:
   void _lineTraceViewportMouse(
       const bool ShowTrace,
       bool& Success,
-      FHitResult& HitResult);
+      FHitResult& HitResult) const;
+
+  /**
+   * @brief Show the load radius of each sub-level as a sphere.
+   * 
+   * If this is not called "in-game", and `ShowLoadRadii` is `true`,
+   * then it will show a sphere indicating the load radius of each
+   * sub-level.
+   */
+  void _showSubLevelLoadRadii() const;
+
+  /**
+   * @brief Allow editing the origin with the mouse.
+   * 
+   * If `EditOriginInViewport` is true, this will trace the mouse
+   * position, and update the origin based on the point that was
+   * hit.
+   */
+  void _handleViewportOriginEditing();
+
+  /**
+   * @brief Perform the origin-rebasing.
+   * 
+   * If this actor is currently "in-game", and has an associated
+   * `WorldOriginCamera`, then (depending on some conditions related
+   * to `KeepWorldOriginNearCamera`, sublevels, and `OriginRebaseInsideSublevels`)
+   * this may set a new world origin by calling `GetWorld()->SetNewWorldOrigin`
+   * with a new position.
+   */
+  void _performOriginRebasing();
+
 #endif
   TArray<TWeakInterfacePtr<ICesiumGeoreferenceable>> _georeferencedObjects;
 };

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -536,8 +536,9 @@ public:
 
   /**
    * @brief Function called every frame on this Actor.
-   * 
-   * @param DeltaTime Game time elapsed during last frame modified by the time dilation
+   *
+   * @param DeltaTime Game time elapsed during last frame modified by the time
+   * dilation
    */
   virtual void Tick(float DeltaTime) override;
 
@@ -586,7 +587,7 @@ private:
 
   /**
    * @brief Show the load radius of each sub-level as a sphere.
-   * 
+   *
    * If this is not called "in-game", and `ShowLoadRadii` is `true`,
    * then it will show a sphere indicating the load radius of each
    * sub-level.
@@ -595,7 +596,7 @@ private:
 
   /**
    * @brief Allow editing the origin with the mouse.
-   * 
+   *
    * If `EditOriginInViewport` is true, this will trace the mouse
    * position, and update the origin based on the point that was
    * hit.
@@ -604,12 +605,12 @@ private:
 
   /**
    * @brief Perform the origin-rebasing.
-   * 
+   *
    * If this actor is currently "in-game", and has an associated
    * `WorldOriginCamera`, then (depending on some conditions related
-   * to `KeepWorldOriginNearCamera`, sublevels, and `OriginRebaseInsideSublevels`)
-   * this may set a new world origin by calling `GetWorld()->SetNewWorldOrigin`
-   * with a new position.
+   * to `KeepWorldOriginNearCamera`, sublevels, and
+   * `OriginRebaseInsideSublevels`) this may set a new world origin by calling
+   * `GetWorld()->SetNewWorldOrigin` with a new position.
    */
   void _performOriginRebasing();
 

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -603,6 +603,8 @@ private:
    */
   void _handleViewportOriginEditing();
 
+#endif
+
   /**
    * @brief Perform the origin-rebasing.
    *
@@ -614,6 +616,5 @@ private:
    */
   void _performOriginRebasing();
 
-#endif
   TArray<TWeakInterfacePtr<ICesiumGeoreferenceable>> _georeferencedObjects;
 };


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium-unreal/issues/284 ...

... as far as reasonably possible. I noticed that the controls are still wonky when moving too far and e.g. rotating with WASD. But this fix until now avoids the "flickering" of the position, by clamping the world origin (during rebase operations) to the valid 32bit integer range. 

