### PR TITLE
Fixed `GlobeAwareDefaultPawn` not being georeferenced during play

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ##### Fixes :wrench:
 
+- Fixed regression in Cesium for Unreal v1.2.0 where `GlobeAwareDefaultPawn` lost its georeference during playmode.
 - Fixed a regression in Cesium for Unreal v1.2.0 that broke the ability to paint foliage on terrain and other tilesets.
 - Fixed a bug that caused glTF node `translation`, `rotation`, and `scale` properties to be ignored even if the node had no `matrix`.
 

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -410,6 +410,13 @@ void AGlobeAwareDefaultPawn::OnConstruction(const FTransform& Transform) {
 void AGlobeAwareDefaultPawn::BeginPlay() {
   Super::BeginPlay();
 
+  if (!this->Georeference) {
+    this->Georeference = ACesiumGeoreference::GetDefaultForActor(this);
+  }
+
+  this->_currentEcef = this->GetECEFCameraLocation();
+  this->Georeference->AddGeoreferencedObject(this);
+
   // TODO: find more elegant solution
   // the controller gets confused if the pawn itself has a nonzero orientation
   this->SetActorRotation(FRotator(0.0, 0.0, 0.0));


### PR DESCRIPTION
Fixes: https://github.com/CesiumGS/cesium-unreal/issues/421