### PR TITLE
Temporarily remove Android support.

### DIFF
--- a/CesiumForUnreal.uplugin
+++ b/CesiumForUnreal.uplugin
@@ -21,13 +21,15 @@
 			"Name": "CesiumRuntime",
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
-			"WhitelistPlatforms": [ "Win64", "Mac", "Linux", "Android" ]
+			"WhitelistPlatforms": [ "Win64", "Mac", "Linux" ],
+			"BlacklistPlatforms": [ "Android" ]
 		},
 		{
 			"Name": "CesiumEditor",
 			"Type": "Editor",
 			"LoadingPhase": "PostEngineInit",
-			"WhitelistPlatforms": [ "Win64", "Mac", "Linux", "Android" ]
+			"WhitelistPlatforms": [ "Win64", "Mac", "Linux" ],
+			"BlacklistPlatforms": [ "Android" ]
 		}
 	],
 	"Plugins": [


### PR DESCRIPTION
It's not working in Epic's plugin build environment, and not production ready in any case.