### PR TITLE
Add a couple missing #include to be able to compile with -DisableUnity.

### DIFF
--- a/Source/CesiumEditor/Private/CesiumPanel.h
+++ b/Source/CesiumEditor/Private/CesiumPanel.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "Dialogs/CustomDialog.h"
 #include "Widgets/SCompoundWidget.h"
 
 class FArguments;

--- a/Source/CesiumEditor/Private/IonLoginPanel.h
+++ b/Source/CesiumEditor/Private/IonLoginPanel.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "Dialogs/CustomDialog.h"
 #include "Widgets/SCompoundWidget.h"
 
 class FArguments;

--- a/Source/CesiumEditor/Private/IonQuickAddPanel.h
+++ b/Source/CesiumEditor/Private/IonQuickAddPanel.h
@@ -2,7 +2,9 @@
 
 #pragma once
 
+#include "Dialogs/CustomDialog.h"
 #include "Widgets/SCompoundWidget.h"
+#include "Widgets/Views/STableRow.h"
 #include <string>
 #include <unordered_set>
 

--- a/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
@@ -3,6 +3,8 @@
 #include "CesiumCreditSystem.h"
 #include "Cesium3DTiles/CreditSystem.h"
 #include "CesiumCreditSystemBPLoader.h"
+#include "CesiumRuntime.h"
+#include "Engine/World.h"
 #include <string>
 #include <vector>
 

--- a/Source/CesiumRuntime/Private/SpdlogUnrealLoggerSink.cpp
+++ b/Source/CesiumRuntime/Private/SpdlogUnrealLoggerSink.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 CesiumGS, Inc. and Contributors
 
 #include "SpdlogUnrealLoggerSink.h"
+#include "CesiumRuntime.h"
 #include "CoreMinimal.h"
 
 void SpdlogUnrealLoggerSink::sink_it_(const spdlog::details::log_msg& msg) {

--- a/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
+++ b/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
@@ -9,6 +9,7 @@
 #include "Interfaces/IHttpRequest.h"
 #include "Interfaces/IHttpResponse.h"
 #include "Interfaces/IPluginManager.h"
+#include "Misc/App.h"
 #include "Misc/EngineVersion.h"
 #include <cstddef>
 #include <optional>

--- a/Source/CesiumRuntime/Public/CesiumGlobeAnchorParent.h
+++ b/Source/CesiumRuntime/Public/CesiumGlobeAnchorParent.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "CesiumGeoreferenceComponent.h"
 #include "GameFramework/Actor.h"
 
 #include "CesiumGlobeAnchorParent.generated.h"


### PR DESCRIPTION
Whenever I edit some files locally, Unreal will exclude them from the unity blob and the build will start failing because of these missing includes.