### PR TITLE
Initialize georeference matrices with identity, not zero

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ##### Fixes :wrench:
 
+- Fixed a regression in Cesium for Unreal v1.2.0 where the matrices in `CesiumGeoreference` were being initialized to zero instead of identity.
 - Fixed a regression in Cesium for Unreal v1.2.0 that broke the ability to paint foliage on terrain and other tilesets.
 - Fixed a bug that caused glTF node `translation`, `rotation`, and `scale` properties to be ignored even if the node had no `matrix`.
 

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -28,6 +28,9 @@
 #include "Slate/SceneViewport.h"
 #endif
 
+#define IDENTITY_MAT4x4_ARRAY                                                  \
+  1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0
+
 /*static*/ ACesiumGeoreference*
 ACesiumGeoreference::GetDefaultForActor(AActor* Actor) {
   ACesiumGeoreference* pGeoreference = FindObject<ACesiumGeoreference>(
@@ -58,7 +61,12 @@ ACesiumGeoreference::GetDefaultForActor(AActor* Actor) {
   return pGeoreference;
 }
 
-ACesiumGeoreference::ACesiumGeoreference() : _insideSublevel(false) {
+ACesiumGeoreference::ACesiumGeoreference()
+    : _georeferencedToEcef_Array{IDENTITY_MAT4x4_ARRAY},
+      _ecefToGeoreferenced_Array{IDENTITY_MAT4x4_ARRAY},
+      _ueAbsToEcef_Array{IDENTITY_MAT4x4_ARRAY},
+      _ecefToUeAbs_Array{IDENTITY_MAT4x4_ARRAY},
+      _insideSublevel(false) {
   PrimaryActorTick.bCanEverTick = true;
 }
 


### PR DESCRIPTION
The georeference matrices were being initialized to zero after #319. This PR initializes them to identity again, possibly fixing: #407.