### PR TITLE
Ensure HTTP module gets loaded along with Runtime.

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumRuntime.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRuntime.cpp
@@ -3,6 +3,7 @@
 #include "CesiumRuntime.h"
 #include "Cesium3DTiles/registerAllTileContentTypes.h"
 #include "SpdlogUnrealLoggerSink.h"
+#include <Modules/ModuleManager.h>
 #include <spdlog/spdlog.h>
 
 #define LOCTEXT_NAMESPACE "FCesiumRuntimeModule"
@@ -14,6 +15,8 @@ void FCesiumRuntimeModule::StartupModule() {
 
   std::shared_ptr<spdlog::logger> pLogger = spdlog::default_logger();
   pLogger->sinks() = {std::make_shared<SpdlogUnrealLoggerSink>()};
+
+  FModuleManager::Get().LoadModuleChecked(TEXT("HTTP"));
 }
 
 void FCesiumRuntimeModule::ShutdownModule() {}


### PR DESCRIPTION
First load needs to happen inside GameThread.
Since we always use it through async, we could crash if nobody ended up loading the HTTP module before we did.

Addressing issue reported in https://github.com/CesiumGS/cesium-unreal/issues/439