### PR TITLE
UE5 Compilation Support

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -242,7 +242,8 @@ void ACesiumGeoreference::AddGeoreferencedObject(
   }
 
 #if ENGINE_MAJOR_VERSION == 5
-  this->_georeferencedObjects.Add(TWeakInterfacePtr<ICesiumGeoreferenceable>(Object));
+  this->_georeferencedObjects.Add(
+      TWeakInterfacePtr<ICesiumGeoreferenceable>(Object));
 #else
   this->_georeferencedObjects.Add(*Object);
 #endif

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -241,7 +241,11 @@ void ACesiumGeoreference::AddGeoreferencedObject(
     }
   }
 
+#if ENGINE_MAJOR_VERSION == 5
+  this->_georeferencedObjects.Add(TWeakInterfacePtr<ICesiumGeoreferenceable>(Object));
+#else
   this->_georeferencedObjects.Add(*Object);
+#endif
 
   // If this object is an Actor or UActorComponent, make sure it ticks _after_
   // the CesiumGeoreference.

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -20,7 +20,9 @@
 #else
 #include "Chaos/CollisionConvexMesh.h"
 #include "Chaos/TriangleMeshImplicitObject.h"
+#if ENGINE_MAJOR_VERSION == 4
 #include "ChaosDerivedDataUtil.h"
+#endif
 #endif
 #include "Cesium3DTiles/RasterOverlayTile.h"
 #include "CesiumGeometry/Axis.h"
@@ -926,8 +928,13 @@ static void loadPrimitive(
       StaticMeshBuildVertices,
       textureCoordinateMap.size() == 0 ? 1 : textureCoordinateMap.size());
 
+#if ENGINE_MAJOR_VERSION == 5
+  FStaticMeshSectionArray& Sections = LODResources.Sections;
+#else
   FStaticMeshLODResources::FStaticMeshSectionArray& Sections =
       LODResources.Sections;
+#endif
+
   FStaticMeshSection& section = Sections.AddDefaulted_GetRef();
   section.bEnableCollision = true;
 
@@ -954,7 +961,9 @@ static void loadPrimitive(
   LODResources.bHasDepthOnlyIndices = false;
   LODResources.bHasReversedIndices = false;
   LODResources.bHasReversedDepthOnlyIndices = false;
+#if ENGINE_MAJOR_VERSION < 5
   LODResources.bHasAdjacencyInfo = false;
+#endif
 
   primitiveResult.pModel = &model;
   primitiveResult.RenderData = RenderData;
@@ -1435,10 +1444,14 @@ static void loadModelGameThreadPart(
       NewObject<UStaticMesh>(pMesh, FName(loadResult.name.c_str()));
   pMesh->SetStaticMesh(pStaticMesh);
 
+#if ENGINE_MAJOR_VERSION == 5
+  pStaticMesh->SetIsBuiltAtRuntime(true);
+  pStaticMesh->SetRenderData(TUniquePtr<FStaticMeshRenderData>(loadResult.RenderData));
+#else
   pStaticMesh->bIsBuiltAtRuntime = true;
+  pStaticMesh->RenderData = TUniquePtr<FStaticMeshRenderData>(loadResult.RenderData);
+#endif
   pStaticMesh->NeverStream = true;
-  pStaticMesh->RenderData =
-      TUniquePtr<FStaticMeshRenderData>(loadResult.RenderData);
 
   const CesiumGltf::Model& model = *loadResult.pModel;
   const CesiumGltf::Material& material =
@@ -1550,7 +1563,11 @@ static void loadModelGameThreadPart(
   // Set up RenderData bounds and LOD data
   pStaticMesh->CalculateExtendedBounds();
 
+#if ENGINE_MAJOR_VERSION == 5
+  pStaticMesh->GetRenderData()->ScreenSize[0].Default = 1.0f;
+#else
   pStaticMesh->RenderData->ScreenSize[0].Default = 1.0f;
+#endif
   pStaticMesh->CreateBodySetup();
 
   // pMesh->UpdateCollisionFromStaticMesh();

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1446,10 +1446,12 @@ static void loadModelGameThreadPart(
 
 #if ENGINE_MAJOR_VERSION == 5
   pStaticMesh->SetIsBuiltAtRuntime(true);
-  pStaticMesh->SetRenderData(TUniquePtr<FStaticMeshRenderData>(loadResult.RenderData));
+  pStaticMesh->SetRenderData(
+      TUniquePtr<FStaticMeshRenderData>(loadResult.RenderData));
 #else
   pStaticMesh->bIsBuiltAtRuntime = true;
-  pStaticMesh->RenderData = TUniquePtr<FStaticMeshRenderData>(loadResult.RenderData);
+  pStaticMesh->RenderData =
+      TUniquePtr<FStaticMeshRenderData>(loadResult.RenderData);
 #endif
   pStaticMesh->NeverStream = true;
 


### PR DESCRIPTION
* Some APIs have changed from variables to getter/setters.
* I'm not sure why UE5 build tool is not detecting `ChaosDerivedDataUtil.h`, but that header has a single function which we are not using. So maybe we can remove it from the UE4 version as well.
* There is one warning remaining
	```
	[9/13] Module.CesiumRuntime.cpp
	      C:/Users/smohammed/workspace/PackagesUE5/CesiumForUnreal/HostProject/Plugins/CesiumForUnreal/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp(1448): warning C4996: 'UStaticMesh::SetIsBuiltAtRuntime': SetIsBuiltAtRuntime() is no longer used. Please update your code to the new API before upgrading to the next release, otherwise your project will no longer compile.
	```
    But this is weird because UE5 removed the `bIsBuiltAtRuntime` variable, changed it into a const get function, and add `SetIsBuiltAtRuntime`. So I'm not entirely sure why its giving a warning. 
    Ref: https://docs.unrealengine.com/5.0/en-US/API/Runtime/Engine/Engine/UStaticMesh/

Fixes #463