### PR TITLE
Disable support for water mask on Mac

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -697,7 +697,11 @@ void ACesium3DTileset::LoadTileset() {
   this->_startTime = std::chrono::high_resolution_clock::now();
 
   Cesium3DTiles::TilesetOptions options;
+  // TODO: figure out why water material crashes mac
+#if PLATFORM_MAC
+#else
   options.contentOptions.enableWaterMask = this->EnableWaterMask;
+#endif
 
   switch (this->TilesetSource) {
   case ETilesetSource::FromUrl:

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -76,6 +76,8 @@ ACesium3DTileset::ACesium3DTileset()
   this->RootComponent =
       CreateDefaultSubobject<UCesium3DTilesetRoot>(TEXT("Tileset"));
   this->RootComponent->SetMobility(EComponentMobility::Static);
+
+  PlatformName = UGameplayStatics::GetPlatformName();
 }
 
 ACesium3DTileset::~ACesium3DTileset() { this->DestroyTileset(); }

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -27,6 +27,7 @@
 #include "GameFramework/PlayerController.h"
 #include "HttpModule.h"
 #include "IPhysXCookingModule.h"
+#include "Kismet/GameplayStatics.h"
 #include "LevelSequenceActor.h"
 #include "Math/UnrealMathUtility.h"
 #include "Misc/EnumRange.h"

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1469,9 +1469,14 @@ static void loadModelGameThreadPart(
   case CesiumGltf::Material::AlphaMode::OPAQUE:
   default:
     pMaterial = UMaterialInstanceDynamic::Create(
+// TODO: figure out why water material crashes mac
+#if PLATFORM_MAC
+        pGltf->BaseMaterial,
+#else
         (loadResult.onlyWater || !loadResult.onlyLand)
             ? pGltf->BaseMaterialWithWater
             : pGltf->BaseMaterial,
+#endif
         nullptr,
         ImportedSlotName);
     break;

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -13,6 +13,7 @@
 #include <PhysicsEngine/BodyInstance.h>
 #include <chrono>
 #include <glm/mat4x4.hpp>
+
 #include "Cesium3DTileset.generated.h"
 
 class UMaterialInterface;
@@ -324,7 +325,8 @@ private:
       EditAnywhere,
       BlueprintGetter = GetEnableWaterMask,
       BlueprintSetter = SetEnableWaterMask,
-      Category = "Cesium|Rendering")
+      Category = "Cesium|Rendering",
+      meta = (EditCondition = "PlatformName != TEXT(\"Mac\")"))
   bool EnableWaterMask = false;
 
   /**
@@ -372,6 +374,10 @@ private:
       BlueprintSetter = SetOpacityMaskMaterial,
       Category = "Cesium|Rendering")
   UMaterialInterface* OpacityMaskMaterial = nullptr;
+
+protected:
+  UPROPERTY()
+  FString PlatformName;
 
 public:
   UFUNCTION(BlueprintGetter, Category = "Cesium")


### PR DESCRIPTION
I don't have a Mac to test this on, but this should prevent a horrible crash on Mac that seems to be caused by using the water material. In the future once we figure out what's causing it, we may be able to come up with a fix that allows water mask to be supported on Mac.