### PR TITLE
Added teleport flag for cesium georeference transform update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Added `M_CesiumOverlayWater` and `M_CesiumOverlayComplexWater` materials for use with water tiles.
 - Exposed all tileset materials to allow for changes in editor.
 - Fixed a bug that caused rendering- and navigation problems when zooming too far away from the globe when origin rebasing is enabled.
+- Added teleport boolean property to CesiumGeoreferenceComponent.
 
 ##### Fixes :wrench:
 

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -4,6 +4,7 @@
 #include "CesiumGeospatial/Cartographic.h"
 #include "CesiumGeospatial/Ellipsoid.h"
 #include "CesiumGeospatial/Transforms.h"
+#include "CesiumRuntime.h"
 #include "CesiumTransforms.h"
 #include "CesiumUtility/Math.h"
 #include "Engine/EngineTypes.h"
@@ -395,12 +396,16 @@ void UCesiumGeoreferenceComponent::_setTransform(const glm::dmat4& transform) {
   // preemptively mark down to ignore it.
   _ignoreOnUpdateTransform = true;
 
-  this->_ownerRoot->SetWorldTransform(FTransform(FMatrix(
-      FVector(transform[0].x, transform[0].y, transform[0].z),
-      FVector(transform[1].x, transform[1].y, transform[1].z),
-      FVector(transform[2].x, transform[2].y, transform[2].z),
-      FVector(transform[3].x, transform[3].y, transform[3].z))));
-
+  this->_ownerRoot->SetWorldTransform(
+      FTransform(FMatrix(
+          FVector(transform[0].x, transform[0].y, transform[0].z),
+          FVector(transform[1].x, transform[1].y, transform[1].z),
+          FVector(transform[2].x, transform[2].y, transform[2].z),
+          FVector(transform[3].x, transform[3].y, transform[3].z))),
+      false,
+      nullptr,
+      TeleportWhenUpdatingTransform ? ETeleportType::TeleportPhysics
+                                    : ETeleportType::None);
   // TODO: try direct setting of transformation, may work for static objects on
   // origin rebase
   /*

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -51,6 +51,15 @@ public:
   bool FixTransformOnOriginRebase = true;
 
   /**
+   * Using the teleport flag will move objects to the updated transform
+   * immediately and without affecting their velocity. This is useful when
+   * working with physics actors that maintain an internal velocity which we do
+   * not want to change when updating location.
+   */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
+  bool TeleportWhenUpdatingTransform = true;
+
+  /**
    * The WGS84 longitude in degrees of this actor, in the range [-180, 180]
    */
   UPROPERTY(


### PR DESCRIPTION
Closes #307 

I added a bool UPROPERTY which determines whether the teleport setting is set to None or TeleportPhysics. Perhaps it'd be a good idea to expose all three options here instead of a boolean?

UE documentation regarding this flag:
```
/** Whether to teleport physics body or not */
UENUM()
enum class ETeleportType : uint8
{
	/** Do not teleport physics body. This means velocity will reflect the movement between initial and final position, and collisions along the way will occur */
	None,

	/** Teleport physics body so that velocity remains the same and no collision occurs */
	TeleportPhysics,

	/** Teleport physics body and reset physics state completely */
	ResetPhysics,
};
```

Also found this page from the UE blog helpful: https://www.unrealengine.com/en-US/blog/moving-physical-objects