### PR TITLE
Implement other types of index accessor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,14 @@
 
 ### ? - ?
 
+##### Breaking :mega:
+
+##### Additions :tada:
+
+##### Fixes :wrench:
+
 - Fixed a bug that caused Cesium toolbar buttons to disappear when `Editor Preferences` -> `Use Small Tool Bar Icons` is enabled.
+- Add support for other types of Gltf index accessors: `BYTE`, `UNSIGNED_BYTE`, `SHORT`, `UNSIGNED_SHORT`
 
 ### v1.3.1 - 2021-06-02
 
@@ -10,12 +17,12 @@
 
 ### v1.3.0 - 2021-06-01
 
-##### Breaking  :mega:
+##### Breaking :mega:
 
 - Tileset properties that require a tileset reload (URL, Source, IonAssetID, IonAccessToken, Materials) have been moved to `private`. Setter and getter methods are now provided for modifying them in Blueprints and C++.
 - Deprecated `CesiumGlobeAnchorParent` and `FloatingPawn`. The `CesiumGlobeAnchorParent` functionality can be recreated using an empty actor with a `CesiumGeoreferenceComponent`. The `FloatingPawn` is now replaced by the `DynamicPawn`. In a future release, the `DynamicPawn` will be renamed to `CesiumFloatingPawn`.
 
-##### Additions  :tada:
+##### Additions :tada:
 
 - Added support for the Android platform.
 - Added support for displaying a water effect for the parts of quantized-mesh terrain tiles that are known to be water.
@@ -53,7 +60,7 @@ In addition to the above, this release updates [cesium-native](https://github.co
 
 ### v1.2.0 - 2021-05-03
 
-##### Additions  :tada:
+##### Additions :tada:
 
 - Added a dynamic camera that adapts to height above terrain.
 - Added Linux support.
@@ -61,11 +68,11 @@ In addition to the above, this release updates [cesium-native](https://github.co
 
 ##### Fixes :wrench:
 
-* Fixed issue where displayed longitude-latitude-height in `CesiumGeoreferenceComponent` wasn't updating in certain cases.
-* `FEditorDelegates::OnFocusViewportOnActors` is no longer unnecessarily subscribed to multiple times.
-* `Loading tileset ...` is now only written to the output log when the tileset actually needs to be reloaded.
-* Fixed a bug where collision does not update correctly when changing properties of a tileset in the editor.
-* Fixed a bug that caused tiles to disappear when "Suspend Update" was enabled.
+- Fixed issue where displayed longitude-latitude-height in `CesiumGeoreferenceComponent` wasn't updating in certain cases.
+- `FEditorDelegates::OnFocusViewportOnActors` is no longer unnecessarily subscribed to multiple times.
+- `Loading tileset ...` is now only written to the output log when the tileset actually needs to be reloaded.
+- Fixed a bug where collision does not update correctly when changing properties of a tileset in the editor.
+- Fixed a bug that caused tiles to disappear when "Suspend Update" was enabled.
 
 ### v1.1.1 - 2021-04-23
 
@@ -100,7 +107,7 @@ In addition to the above, this release updates [cesium-native](https://github.co
 
 ### v1.0.0 - 2021-03-30 - Initial Release
 
-##### Features  :tada:
+##### Features :tada:
 
 - High-accuracy, global-scale WGS84 globe for visualization of real-world 3D content
 - 3D Tiles runtime engine to stream massive 3D geospatial datasets, such as terrain, imagery, 3D cities, and photogrammetry

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1005,6 +1005,101 @@ static void loadPrimitive(
   result.push_back(std::move(primitiveResult));
 }
 
+static void loadIndexedPrimitive(
+    std::vector<LoadModelResult>& result,
+    const CesiumGltf::Model& model,
+    const CesiumGltf::Mesh& mesh,
+    const CesiumGltf::MeshPrimitive& primitive,
+    const glm::dmat4x4& transform,
+#if PHYSICS_INTERFACE_PHYSX
+    IPhysXCooking* pPhysXCooking,
+#endif
+    const CesiumGltf::Accessor& positionAccessor,
+    const CesiumGltf::AccessorView<FVector>& positionView) {
+  const CesiumGltf::Accessor& indexAccessorGltf =
+      model.accessors[primitive.indices];
+  if (indexAccessorGltf.componentType ==
+      CesiumGltf::Accessor::ComponentType::BYTE) {
+    CesiumGltf::AccessorView<int8_t> indexAccessor(model, primitive.indices);
+    loadPrimitive(
+        result,
+        model,
+        mesh,
+        primitive,
+        transform,
+#if PHYSICS_INTERFACE_PHYSX
+        pPhysXCooking,
+#endif
+        positionAccessor,
+        positionView,
+        indexAccessor);
+  } else if (
+      indexAccessorGltf.componentType ==
+      CesiumGltf::Accessor::ComponentType::UNSIGNED_BYTE) {
+    CesiumGltf::AccessorView<uint8_t> indexAccessor(model, primitive.indices);
+    loadPrimitive(
+        result,
+        model,
+        mesh,
+        primitive,
+        transform,
+#if PHYSICS_INTERFACE_PHYSX
+        pPhysXCooking,
+#endif
+        positionAccessor,
+        positionView,
+        indexAccessor);
+  } else if (
+      indexAccessorGltf.componentType ==
+      CesiumGltf::Accessor::ComponentType::SHORT) {
+    CesiumGltf::AccessorView<int16_t> indexAccessor(model, primitive.indices);
+    loadPrimitive(
+        result,
+        model,
+        mesh,
+        primitive,
+        transform,
+#if PHYSICS_INTERFACE_PHYSX
+        pPhysXCooking,
+#endif
+        positionAccessor,
+        positionView,
+        indexAccessor);
+  } else if (
+      indexAccessorGltf.componentType ==
+      CesiumGltf::Accessor::ComponentType::UNSIGNED_SHORT) {
+    CesiumGltf::AccessorView<uint16_t> indexAccessor(model, primitive.indices);
+    loadPrimitive(
+        result,
+        model,
+        mesh,
+        primitive,
+        transform,
+#if PHYSICS_INTERFACE_PHYSX
+        pPhysXCooking,
+#endif
+        positionAccessor,
+        positionView,
+        indexAccessor);
+  } else if (
+      indexAccessorGltf.componentType ==
+      CesiumGltf::Accessor::ComponentType::UNSIGNED_INT) {
+    CesiumGltf::AccessorView<uint32_t> indexAccessor(model, primitive.indices);
+    loadPrimitive(
+        result,
+        model,
+        mesh,
+        primitive,
+        transform,
+#if PHYSICS_INTERFACE_PHYSX
+        pPhysXCooking,
+#endif
+        positionAccessor,
+        positionView,
+        indexAccessor);
+  }
+}
+
 static void loadPrimitive(
     std::vector<LoadModelResult>& result,
     const CesiumGltf::Model& model,
@@ -1051,47 +1146,17 @@ static void loadPrimitive(
         positionView,
         syntheticIndexBuffer);
   } else {
-    const CesiumGltf::Accessor& indexAccessorGltf =
-        model.accessors[primitive.indices];
-    if (indexAccessorGltf.componentType ==
-        CesiumGltf::Accessor::ComponentType::UNSIGNED_SHORT) {
-      CesiumGltf::AccessorView<uint16_t> indexAccessor(
-          model,
-          primitive.indices);
-      loadPrimitive(
-          result,
-          model,
-          mesh,
-          primitive,
-          transform,
+    loadIndexedPrimitive(
+        result,
+        model,
+        mesh,
+        primitive,
+        transform,
 #if PHYSICS_INTERFACE_PHYSX
-          pPhysXCooking,
+        pPhysXCooking,
 #endif
-          *pPositionAccessor,
-          positionView,
-          indexAccessor);
-    } else if (
-        indexAccessorGltf.componentType ==
-        CesiumGltf::Accessor::ComponentType::UNSIGNED_INT) {
-      CesiumGltf::AccessorView<uint32_t> indexAccessor(
-          model,
-          primitive.indices);
-      loadPrimitive(
-          result,
-          model,
-          mesh,
-          primitive,
-          transform,
-#if PHYSICS_INTERFACE_PHYSX
-          pPhysXCooking,
-#endif
-          *pPositionAccessor,
-          positionView,
-          indexAccessor);
-    } else {
-      // TODO: report unsupported index type.
-      return;
-    }
+        *pPositionAccessor,
+        positionView);
   }
 }
 


### PR DESCRIPTION
We receive the asset that has `UNSIGNED_BYTE` for the index accessor, but the plugin only supports `UNSIGNED_SHORT` and `UNSIGNED_INT`. This PR adds support for the rest too.

@kring I just quickly add a tile content inspector actor in this branch https://github.com/CesiumGS/cesium-unreal/tree/TileContentInspector. It should render the tile content by passing the URL to it for a check