### PR TITLE
Fix zooming limit only

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Make origin rebasing boolean properties in `CesiumGeoreference` and `CesiumGeoreferenceComponent` blueprint editable.
 - Improvements to dynamic camera, created altitude curves for FlyTo behavior.
 - Constrained the values for `UPROPERTY` user inputs to be in valid ranges.
+- Fixed a bug that caused rendering- and navigation problems when zooming too far away from the globe when origin rebasing is enabled.
 
 ##### Fixes :wrench:
 

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -565,9 +565,9 @@ void ACesiumGeoreference::Tick(float DeltaTime) {
       // Camera has moved too far from the origin, move the origin,
       // but make sure that no component exceeds the maximum value
       // that can be represented as a 32bit signed integer.
-      int64 newX = clampedAdd(cameraLocation.X, originLocation.X);
-      int64 newY = clampedAdd(cameraLocation.Y, originLocation.Y);
-      int64 newZ = clampedAdd(cameraLocation.Z, originLocation.Z);
+      int32 newX = clampedAdd(cameraLocation.X, originLocation.X);
+      int32 newY = clampedAdd(cameraLocation.Y, originLocation.Y);
+      int32 newZ = clampedAdd(cameraLocation.Z, originLocation.Z);
       this->GetWorld()->SetNewWorldOrigin(FIntVector(newX, newY, newZ));
     }
   }

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -378,6 +378,27 @@ void ACesiumGeoreference::PostEditChangeProperty(FPropertyChangedEvent& event) {
 }
 #endif
 
+namespace {
+/**
+ * @brief Clamping addition.
+ *
+ * Returns the sum of the given values, clamping the result to
+ * the minimum/maximum value that can be represented as a 32 bit
+ * signed integer.
+ *
+ * @param f The floating point value
+ * @param i The integer value
+ * @return The clamped result
+ */
+int32 clampedAdd(float f, int32 i) {
+  int64 sum = static_cast<int64>(f) + static_cast<int64>(i);
+  int64 min = static_cast<int64>(TNumericLimits<int32>::Min());
+  int64 max = static_cast<int64>(TNumericLimits<int32>::Max());
+  int64 clamped = FMath::Max(min, FMath::Min(max, sum));
+  return static_cast<int32>(clamped);
+}
+} // namespace
+
 // Called every frame
 bool ACesiumGeoreference::ShouldTickIfViewportsOnly() const { return true; }
 
@@ -541,14 +562,13 @@ void ACesiumGeoreference::Tick(float DeltaTime) {
         !cameraLocation.Equals(
             FVector(0.0f, 0.0f, 0.0f),
             this->MaximumWorldOriginDistanceFromCamera)) {
-      // Camera has moved too far from the origin, move the origin.
-      this->GetWorld()->SetNewWorldOrigin(FIntVector(
-          static_cast<int32>(cameraLocation.X) +
-              static_cast<int32>(originLocation.X),
-          static_cast<int32>(cameraLocation.Y) +
-              static_cast<int32>(originLocation.Y),
-          static_cast<int32>(cameraLocation.Z) +
-              static_cast<int32>(originLocation.Z)));
+      // Camera has moved too far from the origin, move the origin,
+      // but make sure that no component exceeds the maximum value
+      // that can be represented as a 32bit signed integer.
+      int64 newX = clampedAdd(cameraLocation.X, originLocation.X);
+      int64 newY = clampedAdd(cameraLocation.Y, originLocation.Y);
+      int64 newZ = clampedAdd(cameraLocation.Z, originLocation.Z);
+      this->GetWorld()->SetNewWorldOrigin(FIntVector(newX, newY, newZ));
     }
   }
 }


### PR DESCRIPTION
This is the core of what was originally done in https://github.com/CesiumGS/cesium-unreal/pull/409 : 

It only makes sure that the rebased world origin stays in the integer range.

(EDIT: Fixes https://github.com/CesiumGS/cesium-unreal/issues/284 )