### PR TITLE
Fix one-frame holes in models.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ##### Fixes :wrench:
 
+- Fixed a bug that could sometimes cause tile-sized holes to appear in a 3D Tiles model for one render frame.
 - Fixed a bug that caused Cesium toolbar buttons to disappear when `Editor Preferences` -> `Use Small Tool Bar Icons` is enabled.
 - Add support for other types of Gltf index accessors: `BYTE`, `UNSIGNED_BYTE`, `SHORT`, `UNSIGNED_SHORT`
 

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -584,4 +584,5 @@ private:
   bool _beforeMoviePreloadSiblings;
   int32_t _beforeMovieLoadingDescendantLimit;
   bool _beforeMovieKeepWorldOriginNearCamera;
+  std::vector<Cesium3DTiles::Tile*> _tilesToNoLongerRenderNextFrame;
 };

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -584,5 +584,18 @@ private:
   bool _beforeMoviePreloadSiblings;
   int32_t _beforeMovieLoadingDescendantLimit;
   bool _beforeMovieKeepWorldOriginNearCamera;
+
+  // This is used as a workaround for cesium-native#186
+  //
+  // The tiles that are no longer supposed to be rendered in the current
+  // frame, according to ViewUpdateResult::tilesToNoLongerRenderThisFrame,
+  // are kept in this list, and hidden in the NEXT frame, because some
+  // internal occlusion culling information from Unreal might prevent
+  // the tiles that are supposed to be rendered instead from appearing
+  // immediately.
+  //
+  // If we find a way to clear the wrong occlusion information in the
+  // Unreal Engine, then this field may be removed, and the
+  // tilesToNoLongerRenderThisFrame may be hidden immediately.
   std::vector<Cesium3DTiles::Tile*> _tilesToNoLongerRenderNextFrame;
 };


### PR DESCRIPTION
Fixes CesiumGS/cesium-native#186.

The one-frame holes happen when we switch between LODs and the timing is just right so that Unreal Engine ends up using previously cached (and incorrect) occlusion information for the new LOD. A new occlusion query sorts it out quickly for the next frame, but not before the user can notice a flash of part of the model missing.

There doesn't appear to be a way to clear the stale occlusion information, so instead I've implemented a bit of a hack. On each Tick, we get a new list of tiles to hide this frame. But we don't actually hide them. Instead, we copy the list to a separate list, and we hide the tiles in that list _next_ frame. So effectively there's a one-frame delay for all tile hiding. That will mean briefly showing two LODs together for one frame, but it isn't noticeable to my eye (certainly much less noticeable than the holes!). We have to be careful to make sure that the tiles hidden last frame aren't meant to be visible this frame, though.

More details of the problem on UDN: https://udn.unrealengine.com/s/question/0D54z0000708yGxCAI/one-frame-delay-after-setvisibilitytrue-true
