### PR TITLE
Georeference component refactoring / fixes

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -106,7 +106,6 @@ void ACesium3DTileset::PostInitProperties() {
   }
 
   AddFocusViewportDelegate();
-
 }
 
 void ACesium3DTileset::SetTilesetSource(ETilesetSource InSource) {
@@ -174,7 +173,7 @@ void ACesium3DTileset::SetOpacityMaskMaterial(UMaterialInterface* InMaterial) {
 void ACesium3DTileset::PlayMovieSequencer() {
   // TODO GEOREF_REFACTORING: This should proably use the
   // actual Georeference, and not obtain a new one, to make
-  // sure that the behavior in the sequencer is the 
+  // sure that the behavior in the sequencer is the
   // same as in the non-sequencer run
   ACesiumGeoreference* cesiumGeoreference =
       ACesiumGeoreference::GetDefaultGeoreference(this);
@@ -195,7 +194,7 @@ void ACesium3DTileset::PlayMovieSequencer() {
 void ACesium3DTileset::StopMovieSequencer() {
   // TODO GEOREF_REFACTORING: This should proably use the
   // actual Georeference, and not obtain a new one, to make
-  // sure that the behavior in the sequencer is the 
+  // sure that the behavior in the sequencer is the
   // same as in the non-sequencer run
   ACesiumGeoreference* cesiumGeoreference =
       ACesiumGeoreference::GetDefaultGeoreference(this);
@@ -1136,7 +1135,7 @@ void ACesium3DTileset::Serialize(FArchive& Ar) {
 void ACesium3DTileset::PostEditChangeProperty(
     FPropertyChangedEvent& PropertyChangedEvent) {
   Super::PostEditChangeProperty(PropertyChangedEvent);
-  
+
   if (!PropertyChangedEvent.Property) {
     return;
   }
@@ -1152,9 +1151,11 @@ void ACesium3DTileset::PostEditChangeProperty(
       PropName ==
           GET_MEMBER_NAME_CHECKED(ACesium3DTileset, OpacityMaskMaterial)) {
     MarkTilesetDirty();
-  } else if (PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, Georeference)) {
+  } else if (
+      PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, Georeference)) {
     if (IsValid(this->Georeference)) {
-      UCesium3DTilesetRoot* pRoot = Cast<UCesium3DTilesetRoot>(this->RootComponent);
+      UCesium3DTilesetRoot* pRoot =
+          Cast<UCesium3DTilesetRoot>(this->RootComponent);
       if (pRoot) {
         this->Georeference->OnGeoreferenceUpdated.AddUniqueDynamic(
             pRoot,

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -219,14 +219,11 @@ void ACesium3DTileset::OnFocusEditorViewportOnThis() {
 
   struct CalculateECEFCameraPosition {
 
-    ACesiumGeoreference* localGeoreference;
+    const GeoTransforms& localGeoTransforms;
 
     glm::dvec3 operator()(const CesiumGeometry::BoundingSphere& sphere) {
       const glm::dvec3& center = sphere.getCenter();
-      glm::dmat4 ENU = glm::dmat4(1.0);
-      if (IsValid(localGeoreference)) {
-        ENU = localGeoreference->ComputeEastNorthUpToEcef(center);
-      }
+      glm::dmat4 ENU = localGeoTransforms.ComputeEastNorthUpToEcef(center);
       glm::dvec3 offset =
           sphere.getRadius() * glm::normalize(ENU[0] + ENU[1] + ENU[2]);
       glm::dvec3 position = center + offset;
@@ -236,10 +233,7 @@ void ACesium3DTileset::OnFocusEditorViewportOnThis() {
     glm::dvec3
     operator()(const CesiumGeometry::OrientedBoundingBox& orientedBoundingBox) {
       const glm::dvec3& center = orientedBoundingBox.getCenter();
-      glm::dmat4 ENU = glm::dmat4(1.0);
-      if (IsValid(localGeoreference)) {
-        ENU = localGeoreference->ComputeEastNorthUpToEcef(center);
-      }
+      glm::dmat4 ENU = localGeoTransforms.ComputeEastNorthUpToEcef(center);
       const glm::dmat3& halfAxes = orientedBoundingBox.getHalfAxes();
       glm::dvec3 offset = glm::length(halfAxes[0] + halfAxes[1] + halfAxes[2]) *
                           glm::normalize(ENU[0] + ENU[1] + ENU[2]);
@@ -272,7 +266,7 @@ void ACesium3DTileset::OnFocusEditorViewportOnThis() {
   const glm::dmat4& transform =
       this->GetCesiumTilesetToUnrealRelativeWorldTransform();
   glm::dvec3 ecefCameraPosition = std::visit(
-      CalculateECEFCameraPosition{this->Georeference},
+      CalculateECEFCameraPosition{this->Georeference->getGeoTransforms()},
       boundingVolume);
   glm::dvec3 unrealCameraPosition =
       transform * glm::dvec4(ecefCameraPosition, 1.0);

--- a/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.cpp
@@ -40,7 +40,7 @@ void UCesium3DTilesetRoot::HandleGeoreferenceUpdated() {
   UE_LOG(
       LogCesium,
       Verbose,
-      TEXT("Called HandleGeoreferenceUpdated for %s"),
+      TEXT("Called HandleGeoreferenceUpdated for tileset root %s"),
       *this->GetName());
   this->_updateTilesetToUnrealRelativeWorldTransform();
 }

--- a/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.cpp
@@ -94,7 +94,8 @@ void UCesium3DTilesetRoot::_updateTilesetToUnrealRelativeWorldTransform() {
   }
 
   const glm::dmat4& ellipsoidCenteredToUnrealWorld =
-      pTileset->Georeference->GetEllipsoidCenteredToUnrealWorldTransform();
+      pTileset->Georeference->getGeoTransforms()
+          .GetEllipsoidCenteredToUnrealWorldTransform();
 
   glm::dvec3 relativeLocation =
       this->_absoluteLocation - this->_worldOriginLocation;

--- a/Source/CesiumRuntime/Private/CesiumActors.cpp
+++ b/Source/CesiumRuntime/Private/CesiumActors.cpp
@@ -1,0 +1,25 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#include "CesiumActors.h"
+#include "CesiumRuntime.h"
+#include "Engine/World.h"
+
+#include <glm/glm.hpp>
+
+glm::dvec4 CesiumActors::getWorldOrigin4D(const AActor* actor) {
+  if (!IsValid(actor)) {
+    UE_LOG(LogCesium, Warning, TEXT("The actor is not valid"));
+    return glm::dvec4();
+  }
+  const UWorld* world = actor->GetWorld();
+  if (!IsValid(world)) {
+    UE_LOG(
+        LogCesium,
+        Warning,
+        TEXT("The actor %s is not spawned in a level"),
+        *actor->GetName());
+    return glm::dvec4();
+  }
+  const FIntVector& originLocation = world->OriginLocation;
+  return glm::dvec4(originLocation.X, originLocation.Y, originLocation.Z, 1.0);
+}

--- a/Source/CesiumRuntime/Private/CesiumActors.h
+++ b/Source/CesiumRuntime/Private/CesiumActors.h
@@ -1,0 +1,24 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "GameFramework/Actor.h"
+#include <glm/glm.hpp>
+
+/**
+ * @brief Utility functions related to Unreal actors
+ */
+class CesiumActors {
+public:
+  /**
+   * @brief Returns the origin location of the world that the given
+   * actor is contained in.
+   *
+   * If the given actor is not valid or not contained in a world,
+   * then a warning is printed and (0,0,0,0) is returned.
+   *
+   * @param actor The actor
+   * @return The world origin
+   */
+  static glm::dvec4 getWorldOrigin4D(const AActor* actor);
+};

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -593,11 +593,22 @@ void ACesiumGeoreference::Tick(float DeltaTime) {
  * Useful Conversion Functions
  */
 
+glm::dvec3 ACesiumGeoreference::TransformLongitudeLatitudeHeightToEcef(
+    const glm::dvec3& longitudeLatitudeHeight) const {
+  return _geoTransforms.TransformLongitudeLatitudeHeightToEcef(
+      longitudeLatitudeHeight);
+}
+
 FVector ACesiumGeoreference::InaccurateTransformLongitudeLatitudeHeightToEcef(
     const FVector& longitudeLatitudeHeight) const {
   glm::dvec3 ecef = this->_geoTransforms.TransformLongitudeLatitudeHeightToEcef(
       VecMath::createVector3D(longitudeLatitudeHeight));
   return FVector(ecef.x, ecef.y, ecef.z);
+}
+
+glm::dvec3 ACesiumGeoreference::TransformEcefToLongitudeLatitudeHeight(
+    const glm::dvec3& ecef) const {
+  return _geoTransforms.TransformEcefToLongitudeLatitudeHeight(ecef);
 }
 
 FVector ACesiumGeoreference::InaccurateTransformEcefToLongitudeLatitudeHeight(
@@ -607,12 +618,26 @@ FVector ACesiumGeoreference::InaccurateTransformEcefToLongitudeLatitudeHeight(
   return FVector(llh.x, llh.y, llh.z);
 }
 
+glm::dvec3 ACesiumGeoreference::TransformLongitudeLatitudeHeightToUnreal(
+    const glm::dvec3& longitudeLatitudeHeight) const {
+  return this->_geoTransforms.TransformLongitudeLatitudeHeightToUnreal(
+      CesiumActors::getWorldOrigin4D(this),
+      longitudeLatitudeHeight);
+}
+
 FVector ACesiumGeoreference::InaccurateTransformLongitudeLatitudeHeightToUnreal(
     const FVector& longitudeLatitudeHeight) const {
   glm::dvec3 ue = this->_geoTransforms.TransformLongitudeLatitudeHeightToUnreal(
       CesiumActors::getWorldOrigin4D(this),
       VecMath::createVector3D(longitudeLatitudeHeight));
   return FVector(ue.x, ue.y, ue.z);
+}
+
+glm::dvec3 ACesiumGeoreference::TransformUnrealToLongitudeLatitudeHeight(
+    const glm::dvec3& ue) const {
+  return this->_geoTransforms.TransformUnrealToLongitudeLatitudeHeight(
+      CesiumActors::getWorldOrigin4D(this),
+      ue);
 }
 
 FVector ACesiumGeoreference::InaccurateTransformUnrealToLongitudeLatitudeHeight(
@@ -624,12 +649,26 @@ FVector ACesiumGeoreference::InaccurateTransformUnrealToLongitudeLatitudeHeight(
   return FVector(llh.x, llh.y, llh.z);
 }
 
+glm::dvec3
+ACesiumGeoreference::TransformEcefToUnreal(const glm::dvec3& ecef) const {
+  return this->_geoTransforms.TransformEcefToUnreal(
+      CesiumActors::getWorldOrigin4D(this),
+      ecef);
+}
+
 FVector ACesiumGeoreference::InaccurateTransformEcefToUnreal(
     const FVector& ecef) const {
   glm::dvec3 ue = this->_geoTransforms.TransformEcefToUnreal(
       CesiumActors::getWorldOrigin4D(this),
       glm::dvec3(ecef.X, ecef.Y, ecef.Z));
   return FVector(ue.x, ue.y, ue.z);
+}
+
+glm::dvec3
+ACesiumGeoreference::TransformUnrealToEcef(const glm::dvec3& ue) const {
+  return this->_geoTransforms.TransformUnrealToEcef(
+      CesiumActors::getWorldOrigin4D(this),
+      ue);
 }
 
 FVector
@@ -641,25 +680,30 @@ ACesiumGeoreference::InaccurateTransformUnrealToEcef(const FVector& ue) const {
 }
 
 FRotator ACesiumGeoreference::InaccurateTransformRotatorUnrealToEastNorthUp(
-    const FIntVector& origin,
     const FRotator& UERotator,
     const FVector& ueLocation) const {
   glm::dquat q = this->_geoTransforms.TransformRotatorUnrealToEastNorthUp(
-      VecMath::createVector3D(origin),
+      CesiumActors::getWorldOrigin4D(this),
       VecMath::createQuaternion(UERotator.Quaternion()),
       VecMath::createVector3D(ueLocation));
   return VecMath::createRotator(q);
 }
 
 FRotator ACesiumGeoreference::InaccurateTransformRotatorEastNorthUpToUnreal(
-    const FIntVector& origin,
     const FRotator& ENURotator,
     const FVector& ueLocation) const {
   glm::dquat q = this->_geoTransforms.TransformRotatorEastNorthUpToUnreal(
-      VecMath::createVector3D(origin),
+      CesiumActors::getWorldOrigin4D(this),
       VecMath::createQuaternion(ENURotator.Quaternion()),
       VecMath::createVector3D(ueLocation));
   return VecMath::createRotator(q);
+}
+
+glm::dmat3
+ACesiumGeoreference::ComputeEastNorthUpToUnreal(const glm::dvec3& ue) const {
+  return _geoTransforms.ComputeEastNorthUpToUnreal(
+      CesiumActors::getWorldOrigin4D(this),
+      ue);
 }
 
 FMatrix ACesiumGeoreference::InaccurateComputeEastNorthUpToUnreal(
@@ -668,6 +712,11 @@ FMatrix ACesiumGeoreference::InaccurateComputeEastNorthUpToUnreal(
       CesiumActors::getWorldOrigin4D(this),
       glm::dvec3(ue.X, ue.Y, ue.Z));
   return VecMath::createMatrix(enuToUnreal);
+}
+
+glm::dmat3
+ACesiumGeoreference::ComputeEastNorthUpToEcef(const glm::dvec3& ecef) const {
+  return _geoTransforms.ComputeEastNorthUpToEcef(ecef);
 }
 
 FMatrix ACesiumGeoreference::InaccurateComputeEastNorthUpToEcef(

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -330,6 +330,13 @@ void ACesiumGeoreference::UpdateGeoreference() {
         this->OriginHeight));
   }
   _geoTransforms.setCenter(center);
+
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Broadcasting OnGeoreferenceUpdated for Georeference %s"),
+      *this->GetFullName());
+
   OnGeoreferenceUpdated.Broadcast();
 }
 
@@ -639,6 +646,10 @@ namespace {
  * @return The world origin
  */
 glm::dvec4 getWorldOrigin4D(const AActor* actor) {
+  if (!IsValid(actor)) {
+    UE_LOG(LogCesium, Warning, TEXT("The actor is not valid"));
+    return glm::dvec4();
+  }
   const UWorld* world = actor->GetWorld();
   if (!IsValid(world)) {
     UE_LOG(LogCesium, Warning, TEXT("The actor is not spawned in a level"));

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -128,7 +128,8 @@ void ACesiumGeoreference::PostInitProperties() {
 
   // Initialize the GeoTransforms with the state from the
   // deserialized properties
-  _geoTransforms.setEllipsoid(CesiumGeospatial::Ellipsoid(glm::dvec3(_ellipsoidRadii[0], _ellipsoidRadii[1], _ellipsoidRadii[2])));
+  _geoTransforms.setEllipsoid(CesiumGeospatial::Ellipsoid(
+      glm::dvec3(_ellipsoidRadii[0], _ellipsoidRadii[1], _ellipsoidRadii[2])));
   UpdateGeoreference();
 }
 

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -679,21 +679,37 @@ ACesiumGeoreference::InaccurateTransformUnrealToEcef(const FVector& ue) const {
   return FVector(ecef.x, ecef.y, ecef.z);
 }
 
+glm::dquat ACesiumGeoreference::TransformRotatorUnrealToEastNorthUp(
+    const glm::dquat& UeRotator,
+    const glm::dvec3& UeLocation) const {
+  return this->_geoTransforms.TransformRotatorUnrealToEastNorthUp(
+      CesiumActors::getWorldOrigin4D(this),
+      UeRotator,
+      UeLocation);
+}
+
 FRotator ACesiumGeoreference::InaccurateTransformRotatorUnrealToEastNorthUp(
     const FRotator& UERotator,
     const FVector& ueLocation) const {
-  glm::dquat q = this->_geoTransforms.TransformRotatorUnrealToEastNorthUp(
-      CesiumActors::getWorldOrigin4D(this),
+  glm::dquat q = TransformRotatorUnrealToEastNorthUp(
       VecMath::createQuaternion(UERotator.Quaternion()),
       VecMath::createVector3D(ueLocation));
   return VecMath::createRotator(q);
 }
 
+glm::dquat ACesiumGeoreference::TransformRotatorEastNorthUpToUnreal(
+    const glm::dquat& EnuRotator,
+    const glm::dvec3& UeLocation) const {
+  return this->_geoTransforms.TransformRotatorEastNorthUpToUnreal(
+      CesiumActors::getWorldOrigin4D(this),
+      EnuRotator,
+      UeLocation);
+}
+
 FRotator ACesiumGeoreference::InaccurateTransformRotatorEastNorthUpToUnreal(
     const FRotator& ENURotator,
     const FVector& ueLocation) const {
-  glm::dquat q = this->_geoTransforms.TransformRotatorEastNorthUpToUnreal(
-      CesiumActors::getWorldOrigin4D(this),
+  glm::dquat q = TransformRotatorEastNorthUpToUnreal(
       VecMath::createQuaternion(ENURotator.Quaternion()),
       VecMath::createVector3D(ueLocation));
   return VecMath::createRotator(q);

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -112,7 +112,6 @@ ACesiumGeoreference::GetDefaultGeoreference(const UObject* WorldContextObject) {
 
 ACesiumGeoreference::ACesiumGeoreference()
     : _ellipsoidRadii{WGS84_ELLIPSOID_RADII},
-      _center{0.0, 0.0, 0.0},
       _geoTransforms(),
       _insideSublevel(false) {
   PrimaryActorTick.bCanEverTick = true;
@@ -126,6 +125,10 @@ void ACesiumGeoreference::PostInitProperties() {
       *this->GetName());
 
   Super::PostInitProperties();
+
+  // Initialize the GeoTransforms with the state from the
+  // deserialized properties
+  _geoTransforms.setEllipsoid(CesiumGeospatial::Ellipsoid(glm::dvec3(_ellipsoidRadii[0], _ellipsoidRadii[1], _ellipsoidRadii[2])));
   UpdateGeoreference();
 }
 

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -313,6 +313,7 @@ void ACesiumGeoreference::BeginPlay() {
   for (FCesiumSubLevel& level : CesiumSubLevels) {
     level.CurrentlyLoaded = false;
   }
+  UpdateGeoreference();
 }
 
 /** In case the CesiumGeoreference gets spawned at run time, instead of design

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -83,12 +83,8 @@ void UCesiumGeoreferenceComponent::SnapToEastSouthUp() {
         *this->GetName());
     return;
   }
-  const glm::dvec3 worldOriginLocation =
-      VecMath::createVector3D(world->OriginLocation);
   const glm::dmat3 newActorRotation =
-      this->Georeference->getGeoTransforms().ComputeEastNorthUpToUnreal(
-          worldOriginLocation,
-          _currentEcef);
+      this->Georeference->ComputeEastNorthUpToUnreal(_currentEcef);
   const glm::dvec3 relativeLocation = _computeRelativeLocation(_currentEcef);
 
   this->_updateActorTransform(newActorRotation, relativeLocation);
@@ -107,9 +103,8 @@ void UCesiumGeoreferenceComponent::MoveToLongitudeLatitudeHeight(
         *this->GetName());
     return;
   }
-  glm::dvec3 ecef = this->Georeference->getGeoTransforms()
-                        .TransformLongitudeLatitudeHeightToEcef(
-                            targetLongitudeLatitudeHeight);
+  glm::dvec3 ecef = this->Georeference->TransformLongitudeLatitudeHeightToEcef(
+      targetLongitudeLatitudeHeight);
 
   this->_setECEF(ecef, maintainRelativeOrientation);
 }
@@ -527,7 +522,7 @@ glm::dvec3 UCesiumGeoreferenceComponent::_computeEllipsoidNormalUnreal(
     return glm::dvec3();
   }
   const glm::dvec3 ellipsoidNormalEcef =
-      this->Georeference->getGeoTransforms().ComputeGeodeticSurfaceNormal(ecef);
+      this->Georeference->ComputeGeodeticSurfaceNormal(ecef);
   const glm::dmat4& ecefToUnreal =
       this->Georeference->getGeoTransforms()
           .GetEllipsoidCenteredToUnrealWorldTransform();
@@ -671,8 +666,7 @@ void UCesiumGeoreferenceComponent::_updateDisplayLongitudeLatitudeHeight() {
     return;
   }
   const glm::dvec3 cartographic =
-      this->Georeference->getGeoTransforms()
-          .TransformEcefToLongitudeLatitudeHeight(_currentEcef);
+      this->Georeference->TransformEcefToLongitudeLatitudeHeight(_currentEcef);
   this->Longitude = cartographic.x;
   this->Latitude = cartographic.y;
   this->Height = cartographic.z;
@@ -706,11 +700,11 @@ void UCesiumGeoreferenceComponent::_debugLogState() {
         *this->GetName());
     return;
   }
-  const glm::dmat4& ecefToUnreal =
+  const glm::dmat4& ecefToAbsoluteUnreal =
       this->Georeference->getGeoTransforms()
           .GetEllipsoidCenteredToUnrealWorldTransform();
   const glm::dvec3 absoluteLocation =
-      ecefToUnreal * glm::dvec4(_currentEcef, 1.0);
+      ecefToAbsoluteUnreal * glm::dvec4(_currentEcef, 1.0);
   const glm::dvec3 worldOriginLocation =
       VecMath::createVector3D(world->OriginLocation);
   const glm::dvec3 relativeLocation = absoluteLocation - worldOriginLocation;

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -9,6 +9,7 @@
 #include "CesiumUtility/Math.h"
 #include "Engine/EngineTypes.h"
 #include "Engine/World.h"
+#include "GlmLogging.h"
 #include "UObject/NameTypes.h"
 #include "VecMath.h"
 #include <glm/ext/matrix_transform.hpp>
@@ -16,58 +17,6 @@
 #include <glm/gtx/quaternion.hpp>
 #include <glm/gtx/string_cast.hpp>
 #include <optional>
-
-// Functions for debug logging. These functions could (in a similar form)
-// be offered elsewhere, e.g. in VecMath.
-namespace {
-
-void logVector(const std::string& name, const glm::dvec3& vector) {
-  UE_LOG(
-      LogCesium,
-      Verbose,
-      TEXT("%s: %16.6f %16.6f %16.6f"),
-      *FString(name.c_str()),
-      vector.x,
-      vector.y,
-      vector.z);
-}
-
-void logMatrix(const std::string& name, const glm::dmat4& matrix) {
-  UE_LOG(LogCesium, Verbose, TEXT("%s:"), *FString(name.c_str()));
-  UE_LOG(
-      LogCesium,
-      Verbose,
-      TEXT(" %16.6f %16.6f %16.6f %16.6f"),
-      matrix[0][0],
-      matrix[1][0],
-      matrix[2][0],
-      matrix[3][0]);
-  UE_LOG(
-      LogCesium,
-      Verbose,
-      TEXT(" %16.6f %16.6f %16.6f %16.6f"),
-      matrix[0][1],
-      matrix[1][1],
-      matrix[2][1],
-      matrix[3][1]);
-  UE_LOG(
-      LogCesium,
-      Verbose,
-      TEXT(" %16.6f %16.6f %16.6f %16.6f"),
-      matrix[0][2],
-      matrix[1][2],
-      matrix[2][2],
-      matrix[3][2]);
-  UE_LOG(
-      LogCesium,
-      Verbose,
-      TEXT(" %16.6f %16.6f %16.6f %16.6f"),
-      matrix[0][3],
-      matrix[1][3],
-      matrix[2][3],
-      matrix[3][3]);
-}
-} // namespace
 
 UCesiumGeoreferenceComponent::UCesiumGeoreferenceComponent()
     : _updatingActorTransform(false),
@@ -617,8 +566,8 @@ void UCesiumGeoreferenceComponent::_setECEF(
     const glm::dvec3& targetEcef,
     bool maintainRelativeOrientation) {
 
-  logVector("_setECEF _currentEcef ", _currentEcef);
-  logVector("_setECEF   targetEcef ", targetEcef);
+  GlmLogging::logVector("_setECEF _currentEcef ", _currentEcef);
+  GlmLogging::logVector("_setECEF   targetEcef ", targetEcef);
   _debugLogState();
 
   if (!IsValid(this->Georeference)) {
@@ -672,7 +621,7 @@ void UCesiumGeoreferenceComponent::_setECEF(
   _updateActorTransform(newActorRotation, newRelativeLocation);
   this->_updateDisplayLongitudeLatitudeHeight();
 
-  logVector("_setECEF done, _currentEcef now ", _currentEcef);
+  GlmLogging::logVector("_setECEF done, _currentEcef now ", _currentEcef);
   _debugLogState();
 }
 
@@ -738,10 +687,12 @@ void UCesiumGeoreferenceComponent::_debugLogState() {
       VecMath::createVector3D(componentLocation);
 
   UE_LOG(LogCesium, Verbose, TEXT("State of %s"), *this->GetName());
-  logVector("  _currentEcef                ", _currentEcef);
-  logVector("  worldOriginLocation         ", worldOriginLocation);
-  logVector("  relativeLocation            ", relativeLocation);
-  logVector("  absoluteLocation            ", absoluteLocation);
-  logVector("  relativeLocationFromActor   ", relativeLocationFromActor);
-  logMatrix("  actorRotation", glm::dmat4(actorRotation));
+  GlmLogging::logVector("  _currentEcef                ", _currentEcef);
+  GlmLogging::logVector("  worldOriginLocation         ", worldOriginLocation);
+  GlmLogging::logVector("  relativeLocation            ", relativeLocation);
+  GlmLogging::logVector("  absoluteLocation            ", absoluteLocation);
+  GlmLogging::logVector(
+      "  relativeLocationFromActor   ",
+      relativeLocationFromActor);
+  GlmLogging::logMatrix("  actorRotation", glm::dmat4(actorRotation));
 }

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -120,6 +120,15 @@ void UCesiumGeoreferenceComponent::InaccurateMoveToLongitudeLatitudeHeight(
       VecMath::createVector3D(targetLongitudeLatitudeHeight),
       maintainRelativeOrientation);
 }
+
+FVector
+UCesiumGeoreferenceComponent::InaccurateGetLongitudeLatitudeHeight() const {
+  return FVector(
+      static_cast<float>(this->Longitude),
+      static_cast<float>(this->Latitude),
+      static_cast<float>(this->Height));
+}
+
 void UCesiumGeoreferenceComponent::MoveToECEF(
     const glm::dvec3& targetEcef,
     bool maintainRelativeOrientation) {
@@ -132,6 +141,13 @@ void UCesiumGeoreferenceComponent::InaccurateMoveToECEF(
   this->MoveToECEF(
       VecMath::createVector3D(targetEcef),
       maintainRelativeOrientation);
+}
+
+FVector UCesiumGeoreferenceComponent::InaccurateGetECEF() const {
+  return FVector(
+      static_cast<float>(this->ECEF_X),
+      static_cast<float>(this->ECEF_Y),
+      static_cast<float>(this->ECEF_Z));
 }
 
 void UCesiumGeoreferenceComponent::OnRegister() {

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -129,7 +129,7 @@ void UCesiumGeoreferenceComponent::SnapToEastSouthUp() {
 
   const glm::dvec3 ecef(this->ECEF_X, this->ECEF_Y, this->ECEF_Z);
   const glm::dmat3 newActorRotation =
-      this->Georeference->ComputeEastNorthUpToEcef(ecef);
+      this->Georeference->ComputeEastNorthUpToUnreal(ecef);
   const glm::dvec3 relativeLocation = _computeRelativeLocation();
 
   this->_updateActorTransform(newActorRotation, relativeLocation);
@@ -463,14 +463,14 @@ void UCesiumGeoreferenceComponent::HandleGeoreferenceUpdated() {
       *this->GetName());
   this->_updateActorTransform();
 }
-
+/*
 void UCesiumGeoreferenceComponent::SetAutoSnapToEastSouthUp(bool value) {
   this->_autoSnapToEastSouthUp = value;
   if (value) {
     this->SnapToEastSouthUp();
   }
 }
-
+*/
 glm::dvec3 UCesiumGeoreferenceComponent::_computeRelativeLocation() {
   const UWorld* const world = this->GetWorld();
   if (!IsValid(world)) {
@@ -526,12 +526,6 @@ void UCesiumGeoreferenceComponent::_updateActorTransform() {
 
   const glm::dvec3 relativeLocation = _computeRelativeLocation();
   const glm::dmat3 actorRotation = _getRotationFromActor();
-
-  // TODO GEOREF_REFACTORING Somewhere here, the auto-snapping should happen...
-  if (this->_autoSnapToEastSouthUp) {
-    // this->SnapToEastSouthUp();
-  }
-
   _updateActorTransform(actorRotation, relativeLocation);
 }
 
@@ -619,11 +613,6 @@ void UCesiumGeoreferenceComponent::_setECEF(
   this->ECEF_Z = targetEcef.z;
 
   _updateActorTransform();
-
-  // If the transform needs to be snapped to the tangent plane, do it here.
-  if (this->_autoSnapToEastSouthUp) {
-    // this->SnapToEastSouthUp();
-  }
 
   this->_updateDisplayLongitudeLatitudeHeight();
 }

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -318,6 +318,7 @@ void UCesiumGeoreferenceComponent::OnComponentCreated() {
       this->Georeference->TransformUnrealToEcef(absoluteLocation);
   _setECEF(ecef, false);
 }
+
 void UCesiumGeoreferenceComponent::PostLoad() {
   UE_LOG(
       LogCesium,

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -197,9 +197,11 @@ void UCesiumGeoreferenceComponent::OnRegister() {
     return;
   }
   USceneComponent* ownerRoot = owner->GetRootComponent();
-  ownerRoot->TransformUpdated.AddUObject(
-      this,
-      &UCesiumGeoreferenceComponent::HandleActorTransformUpdated);
+  if(ownerRoot) {
+    ownerRoot->TransformUpdated.AddUObject(
+    this,
+    &UCesiumGeoreferenceComponent::HandleActorTransformUpdated);
+  }
 }
 
 void UCesiumGeoreferenceComponent::OnUnregister() {
@@ -220,7 +222,9 @@ void UCesiumGeoreferenceComponent::OnUnregister() {
     return;
   }
   USceneComponent* ownerRoot = owner->GetRootComponent();
-  ownerRoot->TransformUpdated.RemoveAll(this);
+  if(ownerRoot) {
+    ownerRoot->TransformUpdated.RemoveAll(this);    
+  }
 }
 
 void UCesiumGeoreferenceComponent::HandleActorTransformUpdated(

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -243,6 +243,13 @@ void UCesiumGeoreferenceComponent::PostEditChangeProperty(
           GET_MEMBER_NAME_CHECKED(UCesiumGeoreferenceComponent, ECEF_Z)) {
     this->MoveToECEF(glm::dvec3(this->ECEF_X, this->ECEF_Y, this->ECEF_Z));
     return;
+  } else if (propertyName == GET_MEMBER_NAME_CHECKED(UCesiumGeoreferenceComponent, Georeference)) {
+    if (IsValid(this->Georeference)) {
+      this->Georeference->OnGeoreferenceUpdated.AddUniqueDynamic(
+          this,
+          &UCesiumGeoreferenceComponent::HandleGeoreferenceUpdated);
+    }
+    return;
   }
 }
 #endif

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -410,6 +410,11 @@ void UCesiumGeoreferenceComponent::PreEditChange(
       GET_MEMBER_NAME_CHECKED(UCesiumGeoreferenceComponent, Georeference)) {
     if (IsValid(this->Georeference)) {
       this->Georeference->OnGeoreferenceUpdated.RemoveAll(this);
+
+      // The Georeference might be set to None/null, so a final update
+      // of the actor transform based on the last valid state.
+      // (TODO: This might not be necessary, but possible side effects
+      // of a null Georeference should be covered with tests)
       _updateActorTransform();
     }
     return;

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -236,9 +236,8 @@ void UCesiumGeoreferenceComponent::_updateFromActor() {
     return;
   }
   const glm::dvec3 absoluteLocation = _getAbsoluteLocationFromActor();
-  const glm::dmat4& unrealToEcef =
-      this->Georeference->GetUnrealWorldToEllipsoidCenteredTransform();
-  const glm::dvec3 ecef = unrealToEcef * glm::dvec4(absoluteLocation, 1.0);
+  const glm::dvec3 ecef = this->Georeference->TransformUnrealToEcef(absoluteLocation);
+
   _setECEF(ecef, false); // TODO GEOREF_REFACTORING true or false?
 }
 
@@ -331,9 +330,7 @@ void UCesiumGeoreferenceComponent::ApplyWorldOffset(
 
   // Compute the absolute location based on the ECEF
   const glm::dvec3 ecef = glm::dvec3(this->ECEF_X, this->ECEF_Y, this->ECEF_Z);
-  const glm::dmat4& ecefToUnreal =
-      this->Georeference->GetEllipsoidCenteredToUnrealWorldTransform();
-  const glm::dvec3 absoluteLocation = ecefToUnreal * glm::dvec4(ecef, 1.0);
+  const glm::dvec3 absoluteLocation = this->Georeference->TransformEcefToUnreal(ecef);;
 
   // Apply the offset to compute the new absolute location
   const glm::dvec3 offset = VecMath::createVector3D(InOffset);
@@ -343,10 +340,7 @@ void UCesiumGeoreferenceComponent::ApplyWorldOffset(
 
   // Convert the new absolute location back to ECEF, and apply it to this
   // component
-  const glm::dmat4& unrealToEcef =
-      this->Georeference->GetUnrealWorldToEllipsoidCenteredTransform();
-  const glm::dvec3 newEcef =
-      unrealToEcef * glm::dvec4(newAbsoluteLocation, 1.0);
+  const glm::dvec3 newEcef = this->Georeference->TransformUnrealToEcef(newAbsoluteLocation);
   _setECEF(newEcef, false); // TODO GEOREF_REFACTORING true or false?
   /*
   //if (this->FixTransformOnOriginRebase) // TODO GEOREF_REFACTORING Figure out
@@ -471,10 +465,9 @@ void UCesiumGeoreferenceComponent::_updateActorTransform() {
   }
 
   // Compute the absolute location from the ECEF
-  const glm::dmat4& ecefToUnreal =
-      this->Georeference->GetEllipsoidCenteredToUnrealWorldTransform();
+  const glm::dvec3 ecef(ECEF_X, ECEF_Y, ECEF_Z);
   const glm::dvec3 absoluteLocation =
-      ecefToUnreal * glm::dvec4(ECEF_X, ECEF_Y, ECEF_Z, 1.0);
+    this->Georeference->TransformEcefToUnreal(ecef);
 
   // Compute the (high-precision) relative location
   // from the absolute location and the world origin

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -98,6 +98,7 @@ void UCesiumGeoreferenceComponent::SnapToEastSouthUp() {
   this->_setTransform(this->_actorToUnrealRelativeWorld);
 }
 
+/*
 void UCesiumGeoreferenceComponent::MoveToLongitudeLatitudeHeight(
     const glm::dvec3& targetLongitudeLatitudeHeight,
     bool maintainRelativeOrientation) {
@@ -114,7 +115,6 @@ void UCesiumGeoreferenceComponent::MoveToLongitudeLatitudeHeight(
 
   this->_setECEF(ecef, maintainRelativeOrientation);
 }
-
 void UCesiumGeoreferenceComponent::InaccurateMoveToLongitudeLatitudeHeight(
     const FVector& targetLongitudeLatitudeHeight,
     bool maintainRelativeOrientation) {
@@ -122,7 +122,6 @@ void UCesiumGeoreferenceComponent::InaccurateMoveToLongitudeLatitudeHeight(
       VecMath::createVector3D(targetLongitudeLatitudeHeight),
       maintainRelativeOrientation);
 }
-
 void UCesiumGeoreferenceComponent::MoveToECEF(
     const glm::dvec3& targetEcef,
     bool maintainRelativeOrientation) {
@@ -136,6 +135,7 @@ void UCesiumGeoreferenceComponent::InaccurateMoveToECEF(
       VecMath::createVector3D(targetEcef),
       maintainRelativeOrientation);
 }
+*/
 
 // TODO: is this the best place to attach to the root component of the owner
 // actor?
@@ -162,7 +162,7 @@ void UCesiumGeoreferenceComponent::_initGeoreference()
         LogCesium,
         Verbose,
         TEXT("Attaching CesiumGeoreferenceComponent callback to Georeference %s"),
-        *this->GetFullName());
+        *this->Georeference->GetFullName());
 
     this->Georeference->OnGeoreferenceUpdated.AddUniqueDynamic(
         this,
@@ -269,6 +269,8 @@ void UCesiumGeoreferenceComponent::PostEditChangeProperty(
 
   FName propertyName = event.Property->GetFName();
 
+  // TODO GEOREF_REFACTORING These are no longer editable here
+  /*
   if (propertyName ==
           GET_MEMBER_NAME_CHECKED(UCesiumGeoreferenceComponent, Longitude) ||
       propertyName ==
@@ -287,11 +289,14 @@ void UCesiumGeoreferenceComponent::PostEditChangeProperty(
           GET_MEMBER_NAME_CHECKED(UCesiumGeoreferenceComponent, ECEF_Z)) {
     this->MoveToECEF(glm::dvec3(this->ECEF_X, this->ECEF_Y, this->ECEF_Z));
     return;
-  } else if (propertyName == GET_MEMBER_NAME_CHECKED(UCesiumGeoreferenceComponent, Georeference)) {
+  } else 
+  */  
+  if (propertyName == GET_MEMBER_NAME_CHECKED(UCesiumGeoreferenceComponent, Georeference)) {
     if (IsValid(this->Georeference)) {
       this->Georeference->OnGeoreferenceUpdated.AddUniqueDynamic(
           this,
           &UCesiumGeoreferenceComponent::HandleGeoreferenceUpdated);
+      HandleGeoreferenceUpdated();
     }
     return;
   }
@@ -306,9 +311,11 @@ void UCesiumGeoreferenceComponent::HandleGeoreferenceUpdated() {
       *this->GetName());
   this->_updateActorToUnrealRelativeWorldTransform();
   
-  // TODO GEOREF_REFACTORING: Figure what this function is 
-  // doing, and whether it has to be called here...
-  //this->_updateActorToECEF();
+  // TODO GEOREF_REFACTORING 
+  // Not sure whether this has to be called here...
+  this->_updateActorToECEF();
+
+
 
   this->_setTransform(this->_actorToUnrealRelativeWorld);
 }
@@ -356,6 +363,8 @@ void UCesiumGeoreferenceComponent::OnAttachmentChanged() {
       TEXT("Called OnAttachmentChanged on component %s"),
       *this->GetName());
   Super::OnAttachmentChanged();
+  if (!IsValid(GetAttachParent())) {
+  }
   _initGeoreference();
 }
 void UCesiumGeoreferenceComponent::PostLoad() {
@@ -583,6 +592,14 @@ void UCesiumGeoreferenceComponent::_updateDisplayLongitudeLatitudeHeight() {
   this->Longitude = cartographic.x;
   this->Latitude = cartographic.y;
   this->Height = cartographic.z;
+
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called _updateDisplayLongitudeLatitudeHeight with height %f on component %s"),
+      this->Height, *this->GetName());
+
+
 }
 
 void UCesiumGeoreferenceComponent::_updateDisplayECEF() {

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -197,10 +197,10 @@ void UCesiumGeoreferenceComponent::OnRegister() {
     return;
   }
   USceneComponent* ownerRoot = owner->GetRootComponent();
-  if(ownerRoot) {
+  if (ownerRoot) {
     ownerRoot->TransformUpdated.AddUObject(
-    this,
-    &UCesiumGeoreferenceComponent::HandleActorTransformUpdated);
+        this,
+        &UCesiumGeoreferenceComponent::HandleActorTransformUpdated);
   }
 }
 
@@ -222,8 +222,8 @@ void UCesiumGeoreferenceComponent::OnUnregister() {
     return;
   }
   USceneComponent* ownerRoot = owner->GetRootComponent();
-  if(ownerRoot) {
-    ownerRoot->TransformUpdated.RemoveAll(this);    
+  if (ownerRoot) {
+    ownerRoot->TransformUpdated.RemoveAll(this);
   }
 }
 

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -468,6 +468,17 @@ void UCesiumGeoreferenceComponent::
 
 void UCesiumGeoreferenceComponent::_setTransform(const glm::dmat4& transform) {
   if (!this->GetWorld()) {
+    UE_LOG(
+        LogCesium,
+        Warning,
+        TEXT("CesiumGeoreferenceComponent is not spawned in world"));
+    return;
+  }
+  if (!IsValid(this->_ownerRoot)) {
+    UE_LOG(
+        LogCesium,
+        Warning,
+        TEXT("CesiumGeoreferenceComponent does not have a valid ownerRoot"));
     return;
   }
 

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -147,7 +147,10 @@ void UCesiumGeoreferenceComponent::OnRegister() {
       *this->GetName());
   Super::OnRegister();
   this->_initRootComponent();
+}
 
+void UCesiumGeoreferenceComponent::_initGeoreference()
+{
   if (!this->Georeference) {
     this->Georeference = ACesiumGeoreference::GetDefaultGeoreference(this);
   }
@@ -179,6 +182,7 @@ void UCesiumGeoreferenceComponent::OnRootComponentChanged(
 void UCesiumGeoreferenceComponent::ApplyWorldOffset(
     const FVector& InOffset,
     bool bWorldShift) {
+
   // USceneComponent::ApplyWorldOffset will call OnUpdateTransform, we want to
   // ignore it since we don't have to recompute everything on origin rebase.
   this->_ignoreOnUpdateTransform = true;
@@ -202,6 +206,13 @@ void UCesiumGeoreferenceComponent::OnUpdateTransform(
     EUpdateTransformFlags UpdateTransformFlags,
     ETeleportType Teleport) {
   USceneComponent::OnUpdateTransform(UpdateTransformFlags, Teleport);
+
+    UE_LOG(
+        LogCesium,
+        Verbose,
+        TEXT("Called OnUpdateTransform on %s"),
+        *this->GetFullName());
+
 
   // if we generated this transform call internally, we should ignore it
   if (this->_ignoreOnUpdateTransform) {
@@ -228,6 +239,13 @@ bool UCesiumGeoreferenceComponent::MoveComponentImpl(
     FHitResult* OutHit,
     EMoveComponentFlags MoveFlags,
     ETeleportType Teleport) {
+
+    UE_LOG(
+        LogCesium,
+        Verbose,
+        TEXT("Called MoveComponentImpl on %s"),
+        *this->GetFullName());
+
   if (this->_ownerRoot != this) {
     return false;
   }
@@ -311,7 +329,7 @@ void UCesiumGeoreferenceComponent::InitializeComponent() {
   UE_LOG(
       LogCesium,
       Verbose,
-      TEXT("Called InitializeComponent on actor %s"),
+      TEXT("Called InitializeComponent on component %s"),
       *this->GetName());
   Super::InitializeComponent();
 }
@@ -323,6 +341,33 @@ void UCesiumGeoreferenceComponent::PostInitProperties() {
       *this->GetName());
   Super::PostInitProperties();
 }
+void UCesiumGeoreferenceComponent::OnComponentCreated() {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called OnComponentCreated on component %s"),
+      *this->GetName());
+  Super::OnComponentCreated();
+}
+void UCesiumGeoreferenceComponent::OnAttachmentChanged() {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called OnAttachmentChanged on component %s"),
+      *this->GetName());
+  Super::OnAttachmentChanged();
+  _initGeoreference();
+}
+void UCesiumGeoreferenceComponent::PostLoad() {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called PostLoad on component %s"),
+      *this->GetName());
+  Super::PostLoad();
+}
+
+
 
 /**
  *  PRIVATE HELPER FUNCTIONS

--- a/Source/CesiumRuntime/Private/CesiumGlobeAnchorParent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGlobeAnchorParent.cpp
@@ -28,6 +28,10 @@ bool ADEPRECATED_CesiumGlobeAnchorParent::ShouldTickIfViewportsOnly() const {
 }
 
 void ADEPRECATED_CesiumGlobeAnchorParent::Tick(float DeltaTime) {
+
+  // TODO GEOREF_REFACTORING This class is deprecated and
+  // about to be removed. 
+  /*
   if (this->GeoreferenceComponent->CheckCoordinatesChanged()) {
 
     this->Longitude = this->GeoreferenceComponent->Longitude;
@@ -40,6 +44,7 @@ void ADEPRECATED_CesiumGlobeAnchorParent::Tick(float DeltaTime) {
 
     this->GeoreferenceComponent->MarkCoordinatesUnchanged();
   }
+  */
 }
 
 #if WITH_EDITOR
@@ -54,9 +59,7 @@ void ADEPRECATED_CesiumGlobeAnchorParent::PostEditChangeProperty(
   FName propertyName = event.Property->GetFName();
 
   // TODO GEOREF_REFACTORING This class is deprecated and
-  // about to be removed. The movement functions that have
-  // been called on the GeoreferenceComponent here should
-  // (if at all...) be called on the Georeference
+  // about to be removed. 
   /*
   if (propertyName == GET_MEMBER_NAME_CHECKED(
                           ADEPRECATED_CesiumGlobeAnchorParent,

--- a/Source/CesiumRuntime/Private/CesiumGlobeAnchorParent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGlobeAnchorParent.cpp
@@ -53,6 +53,11 @@ void ADEPRECATED_CesiumGlobeAnchorParent::PostEditChangeProperty(
 
   FName propertyName = event.Property->GetFName();
 
+  // TODO GEOREF_REFACTORING This class is deprecated and
+  // about to be removed. The movement functions that have
+  // been called on the GeoreferenceComponent here should
+  // (if at all...) be called on the Georeference
+  /*
   if (propertyName == GET_MEMBER_NAME_CHECKED(
                           ADEPRECATED_CesiumGlobeAnchorParent,
                           Longitude) ||
@@ -79,5 +84,6 @@ void ADEPRECATED_CesiumGlobeAnchorParent::PostEditChangeProperty(
         glm::dvec3(this->ECEF_X, this->ECEF_Y, this->ECEF_Z));
     return;
   }
+  */
 }
 #endif

--- a/Source/CesiumRuntime/Private/CesiumGlobeAnchorParent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGlobeAnchorParent.cpp
@@ -30,7 +30,7 @@ bool ADEPRECATED_CesiumGlobeAnchorParent::ShouldTickIfViewportsOnly() const {
 void ADEPRECATED_CesiumGlobeAnchorParent::Tick(float DeltaTime) {
 
   // TODO GEOREF_REFACTORING This class is deprecated and
-  // about to be removed. 
+  // about to be removed.
   /*
   if (this->GeoreferenceComponent->CheckCoordinatesChanged()) {
 
@@ -59,7 +59,7 @@ void ADEPRECATED_CesiumGlobeAnchorParent::PostEditChangeProperty(
   FName propertyName = event.Property->GetFName();
 
   // TODO GEOREF_REFACTORING This class is deprecated and
-  // about to be removed. 
+  // about to be removed.
   /*
   if (propertyName == GET_MEMBER_NAME_CHECKED(
                           ADEPRECATED_CesiumGlobeAnchorParent,

--- a/Source/CesiumRuntime/Private/CesiumGlobeAnchorParent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGlobeAnchorParent.cpp
@@ -22,7 +22,7 @@ void ADEPRECATED_CesiumGlobeAnchorParent::OnConstruction(
   Super::OnConstruction(Transform);
   // TODO GEOREF_REFACTORING This class is deprecated and
   // about to be removed.
-  //this->GeoreferenceComponent->SetAutoSnapToEastSouthUp(true);
+  // this->GeoreferenceComponent->SetAutoSnapToEastSouthUp(true);
 }
 
 bool ADEPRECATED_CesiumGlobeAnchorParent::ShouldTickIfViewportsOnly() const {

--- a/Source/CesiumRuntime/Private/CesiumGlobeAnchorParent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGlobeAnchorParent.cpp
@@ -20,7 +20,9 @@ ADEPRECATED_CesiumGlobeAnchorParent::ADEPRECATED_CesiumGlobeAnchorParent() {
 void ADEPRECATED_CesiumGlobeAnchorParent::OnConstruction(
     const FTransform& Transform) {
   Super::OnConstruction(Transform);
-  this->GeoreferenceComponent->SetAutoSnapToEastSouthUp(true);
+  // TODO GEOREF_REFACTORING This class is deprecated and
+  // about to be removed.
+  //this->GeoreferenceComponent->SetAutoSnapToEastSouthUp(true);
 }
 
 bool ADEPRECATED_CesiumGlobeAnchorParent::ShouldTickIfViewportsOnly() const {

--- a/Source/CesiumRuntime/Private/CesiumSunSky.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.cpp
@@ -4,15 +4,13 @@
 #include "CesiumRuntime.h"
 
 // Sets default values
-ACesiumSunSky::ACesiumSunSky() {
-  PrimaryActorTick.bCanEverTick = false;
-}
+ACesiumSunSky::ACesiumSunSky() { PrimaryActorTick.bCanEverTick = false; }
 
 #if WITH_EDITOR
 void ACesiumSunSky::PostEditChangeProperty(
     FPropertyChangedEvent& PropertyChangedEvent) {
   Super::PostEditChangeProperty(PropertyChangedEvent);
-  
+
   if (!PropertyChangedEvent.Property) {
     return;
   }
@@ -47,7 +45,6 @@ void ACesiumSunSky::PostInitProperties() {
         &ACesiumSunSky::HandleGeoreferenceUpdated);
     this->HandleGeoreferenceUpdated();
   }
-
 }
 
 void ACesiumSunSky::SetSkyAtmosphereGroundRadius(

--- a/Source/CesiumRuntime/Private/CesiumSunSky.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.cpp
@@ -23,6 +23,7 @@ void ACesiumSunSky::PostEditChangeProperty(
       this->Georeference->OnGeoreferenceUpdated.AddUniqueDynamic(
           this,
           &ACesiumSunSky::HandleGeoreferenceUpdated);
+      this->HandleGeoreferenceUpdated();
     }
   }
 }
@@ -44,6 +45,7 @@ void ACesiumSunSky::PostInitProperties() {
     this->Georeference->OnGeoreferenceUpdated.AddUniqueDynamic(
         this,
         &ACesiumSunSky::HandleGeoreferenceUpdated);
+    this->HandleGeoreferenceUpdated();
   }
 
 }

--- a/Source/CesiumRuntime/Private/CesiumSunSky.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.cpp
@@ -5,17 +5,47 @@
 
 // Sets default values
 ACesiumSunSky::ACesiumSunSky() {
-      PrimaryActorTick.bCanEverTick = false;
+  PrimaryActorTick.bCanEverTick = false;
+}
 
-  if (!Georeference) {
-    Georeference = ACesiumGeoreference::GetDefaultGeoreference(this);
+#if WITH_EDITOR
+void ACesiumSunSky::PostEditChangeProperty(
+    FPropertyChangedEvent& PropertyChangedEvent) {
+  Super::PostEditChangeProperty(PropertyChangedEvent);
+  
+  if (!PropertyChangedEvent.Property) {
+    return;
   }
 
-  if (Georeference) {
-    Georeference->OnGeoreferenceUpdated.AddUniqueDynamic(
+  FName PropName = PropertyChangedEvent.Property->GetFName();
+  if (PropName == GET_MEMBER_NAME_CHECKED(ACesiumSunSky, Georeference)) {
+    if (IsValid(this->Georeference)) {
+      this->Georeference->OnGeoreferenceUpdated.AddUniqueDynamic(
+          this,
+          &ACesiumSunSky::HandleGeoreferenceUpdated);
+    }
+  }
+}
+#endif
+
+void ACesiumSunSky::PostInitProperties() {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("Called PostInitProperties on actor %s"),
+      *this->GetName());
+
+  Super::PostInitProperties();
+
+  if (!this->Georeference) {
+    this->Georeference = ACesiumGeoreference::GetDefaultGeoreference(this);
+  }
+  if (IsValid(this->Georeference)) {
+    this->Georeference->OnGeoreferenceUpdated.AddUniqueDynamic(
         this,
         &ACesiumSunSky::HandleGeoreferenceUpdated);
   }
+
 }
 
 void ACesiumSunSky::SetSkyAtmosphereGroundRadius(

--- a/Source/CesiumRuntime/Private/CesiumSunSky.h
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.h
@@ -13,9 +13,22 @@ UCLASS()
 class CESIUMRUNTIME_API ACesiumSunSky : public AActor {
   GENERATED_BODY()
 
+protected:
+  /**
+   * Called after the C++ constructor and after the properties have
+   * been initialized, including those loaded from config.
+   */
+  void PostInitProperties() override;
+
+
 public:
   // Sets default values for this actor's properties
   ACesiumSunSky();
+
+#if WITH_EDITOR
+  virtual void
+  PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+#endif
 
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = Cesium)
   ACesiumGeoreference* Georeference;

--- a/Source/CesiumRuntime/Private/CesiumSunSky.h
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.h
@@ -20,7 +20,6 @@ protected:
    */
   void PostInitProperties() override;
 
-
 public:
   // Sets default values for this actor's properties
   ACesiumSunSky();

--- a/Source/CesiumRuntime/Private/GlmLogging.cpp
+++ b/Source/CesiumRuntime/Private/GlmLogging.cpp
@@ -1,0 +1,54 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#include "GlmLogging.h"
+#include "CesiumRuntime.h"
+
+#include <glm/glm.hpp>
+#include <string>
+
+void GlmLogging::logVector(const std::string& name, const glm::dvec3& vector) {
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("%s: %16.6f %16.6f %16.6f"),
+      *FString(name.c_str()),
+      vector.x,
+      vector.y,
+      vector.z);
+}
+
+void GlmLogging::logMatrix(const std::string& name, const glm::dmat4& matrix) {
+  UE_LOG(LogCesium, Verbose, TEXT("%s:"), *FString(name.c_str()));
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT(" %16.6f %16.6f %16.6f %16.6f"),
+      matrix[0][0],
+      matrix[1][0],
+      matrix[2][0],
+      matrix[3][0]);
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT(" %16.6f %16.6f %16.6f %16.6f"),
+      matrix[0][1],
+      matrix[1][1],
+      matrix[2][1],
+      matrix[3][1]);
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT(" %16.6f %16.6f %16.6f %16.6f"),
+      matrix[0][2],
+      matrix[1][2],
+      matrix[2][2],
+      matrix[3][2]);
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT(" %16.6f %16.6f %16.6f %16.6f"),
+      matrix[0][3],
+      matrix[1][3],
+      matrix[2][3],
+      matrix[3][3]);
+}

--- a/Source/CesiumRuntime/Private/GlmLogging.h
+++ b/Source/CesiumRuntime/Private/GlmLogging.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <String/>
+#include <string>
 #include <glm/glm.hpp>
 
 /**

--- a/Source/CesiumRuntime/Private/GlmLogging.h
+++ b/Source/CesiumRuntime/Private/GlmLogging.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include <string>
 #include <glm/glm.hpp>
+#include <string>
 
 /**
  * @brief Utility functions for logging GLM data in Unreal

--- a/Source/CesiumRuntime/Private/GlmLogging.h
+++ b/Source/CesiumRuntime/Private/GlmLogging.h
@@ -1,0 +1,30 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include <String/>
+#include <glm/glm.hpp>
+
+/**
+ * @brief Utility functions for logging GLM data in Unreal
+ */
+class GlmLogging {
+public:
+  /**
+   * Print the given vector as a verbose `LogCesium`
+   * message, with unspecified formatting.
+   *
+   * @param name The name that will be part of the message
+   * @param vector The vector
+   */
+  static void logVector(const std::string& name, const glm::dvec3& vector);
+
+  /**
+   * Print the given matrix as a verbose `LogCesium`
+   * message, with unspecified formatting.
+   *
+   * @param name The name that will be part of the message
+   * @param matrix The matrix
+   */
+  static void logMatrix(const std::string& name, const glm::dmat4& matrix);
+};

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -71,10 +71,8 @@ void AGlobeAwareDefaultPawn::MoveUp_World(float Val) {
     */
 
     FVector loc = this->GetPawnViewLocation();
-    glm::dvec3 locEcef =
-        this->Georeference->getGeoTransforms().TransformUnrealToEcef(
-            CesiumActors::getWorldOrigin4D(this),
-            glm::dvec3(loc.X, loc.Y, loc.Z));
+    glm::dvec3 locEcef = this->Georeference->TransformUnrealToEcef(
+        glm::dvec3(loc.X, loc.Y, loc.Z));
     glm::dvec4 upEcef(
         CesiumGeospatial::Ellipsoid::WGS84.geodeticSurfaceNormal(locEcef),
         0.0);
@@ -144,10 +142,7 @@ glm::dvec3 AGlobeAwareDefaultPawn::GetECEFCameraLocation() const {
         *this->GetName());
     return ueLocationVec;
   }
-  glm::dvec3 ecef =
-      this->Georeference->getGeoTransforms().TransformUnrealToEcef(
-          CesiumActors::getWorldOrigin4D(this),
-          ueLocationVec);
+  glm::dvec3 ecef = this->Georeference->TransformUnrealToEcef(ueLocationVec);
   return ecef;
 }
 
@@ -161,9 +156,7 @@ void AGlobeAwareDefaultPawn::SetECEFCameraLocation(const glm::dvec3& ecef) {
         *this->GetName());
     ue = ecef;
   } else {
-    ue = this->Georeference->getGeoTransforms().TransformEcefToUnreal(
-        CesiumActors::getWorldOrigin4D(this),
-        ecef);
+    ue = this->Georeference->TransformEcefToUnreal(ecef);
   }
   ADefaultPawn::SetActorLocation(FVector(
       static_cast<float>(ue.x),
@@ -308,9 +301,9 @@ void AGlobeAwareDefaultPawn::FlyToLocationLongitudeLatitudeHeight(
         TEXT("GlobeAwareDefaultPawn %s does not have a valid Georeference"),
         *this->GetName());
   }
-  const glm::dvec3& ecef = this->Georeference->getGeoTransforms()
-                               .TransformLongitudeLatitudeHeightToEcef(
-                                   LongitudeLatitudeHeightDestination);
+  const glm::dvec3& ecef =
+      this->Georeference->TransformLongitudeLatitudeHeightToEcef(
+          LongitudeLatitudeHeightDestination);
   this->FlyToLocationECEF(
       ecef,
       YawAtDestination,
@@ -407,8 +400,7 @@ void AGlobeAwareDefaultPawn::_handleFlightStep(float DeltaSeconds) {
   // Interpolate rotation - Computation has to be done at each step because
   // the ENU CRS is depending on location. Do all calculations in double
   // precision until the very end.
-  const glm::dvec3& ueOriginLocation =
-      VecMath::createVector3D(this->GetWorld()->OriginLocation);
+  const glm::dvec3& ueOriginLocation = CesiumActors::getWorldOrigin4D(this);
   const GeoTransforms& geoTransforms = this->Georeference->getGeoTransforms();
   const glm::dquat startingQuat =
       geoTransforms.TransformRotatorUnrealToEastNorthUp(

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -400,24 +400,19 @@ void AGlobeAwareDefaultPawn::_handleFlightStep(float DeltaSeconds) {
   // Interpolate rotation - Computation has to be done at each step because
   // the ENU CRS is depending on location. Do all calculations in double
   // precision until the very end.
-  const glm::dvec3& ueOriginLocation = CesiumActors::getWorldOrigin4D(this);
-  const GeoTransforms& geoTransforms = this->Georeference->getGeoTransforms();
   const glm::dquat startingQuat =
-      geoTransforms.TransformRotatorUnrealToEastNorthUp(
-          ueOriginLocation,
+      Georeference->TransformRotatorUnrealToEastNorthUp(
           VecMath::createQuaternion(this->_flyToSourceRotation.Quaternion()),
           this->_keypoints[0]);
   const glm::dquat endingQuat =
-      geoTransforms.TransformRotatorUnrealToEastNorthUp(
-          ueOriginLocation,
+      Georeference->TransformRotatorUnrealToEastNorthUp(
           VecMath::createQuaternion(
               this->_flyToDestinationRotation.Quaternion()),
           this->_keypoints.back());
   const glm::dquat& currentQuat =
       glm::slerp(startingQuat, endingQuat, flyPercentage);
   GetController()->SetControlRotation(
-      VecMath::createRotator(geoTransforms.TransformRotatorEastNorthUpToUnreal(
-          ueOriginLocation,
+      VecMath::createRotator(Georeference->TransformRotatorEastNorthUpToUnreal(
           currentQuat,
           currentPosition)));
 }

--- a/Source/CesiumRuntime/Private/VecMath.cpp
+++ b/Source/CesiumRuntime/Private/VecMath.cpp
@@ -182,6 +182,11 @@ VecMath::add4D(const FIntVector& i, const FVector& f) noexcept {
   return glm::dvec4(VecMath::add3D(i, f), 1.0);
 }
 
+inline glm::dvec4
+VecMath::add4D(const glm::vec4& d, const FIntVector& i) noexcept {
+  return glm::dvec4(VecMath::add3D(d, i), 1.0);
+}
+
 inline glm::dvec3
 VecMath::add3D(const FIntVector& i, const FVector& f) noexcept {
   return glm::dvec3(

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -263,10 +263,18 @@ public:
    * Transforms the given longitude in degrees (x), latitude in
    * degrees (y), and height in meters (z) into Earth-Centered, Earth-Fixed
    * (ECEF) coordinates.
+   */
+  glm::dvec3 TransformLongitudeLatitudeHeightToEcef(
+      const glm::dvec3& LongitudeLatitudeHeight) const;
+
+  /**
+   * Transforms the given longitude in degrees (x), latitude in
+   * degrees (y), and height in meters (z) into Earth-Centered, Earth-Fixed
+   * (ECEF) coordinates.
    *
    * This function peforms the computation in single-precision. When using
-   * the C++ API, corresponding double-precision function from the
-   * {@link getGeoTransforms} can be used.
+   * the C++ API, corresponding double-precision function
+   * TransformLongitudeLatitudeHeightToEcef can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateTransformLongitudeLatitudeHeightToEcef(
@@ -276,10 +284,18 @@ public:
    * Transforms the given Earth-Centered, Earth-Fixed (ECEF) coordinates into
    * WGS84 longitude in degrees (x), latitude in degrees (y), and height in
    * meters (z).
+   */
+  glm::dvec3
+  TransformEcefToLongitudeLatitudeHeight(const glm::dvec3& Ecef) const;
+
+  /**
+   * Transforms the given Earth-Centered, Earth-Fixed (ECEF) coordinates into
+   * WGS84 longitude in degrees (x), latitude in degrees (y), and height in
+   * meters (z).
    *
    * This function peforms the computation in single-precision. When using
-   * the C++ API, corresponding double-precision function from the
-   * {@link getGeoTransforms} can be used.
+   * the C++ API, corresponding double-precision function
+   * TransformEcefToLongitudeLatitudeHeight can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector
@@ -289,10 +305,18 @@ public:
    * Transforms the given longitude in degrees (x), latitude in
    * degrees (y), and height in meters (z) into Unreal world coordinates
    * (relative to the floating origin).
+   */
+  glm::dvec3 TransformLongitudeLatitudeHeightToUnreal(
+      const glm::dvec3& longitudeLatitudeHeight) const;
+
+  /**
+   * Transforms the given longitude in degrees (x), latitude in
+   * degrees (y), and height in meters (z) into Unreal world coordinates
+   * (relative to the floating origin).
    *
    * This function peforms the computation in single-precision. When using
-   * the C++ API, corresponding double-precision function from the
-   * {@link getGeoTransforms} can be used.
+   * the C++ API, corresponding double-precision function
+   * TransformLongitudeLatitudeHeightToUnreal can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateTransformLongitudeLatitudeHeightToUnreal(
@@ -303,6 +327,18 @@ public:
    * longitude in degrees (x), latitude in degrees (y), and height in
    * meters (z).
    */
+  glm::dvec3
+  TransformUnrealToLongitudeLatitudeHeight(const glm::dvec3& ue) const;
+
+  /**
+   * Transforms Unreal world coordinates (relative to the floating origin) into
+   * longitude in degrees (x), latitude in degrees (y), and height in
+   * meters (z).
+   *
+   * This function peforms the computation in single-precision. When using
+   * the C++ API, corresponding double-precision function
+   * TransformUnrealToLongitudeLatitudeHeight can be used.
+   */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector
   InaccurateTransformUnrealToLongitudeLatitudeHeight(const FVector& Ue) const;
@@ -310,10 +346,16 @@ public:
   /**
    * Transforms the given point from Earth-Centered, Earth-Fixed (ECEF) into
    * Unreal relative world (relative to the floating origin).
+   */
+  glm::dvec3 TransformEcefToUnreal(const glm::dvec3& ecef) const;
+
+  /**
+   * Transforms the given point from Earth-Centered, Earth-Fixed (ECEF) into
+   * Unreal relative world (relative to the floating origin).
    *
    * This function peforms the computation in single-precision. When using
-   * the C++ API, corresponding double-precision function from the
-   * {@link getGeoTransforms} can be used.
+   * the C++ API, corresponding double-precision function
+   * TransformEcefToUnreal can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateTransformEcefToUnreal(const FVector& Ecef) const;
@@ -321,10 +363,16 @@ public:
   /**
    * Transforms the given point from Unreal relative world (relative to the
    * floating origin) to Earth-Centered, Earth-Fixed (ECEF).
+   */
+  glm::dvec3 TransformUnrealToEcef(const glm::dvec3& ue) const;
+
+  /**
+   * Transforms the given point from Unreal relative world (relative to the
+   * floating origin) to Earth-Centered, Earth-Fixed (ECEF).
    *
    * This function peforms the computation in single-precision. When using
-   * the C++ API, corresponding double-precision function from the
-   * {@link getGeoTransforms} can be used.
+   * the C++ API, corresponding double-precision function
+   * TransformUnrealToEcef can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateTransformUnrealToEcef(const FVector& Ue) const;
@@ -334,12 +382,11 @@ public:
    * Unreal relative world location (relative to the floating origin).
    *
    * This function peforms the computation in single-precision. When using
-   * the C++ API, corresponding double-precision function from the
-   * {@link getGeoTransforms} can be used.
+   * the C++ API, corresponding double-precision function
+   * TransformUnrealToEcef can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FRotator InaccurateTransformRotatorUnrealToEastNorthUp(
-      const FIntVector& Origin,
       const FRotator& UeRotator,
       const FVector& UeLocation) const;
 
@@ -353,7 +400,6 @@ public:
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FRotator InaccurateTransformRotatorEastNorthUpToUnreal(
-      const FIntVector& Origin,
       const FRotator& EnuRotator,
       const FVector& UeLocation) const;
 
@@ -362,10 +408,18 @@ public:
    * specified Unreal relative world location (relative to the floating
    * origin). The returned transformation works in Unreal's left-handed
    * coordinate system.
+   */
+  glm::dmat3 ComputeEastNorthUpToUnreal(const glm::dvec3& Ue) const;
+
+  /**
+   * Computes the rotation matrix from the local East-North-Up to Unreal at the
+   * specified Unreal relative world location (relative to the floating
+   * origin). The returned transformation works in Unreal's left-handed
+   * coordinate system.
    *
    * This function peforms the computation in single-precision. When using
-   * the C++ API, corresponding double-precision function from the
-   * {@link getGeoTransforms} can be used.
+   * the C++ API, corresponding double-precision function
+   * ComputeEastNorthUpToUnreal can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FMatrix InaccurateComputeEastNorthUpToUnreal(const FVector& Ue) const;
@@ -373,14 +427,31 @@ public:
   /**
    * Computes the rotation matrix from the local East-North-Up to
    * Earth-Centered, Earth-Fixed (ECEF) at the specified ECEF location.
+   */
+  glm::dmat3 ComputeEastNorthUpToEcef(const glm::dvec3& ecef) const;
+
+  /**
+   * Computes the rotation matrix from the local East-North-Up to
+   * Earth-Centered, Earth-Fixed (ECEF) at the specified ECEF location.
    *
    * This function peforms the computation in single-precision. When using
-   * the C++ API, corresponding double-precision function from the
-   * {@link getGeoTransforms} can be used.
+   * the C++ API, corresponding double-precision function
+   * ComputeEastNorthUpToEcef can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FMatrix InaccurateComputeEastNorthUpToEcef(const FVector& Ecef) const;
 
+  /**
+   * @brief Computes the normal of the plane tangent to the surface of the
+   * ellipsoid that is used by this instance, at the provided position.
+   *
+   * @param position The cartesian position for which to to determine the
+   * surface normal.
+   * @return The normal.
+   */
+  glm::dvec3 ComputeGeodeticSurfaceNormal(const glm::dvec3& position) const {
+    return _geoTransforms.ComputeGeodeticSurfaceNormal(position);
+  }
   /**
    * A delegate that will be called whenever the Georeference is
    * modified in a way that affects its computations.

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -156,7 +156,7 @@ public:
   double OriginLongitude = -105.25737;
 
   /**
-   * The height of the custom origin placement in meters above the WGS84
+   * The height of the custom origin placement in meters above the
    * ellipsoid.
    */
   UPROPERTY(
@@ -225,19 +225,23 @@ public:
    * Returns the georeference origin position as an FVector. Only valid if
    * the placement type is Cartographic Origin (i.e. Longitude / Latitude /
    * Height).
+   *
+   * This converts the values to single-precision floating point values.
+   * The double-precision values can be accessed via the
+   * OriginLongitude, OriginLatitude and OriginHeight properties.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateGetGeoreferenceOriginLongitudeLatitudeHeight() const;
 
   /**
-   * This aligns the specified WGS84 longitude in degrees (x), latitude in
+   * This aligns the specified longitude in degrees (x), latitude in
    * degrees (y), and height in meters (z) to Unreal's world origin. I.e. it
    * rotates the globe so that these coordinates exactly fall on the origin.
    */
   void SetGeoreferenceOrigin(const glm::dvec3& TargetLongitudeLatitudeHeight);
 
   /**
-   * This aligns the specified WGS84 longitude in degrees (x), latitude in
+   * This aligns the specified longitude in degrees (x), latitude in
    * degrees (y), and height in meters (z) to Unreal's world origin. I.e. it
    * rotates the globe so that these coordinates exactly fall on the origin.
    */
@@ -250,17 +254,13 @@ public:
    */
 
   /**
-   * Transforms the given WGS84 longitude in degrees (x), latitude in
+   * Transforms the given longitude in degrees (x), latitude in
    * degrees (y), and height in meters (z) into Earth-Centered, Earth-Fixed
    * (ECEF) coordinates.
-   */
-  glm::dvec3 TransformLongitudeLatitudeHeightToEcef(
-      const glm::dvec3& LongitudeLatitudeHeight) const;
-
-  /**
-   * Transforms the given WGS84 longitude in degrees (x), latitude in
-   * degrees (y), and height in meters (z) into Earth-Centered, Earth-Fixed
-   * (ECEF) coordinates.
+   *
+   * This function peforms the computation in single-precision. When using
+   * the C++ API, corresponding double-precision function from the
+   * {@link getGeoTransforms} can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateTransformLongitudeLatitudeHeightToEcef(
@@ -270,31 +270,23 @@ public:
    * Transforms the given Earth-Centered, Earth-Fixed (ECEF) coordinates into
    * WGS84 longitude in degrees (x), latitude in degrees (y), and height in
    * meters (z).
-   */
-  glm::dvec3
-  TransformEcefToLongitudeLatitudeHeight(const glm::dvec3& Ecef) const;
-
-  /**
-   * Transforms the given Earth-Centered, Earth-Fixed (ECEF) coordinates into
-   * WGS84 longitude in degrees (x), latitude in degrees (y), and height in
-   * meters (z).
+   *
+   * This function peforms the computation in single-precision. When using
+   * the C++ API, corresponding double-precision function from the
+   * {@link getGeoTransforms} can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector
   InaccurateTransformEcefToLongitudeLatitudeHeight(const FVector& Ecef) const;
 
   /**
-   * Transforms the given WGS84 longitude in degrees (x), latitude in
+   * Transforms the given longitude in degrees (x), latitude in
    * degrees (y), and height in meters (z) into Unreal world coordinates
    * (relative to the floating origin).
-   */
-  glm::dvec3 TransformLongitudeLatitudeHeightToUnreal(
-      const glm::dvec3& LongitudeLatitudeHeight) const;
-
-  /**
-   * Transforms the given WGS84 longitude in degrees (x), latitude in
-   * degrees (y), and height in meters (z) into Unreal world coordinates
-   * (relative to the floating origin).
+   *
+   * This function peforms the computation in single-precision. When using
+   * the C++ API, corresponding double-precision function from the
+   * {@link getGeoTransforms} can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateTransformLongitudeLatitudeHeightToUnreal(
@@ -302,15 +294,7 @@ public:
 
   /**
    * Transforms Unreal world coordinates (relative to the floating origin) into
-   * WGS84 longitude in degrees (x), latitude in degrees (y), and height in
-   * meters (z).
-   */
-  glm::dvec3
-  TransformUnrealToLongitudeLatitudeHeight(const glm::dvec3& Ue) const;
-
-  /**
-   * Transforms Unreal world coordinates (relative to the floating origin) into
-   * WGS84 longitude in degrees (x), latitude in degrees (y), and height in
+   * longitude in degrees (x), latitude in degrees (y), and height in
    * meters (z).
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
@@ -320,12 +304,10 @@ public:
   /**
    * Transforms the given point from Earth-Centered, Earth-Fixed (ECEF) into
    * Unreal relative world (relative to the floating origin).
-   */
-  glm::dvec3 TransformEcefToUnreal(const glm::dvec3& Ecef) const;
-
-  /**
-   * Transforms the given point from Earth-Centered, Earth-Fixed (ECEF) into
-   * Unreal relative world (relative to the floating origin).
+   *
+   * This function peforms the computation in single-precision. When using
+   * the C++ API, corresponding double-precision function from the
+   * {@link getGeoTransforms} can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateTransformEcefToUnreal(const FVector& Ecef) const;
@@ -333,12 +315,10 @@ public:
   /**
    * Transforms the given point from Unreal relative world (relative to the
    * floating origin) to Earth-Centered, Earth-Fixed (ECEF).
-   */
-  glm::dvec3 TransformUnrealToEcef(const glm::dvec3& Ue) const;
-
-  /**
-   * Transforms the given point from Unreal relative world (relative to the
-   * floating origin) to Earth-Centered, Earth-Fixed (ECEF).
+   *
+   * This function peforms the computation in single-precision. When using
+   * the C++ API, corresponding double-precision function from the
+   * {@link getGeoTransforms} can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateTransformUnrealToEcef(const FVector& Ue) const;
@@ -346,15 +326,10 @@ public:
   /**
    * Transforms a rotator from Unreal world to East-North-Up at the given
    * Unreal relative world location (relative to the floating origin).
-   */
-  glm::dquat TransformRotatorUnrealToEastNorthUp(
-      const glm::dvec3& origin,
-      const glm::dquat& UeRotator,
-      const glm::dvec3& UeLocation) const;
-
-  /**
-   * Transforms a rotator from Unreal world to East-North-Up at the given
-   * Unreal relative world location (relative to the floating origin).
+   *
+   * This function peforms the computation in single-precision. When using
+   * the C++ API, corresponding double-precision function from the
+   * {@link getGeoTransforms} can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FRotator InaccurateTransformRotatorUnrealToEastNorthUp(
@@ -365,15 +340,10 @@ public:
   /**
    * Transforms a rotator from East-North-Up to Unreal world at the given
    * Unreal relative world location (relative to the floating origin).
-   */
-  glm::dquat TransformRotatorEastNorthUpToUnreal(
-      const glm::dvec3& origin,
-      const glm::dquat& EnuRotator,
-      const glm::dvec3& UeLocation) const;
-
-  /**
-   * Transforms a rotator from East-North-Up to Unreal world at the given
-   * Unreal relative world location (relative to the floating origin).
+   *
+   * This function peforms the computation in single-precision. When using
+   * the C++ API, corresponding double-precision function from the
+   * {@link getGeoTransforms} can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FRotator InaccurateTransformRotatorEastNorthUpToUnreal(
@@ -386,14 +356,10 @@ public:
    * specified Unreal relative world location (relative to the floating
    * origin). The returned transformation works in Unreal's left-handed
    * coordinate system.
-   */
-  glm::dmat3 ComputeEastNorthUpToUnreal(const glm::dvec3& Ue) const;
-
-  /**
-   * Computes the rotation matrix from the local East-North-Up to Unreal at the
-   * specified Unreal relative world location (relative to the floating
-   * origin). The returned transformation works in Unreal's left-handed
-   * coordinate system.
+   *
+   * This function peforms the computation in single-precision. When using
+   * the C++ API, corresponding double-precision function from the
+   * {@link getGeoTransforms} can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FMatrix InaccurateComputeEastNorthUpToUnreal(const FVector& Ue) const;
@@ -401,85 +367,13 @@ public:
   /**
    * Computes the rotation matrix from the local East-North-Up to
    * Earth-Centered, Earth-Fixed (ECEF) at the specified ECEF location.
-   */
-  glm::dmat3 ComputeEastNorthUpToEcef(const glm::dvec3& Ecef) const;
-
-  /**
-   * Computes the rotation matrix from the local East-North-Up to
-   * Earth-Centered, Earth-Fixed (ECEF) at the specified ECEF location.
+   *
+   * This function peforms the computation in single-precision. When using
+   * the C++ API, corresponding double-precision function from the
+   * {@link getGeoTransforms} can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FMatrix InaccurateComputeEastNorthUpToEcef(const FVector& Ecef) const;
-
-  /*
-   * GEOREFERENCE TRANSFORMS
-   */
-
-  /**
-   * @brief Gets the transformation from the "Georeferenced" reference frame
-   * defined by this instance to the "Ellipsoid-centered" reference frame (i.e.
-   * ECEF).
-   *
-   * Gets a matrix that transforms coordinates from the "Georeference" reference
-   * frame defined by this instance to the "Ellipsoid-centered" reference frame,
-   * which is usually Earth-centered, Earth-fixed.
-   * See {@link reference-frames.md}.
-   */
-  const glm::dmat4& GetGeoreferencedToEllipsoidCenteredTransform() const {
-    return this->_geoTransforms.GetGeoreferencedToEllipsoidCenteredTransform();
-  }
-
-  /**
-   * @brief Gets the transformation from the "Ellipsoid-centered" reference
-   * frame (i.e. ECEF) to the georeferenced reference frame defined by this
-   * instance.
-   *
-   * Gets a matrix that transforms coordinates from the "Ellipsoid-centered"
-   * reference frame (which is usually Earth-centered, Earth-fixed) to the
-   * "Georeferenced" reference frame defined by this instance.
-   * See {@link reference-frames.md}.
-   */
-  const glm::dmat4& GetEllipsoidCenteredToGeoreferencedTransform() const {
-    return this->_geoTransforms.GetEllipsoidCenteredToGeoreferencedTransform();
-  }
-
-  /**
-   * @brief Gets the transformation from the "Unreal World" reference frame to
-   * the "Ellipsoid-centered" reference frame (i.e. ECEF).
-   *
-   * Gets a matrix that transforms coordinates from the "Unreal World" reference
-   * frame (with respect to the absolute world origin, not the floating origin)
-   * to the "Ellipsoid-centered" reference frame (which is usually
-   * Earth-centered, Earth-fixed). See {@link reference-frames.md}.
-   */
-  const glm::dmat4& GetUnrealWorldToEllipsoidCenteredTransform() const {
-    return this->_geoTransforms.GetUnrealWorldToEllipsoidCenteredTransform();
-  }
-
-  /**
-   * @brief Gets the transformation from the "Ellipsoid-centered" reference
-   * frame (i.e. ECEF) to the "Unreal World" reference frame.
-   *
-   * Gets a matrix that transforms coordinates from the "Ellipsoid-centered"
-   * reference frame (which is usually Earth-centered, Earth-fixed) to the
-   * "Unreal world" reference frame (with respect to the absolute world origin,
-   * not the floating origin). See {@link reference-frames.md}.
-   */
-  const glm::dmat4& GetEllipsoidCenteredToUnrealWorldTransform() const {
-    return this->_geoTransforms.GetEllipsoidCenteredToUnrealWorldTransform();
-  }
-
-  /**
-   * @brief Computes the normal of the plane tangent to the surface of the
-   * ellipsoid that is used by this instance, at the provided position.
-   *
-   * @param position The cartesian position for which to to determine the
-   * surface normal.
-   * @return The normal.
-   */
-  glm::dvec3 ComputeGeodeticSurfaceNormal(const glm::dvec3& position) const {
-    return _geoTransforms.ComputeGeodeticSurfaceNormal(position);
-  }
 
   /**
    * A delegate that will be called whenever the Georeference is
@@ -510,7 +404,11 @@ public:
    */
   virtual void Tick(float DeltaTime) override;
 
-  // TODO : Try to avoid exposing this publicly
+  /**
+   * Returns the GeoTransforms that offers the same conversion
+   * functions as this class, but performs the computations
+   * in double precision.
+   */
   const GeoTransforms& getGeoTransforms() const noexcept {
     return _geoTransforms;
   }

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -380,10 +380,18 @@ public:
   /**
    * Transforms a rotator from Unreal world to East-North-Up at the given
    * Unreal relative world location (relative to the floating origin).
+   */
+  glm::dquat TransformRotatorUnrealToEastNorthUp(
+      const glm::dquat& UeRotator,
+      const glm::dvec3& UeLocation) const;
+
+  /**
+   * Transforms a rotator from Unreal world to East-North-Up at the given
+   * Unreal relative world location (relative to the floating origin).
    *
    * This function peforms the computation in single-precision. When using
    * the C++ API, corresponding double-precision function
-   * TransformUnrealToEcef can be used.
+   * TransformRotatorUnrealToEastNorthUp can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FRotator InaccurateTransformRotatorUnrealToEastNorthUp(
@@ -393,10 +401,18 @@ public:
   /**
    * Transforms a rotator from East-North-Up to Unreal world at the given
    * Unreal relative world location (relative to the floating origin).
+   */
+  glm::dquat TransformRotatorEastNorthUpToUnreal(
+      const glm::dquat& EnuRotator,
+      const glm::dvec3& UeLocation) const;
+
+  /**
+   * Transforms a rotator from East-North-Up to Unreal world at the given
+   * Unreal relative world location (relative to the floating origin).
    *
    * This function peforms the computation in single-precision. When using
-   * the C++ API, corresponding double-precision function from the
-   * {@link getGeoTransforms} can be used.
+   * the C++ API, corresponding double-precision function
+   * TransformRotatorEastNorthUpToUnreal can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FRotator InaccurateTransformRotatorEastNorthUpToUnreal(

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -236,14 +236,20 @@ public:
   /**
    * This aligns the specified longitude in degrees (x), latitude in
    * degrees (y), and height in meters (z) to Unreal's world origin. I.e. it
-   * rotates the globe so that these coordinates exactly fall on the origin.
+   * moves the globe so that these coordinates exactly fall on the origin.
+   *
+   * When the WorldOriginCamera of this instance is currently contained
+   * the bounds of a sublevel, then this call has no effect.
    */
   void SetGeoreferenceOrigin(const glm::dvec3& TargetLongitudeLatitudeHeight);
 
   /**
    * This aligns the specified longitude in degrees (x), latitude in
    * degrees (y), and height in meters (z) to Unreal's world origin. I.e. it
-   * rotates the globe so that these coordinates exactly fall on the origin.
+   * moves the globe so that these coordinates exactly fall on the origin.
+   *
+   * When the WorldOriginCamera of this instance is currently contained
+   * the bounds of a sublevel, then this call has no effect.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   void

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -436,11 +436,12 @@ private:
    */
   static FName DEFAULT_GEOREFERENCE_TAG;
 
+  /**
+   * The radii, in x-, y-, and z-direction, of the ellipsoid that
+   * should be used in this instance.
+   */
   UPROPERTY()
   double _ellipsoidRadii[3];
-
-  UPROPERTY()
-  double _center[3];
 
   GeoTransforms _geoTransforms;
 

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -370,13 +370,13 @@ private:
   // This is currently no longer used, but removing this messes up
   // the deserialization (unless we handle different versions)
   // Note: this is done to allow Unreal to recognize and serialize _actorToECEF
-  UPROPERTY()
-  double _actorToECEF_Array[16];
-  glm::dmat4& _actorToECEF = *(glm::dmat4*)_actorToECEF_Array;
+  //UPROPERTY()
+  //double _actorToECEF_Array[16];
+  //glm::dmat4& _actorToECEF = *(glm::dmat4*)_actorToECEF_Array;
 
   // TODO GEOREF_REFACTORING
   // This was only set to "true" from CesiumGlobeAnchorParent (deprecated)
   // In all other cases, the flag had always been "false"
-  UPROPERTY()
-  bool _autoSnapToEastSouthUp;
+  //UPROPERTY()
+  //bool _autoSnapToEastSouthUp;
 };

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -58,13 +58,19 @@ public:
   /**
    * The latitude in degrees of this component, in the range [-90, 90]
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium", meta = (ClampMin = -90.0, ClampMax = 90.0))
+  UPROPERTY(
+      EditAnywhere,
+      Category = "Cesium",
+      meta = (ClampMin = -90.0, ClampMax = 90.0))
   double Latitude = 0.0;
 
   /**
    * The longitude in degrees of this component, in the range [-180, 180]
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium", meta = (ClampMin = -180.0, ClampMax = 180.0))
+  UPROPERTY(
+      EditAnywhere,
+      Category = "Cesium",
+      meta = (ClampMin = -180.0, ClampMax = 180.0))
   double Longitude = 0.0;
 
   /**
@@ -105,7 +111,6 @@ public:
   UFUNCTION(BlueprintCallable, CallInEditor, Category = "Cesium")
   void SnapToEastSouthUp();
 
-
   /**
    * Move the actor to the specified longitude in degrees (x), latitude
    * in degrees (y), and height in meters (z).
@@ -140,71 +145,181 @@ public:
       const FVector& TargetEcef,
       bool MaintainRelativeOrientation = true);
 
+  // TODO Comment (or rather remove it - only used in CesiumGlobeAnchorParent!)
   void SetAutoSnapToEastSouthUp(bool bValue);
 
   /**
-   * Called by owner actor on position shifting Component should update 
-   * all relevant data structures to reflect new actor location. 
-   * 
+   * Called by owner actor on position shifting. The Component should update
+   * all relevant data structures to reflect new actor location.
+   *
+   * Specifically, this is called during origin rebasing. Here, it
+   * will update the ECEF location, to take the new world origin
+   * location into account.
    */
   virtual void
   ApplyWorldOffset(const FVector& InOffset, bool bWorldShift) override;
 
-  virtual void OnRegister() override;
-  virtual void OnUnregister() override;
-  virtual void OnComponentCreated() override;
-  virtual void PostLoad() override;
-
-//  UFUNCTION()
-//  void OnRootComponentChanged(
-//      USceneComponent* UpdatedComponent,
-//      bool bIsRootComponent);
-
-
-  void HandleActorTransformUpdated(USceneComponent* InRootComponent, EUpdateTransformFlags UpdateTransformFlags, ETeleportType Teleport);
-
-
-  UFUNCTION()
-  void HandleGeoreferenceUpdated();
-
-  /**
-   * Initializes the component. Occurs at level startup or actor spawn. 
-   * Requires component to be registered, and bWantsInitializeComponent to be true.
-   */
-  void InitializeComponent() override;
-
 protected:
   /**
-   * Called after the C++ constructor and after the properties have
-   * been initialized, including those loaded from config.
+   * Called when a component is registered.
+   *
+   * In fact, this is called on many other occasions (including
+   * changes to properties in the editor). Here, it us used to
+   * attach the callback to `HandleActorTransformUpdated` to
+   * the `TransformUpdated` delegate of the owner root, so that
+   * movements in the actor can be used for updating the
+   * ECEF coordinates.
    */
-  void PostInitProperties() override;
-  
+  virtual void OnRegister() override;
+
+  /**
+   * Called when a component is unregistered.
+   *
+   * In fact, this is called on many other occasions (including
+   * changes to properties in the editor). Here, it us used to
+   * DEtach the callback to `HandleActorTransformUpdated` from
+   * the `TransformUpdated` delegate of the owner root.
+   */
+  virtual void OnUnregister() override;
+
+  /**
+   * Handle updates in the transform of the owning actor.
+   *
+   * This will be attached to the `TransformUpdated` delegate of
+   * the owner root, and just call `_updateFromActor`, to
+   * include the new actor transform in the ECEF coordinates.
+   */
+  void HandleActorTransformUpdated(
+      USceneComponent* InRootComponent,
+      EUpdateTransformFlags UpdateTransformFlags,
+      ETeleportType Teleport);
+
+  /**
+   * Called when a component is created (not loaded).
+   * This can happen in the editor or during gameplay.
+   *
+   * This is overrideen for initializing the Georeference by calling
+   * _initGeoreference. This indeed seems to be called only exactly
+   * once, when the component is created in the editor.
+   */
+  virtual void OnComponentCreated() override;
+
+  /**
+   * Do any object-specific cleanup required immediately after
+   * loading an object.
+   *
+   * This is overrideen for initializing the Georeference by calling
+   * _initGeoreference. This indeed seems to  be called only exactly
+   * once, when the component is loaded as part of a level in the editor.
+   */
+  virtual void PostLoad() override;
+
 #if WITH_EDITOR
+
+  /**
+   * This is called when a property is about to be modified externally.
+   *
+   * When the georeference is about to be modified, then this will
+   * remove the `HandleGeoreferenceUpdated` callback from the
+   * `OnGeoreferenceUpdated` delegate of the current georeference.
+   */
+  void PreEditChange(FProperty* PropertyThatWillChange);
+
+  /**
+   * Called when a property on this object has been modified externally
+   *
+   * This is called every time that a value is modified in the editor UI.
+   *
+   * When a cartographic value is modified, calls
+   * `MoveToLongitudeLatitudeHeight` with the new values.
+   *
+   * When an ECEF coordinate is modified, it calls `MoveToECEF` with the
+   * new values.
+   *
+   * When the georeference is about to be modified, then this will
+   * attach the `HandleGeoreferenceUpdated` callback to the
+   * `OnGeoreferenceUpdated` delegate of the new georeference,
+   * and call `_updateActorTransform` to take the new georeference
+   * into account.
+   */
   virtual void
   PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif
 
 private:
+  /**
+   * A function that is attached to the `OnGeoreferenceUpdated` delegate,
+   * of the Georeference, and just calls `_updateActorTransform`.
+   */
+  UFUNCTION()
+  void HandleGeoreferenceUpdated();
+
+  /**
+   * Initializes the `Georeference`.
+   *
+   * If there is no `Georeference`, then a default one is obtained.
+   * In any case, `HandleGeoreferenceUpdated` callback will be attached
+   * to the `OnGeoreferenceChanged` delegate, to be notified about
+   * changes in the georeference that may affect this component.
+   */
   void _initGeoreference();
 
+  /**
+   * Updates the ECEF coordinates of this instance, based on an update
+   * of the transform of the owning actor.
+   *
+   * This will compute the new ECEF coordinates, based on the actor
+   * transform, and assign them to this instance by calling `_setECEF`.
+   */
   void _updateFromActor();
-  glm::dvec3 _getRelativeLocationFromActor();
 
+  /**
+   * Obtains the absolute location of the owner actor.
+   *
+   * This is the sum of the world origin location and the relative location
+   * (as of `this->GetOwner()->GetRootComponent()->GetComponentLocation()`),
+   * as a GLM vector, with the appropriate validity checks.
+   */
+  glm::dvec3 _getAbsoluteLocationFromActor();
+
+  /**
+   * Set the position of this component, in ECEF coordinates.
+   *
+   * This will perform the necessary updates of the `ECEF_X`, `ECEF_Y`,
+   * and `ECEF_Z` properties as well as the cartographic coordinate
+   * properties, and call `_updateActorTransform`.
+   *
+   * @param targetEcef The ECEF coordinates.
+   * @param maintainRelativeOrientation TODO Explain that...
+   */
+  void _setECEF(const glm::dvec3& targetEcef, bool maintainRelativeOrientation);
+
+  /**
+   * Updates the transform of the owning actor.
+   *
+   * This will use the (high-precision) `ECEF_X`, `ECEF_Y`, and `ECEF_Z`
+   * coordinates of this instance, as well as the rotation component of
+   * the current actor transform, to compute an updated transform matrix
+   * that is applied to the owner by calling `SetWorldTransform`.
+   */
   void _updateActorTransform();
 
-
-  void _setECEF(const glm::dvec3& targetEcef, bool maintainRelativeOrientation);
+  /**
+   * Updates the `Longitude`, `Latitude` and `Height` properties
+   * of this instance, based on the current ECEF_X/Y/Z coordinates.
+   */
   void _updateDisplayLongitudeLatitudeHeight();
 
-  void _logState();
+  /**
+   * A function to print some debug message about the state
+   * (absolute and relative location) of this component.
+   */
+  void _debugLogState();
 
   // TODO GEOREF_REFACTORING
-  // I'm relatively sure that serializing these should not be
-  // necessary, because they are derived from the state of
-  // this object and the GeoRef. But removing this messes up
+  // This is currently no longer used, but removing this messes up
   // the deserialization (unless we handle different versions)
-  // Note: this is done to allow Unreal to recognize and serialize _actorToECEF  
+  // Note: this is done to allow Unreal to recognize and serialize _actorToECEF
   UPROPERTY()
   double _actorToECEF_Array[16];
   glm::dmat4& _actorToECEF = *(glm::dmat4*)_actorToECEF_Array;

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -18,10 +18,10 @@
  * normal Unreal Engine mechanisms, the internal geospatial coordinates will be
  * automatically updated. The actor position can also be set in terms of
  * Earth-Centered, Eath-Fixed coordinates (ECEF) or Longitude, Latitude, and
- * Height relative to the WGS84 ellipsoid.
+ * Height relative to the ellipsoid.
  */
 UCLASS(ClassGroup = (Cesium), meta = (BlueprintSpawnableComponent))
-class CESIUMRUNTIME_API UCesiumGeoreferenceComponent : public USceneComponent {
+class CESIUMRUNTIME_API UCesiumGeoreferenceComponent : public UActorComponent {
   GENERATED_BODY()
 
 public:
@@ -58,37 +58,37 @@ public:
   /**
    * The latitude in degrees of the Georeference of this component, in the range [-90, 90]
    */
-  UPROPERTY(VisibleAnywhere, Category = "Cesium", meta = (ClampMin = -90.0, ClampMax = 90.0))
+  UPROPERTY(EditAnywhere, Category = "Cesium", meta = (ClampMin = -90.0, ClampMax = 90.0))
   double Latitude = 0.0;
 
   /**
    * The longitude in degrees of the Georeference of this component, in the range [-180, 180]
    */
-  UPROPERTY(VisibleAnywhere, Category = "Cesium", meta = (ClampMin = -180.0, ClampMax = 180.0))
+  UPROPERTY(EditAnywhere, Category = "Cesium", meta = (ClampMin = -180.0, ClampMax = 180.0))
   double Longitude = 0.0;
 
   /**
    * The height in meters (above the ellipsoid) of the Georeference of this component.
    */
-  UPROPERTY(VisibleAnywhere, Category = "Cesium")
+  UPROPERTY(EditAnywhere, Category = "Cesium")
   double Height = 0.0;
 
   /**
    * The Earth-Centered Earth-Fixed X-coordinate of the Georeference of this component.
    */
-  UPROPERTY(VisibleAnywhere, Category = "Cesium")
+  UPROPERTY(EditAnywhere, Category = "Cesium")
   double ECEF_X = 0.0;
 
   /**
    * The Earth-Centered Earth-Fixed Y-coordinate of the Georeference of this component.
    */
-  UPROPERTY(VisibleAnywhere, Category = "Cesium")
+  UPROPERTY(EditAnywhere, Category = "Cesium")
   double ECEF_Y = 0.0;
 
   /**
    * The Earth-Centered Earth-Fixed Z-coordinate of the Georeference of this component.
    */
-  UPROPERTY(VisibleAnywhere, Category = "Cesium")
+  UPROPERTY(EditAnywhere, Category = "Cesium")
   double ECEF_Z = 0.0;
 
   /**
@@ -107,73 +107,62 @@ public:
 
 
   /**
-   * Move the actor to the specified WGS84 longitude in degrees (x), latitude
+   * Move the actor to the specified longitude in degrees (x), latitude
    * in degrees (y), and height in meters (z).
    */
-  // TODO GEOREF_REFACTORING This was only used in GlobeAnchorPanrent, 
-  // and should be removed
-  //void MoveToLongitudeLatitudeHeight(
-  //    const glm::dvec3& TargetLongitudeLatitudeHeight,
-  //    bool MaintainRelativeOrientation = true);
+  void MoveToLongitudeLatitudeHeight(
+      const glm::dvec3& TargetLongitudeLatitudeHeight,
+      bool MaintainRelativeOrientation = true);
 
   /**
-   * Move the actor to the specified WGS84 longitude in degrees (x), latitude
+   * Move the actor to the specified longitude in degrees (x), latitude
    * in degrees (y), and height in meters (z).
    */
-  // TODO GEOREF_REFACTORING This was only used in GlobeAnchorPanrent, 
-  // and should be removed
-  //UFUNCTION(BlueprintCallable, Category = "Cesium")
-  //void InaccurateMoveToLongitudeLatitudeHeight(
-  //    const FVector& TargetLongitudeLatitudeHeight,
-  //    bool MaintainRelativeOrientation = true);
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  void InaccurateMoveToLongitudeLatitudeHeight(
+      const FVector& TargetLongitudeLatitudeHeight,
+      bool MaintainRelativeOrientation = true);
 
   /**
    * Move the actor to the specified Earth-Centered, Earth-Fixed (ECEF)
    * coordinates.
    */
-  // TODO GEOREF_REFACTORING This was not used at all. Movement should
-  // be done on the Georeference
-  //void MoveToECEF(
-  //    const glm::dvec3& TargetEcef,
-  //    bool MaintainRelativeOrientation = true);
+  void MoveToECEF(
+      const glm::dvec3& TargetEcef,
+      bool MaintainRelativeOrientation = true);
 
   /**
    * Move the actor to the specified Earth-Centered, Earth-Fixed (ECEF)
    * coordinates.
    */
-  // TODO GEOREF_REFACTORING This was not used at all. Movement should
-  // be done on the Georeference
-  //UFUNCTION(BlueprintCallable, Category = "Cesium")
-  //void InaccurateMoveToECEF(
-  //    const FVector& TargetEcef,
-  //    bool MaintainRelativeOrientation = true);
-
-  /**
-   * Delegate implementation to recieve a notification when the owner's root
-   * component has changed.
-   */
-  UFUNCTION()
-  void OnRootComponentChanged(
-      USceneComponent* UpdatedComponent,
-      bool bIsRootComponent);
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  void InaccurateMoveToECEF(
+      const FVector& TargetEcef,
+      bool MaintainRelativeOrientation = true);
 
   void SetAutoSnapToEastSouthUp(bool bValue);
 
-  bool CheckCoordinatesChanged() const { return this->_dirty; }
-
-  void MarkCoordinatesUnchanged() { this->_dirty = false; }
-
+  /**
+   * Called by owner actor on position shifting Component should update 
+   * all relevant data structures to reflect new actor location. 
+   * 
+   */
   virtual void
   ApplyWorldOffset(const FVector& InOffset, bool bWorldShift) override;
 
-  virtual void OnUpdateTransform(
-      EUpdateTransformFlags UpdateTransformFlags,
-      ETeleportType Teleport) override;
-
   virtual void OnRegister() override;
+  virtual void OnUnregister() override;
   virtual void OnComponentCreated() override;
-  virtual void OnAttachmentChanged() override;
   virtual void PostLoad() override;
+
+//  UFUNCTION()
+//  void OnRootComponentChanged(
+//      USceneComponent* UpdatedComponent,
+//      bool bIsRootComponent);
+
+
+  void HandleActorTransformUpdated(USceneComponent* InRootComponent, EUpdateTransformFlags UpdateTransformFlags, ETeleportType Teleport);
+
 
   UFUNCTION()
   void HandleGeoreferenceUpdated();
@@ -185,15 +174,6 @@ public:
   void InitializeComponent() override;
 
 protected:
-  // Called when the game starts
-  virtual bool MoveComponentImpl(
-      const FVector& Delta,
-      const FQuat& NewRotation,
-      bool bSweep,
-      FHitResult* OutHit = NULL,
-      EMoveComponentFlags MoveFlags = MOVECOMP_NoFlags,
-      ETeleportType Teleport = ETeleportType::None) override;
-
   /**
    * Called after the C++ constructor and after the properties have
    * been initialized, including those loaded from config.
@@ -206,40 +186,48 @@ protected:
 #endif
 
 private:
-  void _initRootComponent();
+  void _initGeoreference();
   void _initWorldOriginLocation();
-  void _updateAbsoluteLocation();
-  void _updateRelativeLocation();
+
+  glm::dvec3 _getRelativeLocationFromActor();
+  glm::dvec3 _getAbsoluteLocationFromActor();
+
   void _updateActorToECEF();
-  void _updateActorToUnrealRelativeWorldTransform();
-  void _setTransform(const glm::dmat4& transform);
+
+  glm::dmat4 _computeActorToUnrealRelativeWorldTransform();
+  void _applyTransformToActor(const glm::dmat4& actorToUnrealRelativeWorldTransform);
+
+  void _updateActorTransform();
+
+  void _updateRelativeLocationFromActor();
+
   void _setECEF(const glm::dvec3& targetEcef, bool maintainRelativeOrientation);
+  
   void _updateDisplayLongitudeLatitudeHeight();
   void _updateDisplayECEF();
 
-  void _initGeoreference();
-
-  // TODO GEOREF_REFACTORING I'm somewhat (but not entirely) sure
-  // that these properties are redundant and/or not updated when
-  // the corresponding value in UE changes. Review this...
+  /**
+   * The position of the world origin, as of this->GetWorld()->OriginLocation
+   */
   glm::dvec3 _worldOriginLocation;
-  glm::dvec3 _absoluteLocation;
+
+  /**
+   * The relative location of the actor, as of ownerRoot->GetComponentLocation()
+   */
   glm::dvec3 _relativeLocation;
+
+  void _logState();
 
   // TODO GEOREF_REFACTORING
   // I'm relatively sure that serializing these should not be
-  // becessary, because they are derived from the GeoRef
-  // Note: this is done to allow Unreal to recognize and serialize _actorToECEF
+  // necessary, because they are derived from the state of
+  // this object and the GeoRef. But removing this messes up
+  // the deserialization (unless we handle different versions)
+  // Note: this is done to allow Unreal to recognize and serialize _actorToECEF  
   UPROPERTY()
   double _actorToECEF_Array[16];
-
   glm::dmat4& _actorToECEF = *(glm::dmat4*)_actorToECEF_Array;
 
-  glm::dmat4 _actorToUnrealRelativeWorld;
-  USceneComponent* _ownerRoot;
-
-  bool _ignoreOnUpdateTransform;
   UPROPERTY()
   bool _autoSnapToEastSouthUp;
-  bool _dirty;
 };

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -283,6 +283,11 @@ private:
   glm::dvec3 _getAbsoluteLocationFromActor();
 
   /**
+   * Obtains the current rotation matrix from the transform of the actor.
+   */
+  glm::dmat3 _getRotationFromActor();
+
+  /**
    * Set the position of this component, in ECEF coordinates.
    *
    * This will perform the necessary updates of the `ECEF_X`, `ECEF_Y`,
@@ -295,6 +300,12 @@ private:
   void _setECEF(const glm::dvec3& targetEcef, bool maintainRelativeOrientation);
 
   /**
+   * Computes the relative location, from the current ECEF location
+   * and the world origin location.
+   */
+  glm::dvec3 _computeRelativeLocation();
+
+  /**
    * Updates the transform of the owning actor.
    *
    * This will use the (high-precision) `ECEF_X`, `ECEF_Y`, and `ECEF_Z`
@@ -303,6 +314,16 @@ private:
    * that is applied to the owner by calling `SetWorldTransform`.
    */
   void _updateActorTransform();
+
+  /**
+   * Updates the transform of the owning actor.
+   *
+   * @param rotation The rotation component
+   * @param translation The translation component
+   */
+  void _updateActorTransform(
+      const glm::dmat3& rotation,
+      const glm::dvec3& translation);
 
   /**
    * Updates the `Longitude`, `Latitude` and `Height` properties
@@ -315,6 +336,13 @@ private:
    * (absolute and relative location) of this component.
    */
   void _debugLogState();
+
+  /**
+   * Whether an update of the actor transform is currently in progress,
+   * and further calls that are issued by HandleActorTransformUpdated
+   * should be ignored
+   */
+  bool _updatingActorTransform;
 
   // TODO GEOREF_REFACTORING
   // This is currently no longer used, but removing this messes up

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -172,6 +172,12 @@ public:
   UFUNCTION()
   void HandleGeoreferenceUpdated();
 
+  /**
+   * Initializes the component. Occurs at level startup or actor spawn. 
+   * Requires component to be registered, and bWantsInitializeComponent to be true.
+   */
+  void InitializeComponent() override;
+
 protected:
   // Called when the game starts
   virtual bool MoveComponentImpl(
@@ -187,7 +193,7 @@ protected:
    * been initialized, including those loaded from config.
    */
   void PostInitProperties() override;
-
+  
 #if WITH_EDITOR
   virtual void
   PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -56,37 +56,37 @@ public:
   bool TeleportWhenUpdatingTransform = true;
 
   /**
-   * The latitude in degrees of the Georeference of this component, in the range [-90, 90]
+   * The latitude in degrees of this component, in the range [-90, 90]
    */
   UPROPERTY(EditAnywhere, Category = "Cesium", meta = (ClampMin = -90.0, ClampMax = 90.0))
   double Latitude = 0.0;
 
   /**
-   * The longitude in degrees of the Georeference of this component, in the range [-180, 180]
+   * The longitude in degrees of this component, in the range [-180, 180]
    */
   UPROPERTY(EditAnywhere, Category = "Cesium", meta = (ClampMin = -180.0, ClampMax = 180.0))
   double Longitude = 0.0;
 
   /**
-   * The height in meters (above the ellipsoid) of the Georeference of this component.
+   * The height in meters (above the ellipsoid) of this component.
    */
   UPROPERTY(EditAnywhere, Category = "Cesium")
   double Height = 0.0;
 
   /**
-   * The Earth-Centered Earth-Fixed X-coordinate of the Georeference of this component.
+   * The Earth-Centered Earth-Fixed X-coordinate of this component.
    */
   UPROPERTY(EditAnywhere, Category = "Cesium")
   double ECEF_X = 0.0;
 
   /**
-   * The Earth-Centered Earth-Fixed Y-coordinate of the Georeference of this component.
+   * The Earth-Centered Earth-Fixed Y-coordinate of this component.
    */
   UPROPERTY(EditAnywhere, Category = "Cesium")
   double ECEF_Y = 0.0;
 
   /**
-   * The Earth-Centered Earth-Fixed Z-coordinate of the Georeference of this component.
+   * The Earth-Centered Earth-Fixed Z-coordinate of this component.
    */
   UPROPERTY(EditAnywhere, Category = "Cesium")
   double ECEF_Z = 0.0;

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -129,6 +129,14 @@ public:
       bool MaintainRelativeOrientation = true);
 
   /**
+   * Returns the longitude in degrees (x), latitude in degrees (y),
+   * and height in meters (z) of the actor, downcasted to a
+   * single-precision floating point vector.
+   */
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  FVector InaccurateGetLongitudeLatitudeHeight() const;
+
+  /**
    * Move the actor to the specified Earth-Centered, Earth-Fixed (ECEF)
    * coordinates.
    */
@@ -144,6 +152,14 @@ public:
   void InaccurateMoveToECEF(
       const FVector& TargetEcef,
       bool MaintainRelativeOrientation = true);
+
+  /**
+   * Returns the Earth-Centered, Earth-Fixed (ECEF)
+   * coordinates of the actor, downcasted to a
+   * single-precision floating point vector.
+   */
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  FVector InaccurateGetECEF() const;
 
   /**
    * Called by owner actor on position shifting. The Component should update

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -145,8 +145,10 @@ public:
       const FVector& TargetEcef,
       bool MaintainRelativeOrientation = true);
 
-  // TODO Comment (or rather remove it - only used in CesiumGlobeAnchorParent!)
-  void SetAutoSnapToEastSouthUp(bool bValue);
+  // TODO GEOREF_REFACTORING 
+  // This was only used in CesiumGlobeAnchorParent (deprecated)
+  // In all other cases, the flag had always been "false"
+  //void SetAutoSnapToEastSouthUp(bool bValue);
 
   /**
    * Called by owner actor on position shifting. The Component should update
@@ -236,7 +238,7 @@ protected:
    * When an ECEF coordinate is modified, it calls `MoveToECEF` with the
    * new values.
    *
-   * When the georeference is about to be modified, then this will
+   * When the georeference has been be modified, then this will
    * attach the `HandleGeoreferenceUpdated` callback to the
    * `OnGeoreferenceUpdated` delegate of the new georeference,
    * and call `_updateActorTransform` to take the new georeference
@@ -310,13 +312,16 @@ private:
    *
    * This will use the (high-precision) `ECEF_X`, `ECEF_Y`, and `ECEF_Z`
    * coordinates of this instance, as well as the rotation component of
-   * the current actor transform, to compute an updated transform matrix
-   * that is applied to the owner by calling `SetWorldTransform`.
+   * the current actor transform, and pass them to 
+   * `_updateActorTransform(rotation, translation)`
    */
   void _updateActorTransform();
 
   /**
    * Updates the transform of the owning actor.
+   *
+   * This will compute an updated transform matrix that is applied 
+   * to the owner by calling `SetWorldTransform`.
    *
    * @param rotation The rotation component
    * @param translation The translation component
@@ -352,6 +357,9 @@ private:
   double _actorToECEF_Array[16];
   glm::dmat4& _actorToECEF = *(glm::dmat4*)_actorToECEF_Array;
 
+  // TODO GEOREF_REFACTORING
+  // This was only set to "true" from CesiumGlobeAnchorParent (deprecated)
+  // In all other cases, the flag had always been "false"
   UPROPERTY()
   bool _autoSnapToEastSouthUp;
 };

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -187,31 +187,15 @@ protected:
 
 private:
   void _initGeoreference();
-  void _initWorldOriginLocation();
 
+  void _updateFromActor();
   glm::dvec3 _getRelativeLocationFromActor();
-  glm::dvec3 _getAbsoluteLocationFromActor();
-
-  glm::dvec3 _computeEcef();
 
   void _updateActorTransform();
 
-  void _updateRelativeLocationFromActor();
 
   void _setECEF(const glm::dvec3& targetEcef, bool maintainRelativeOrientation);
-  
   void _updateDisplayLongitudeLatitudeHeight();
-  void _updateDisplayECEF();
-
-  /**
-   * The position of the world origin, as of this->GetWorld()->OriginLocation
-   */
-  glm::dvec3 _worldOriginLocation;
-
-  /**
-   * The relative location of the actor, as of ownerRoot->GetComponentLocation()
-   */
-  glm::dvec3 _relativeLocation;
 
   void _logState();
 

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -56,45 +56,39 @@ public:
   bool TeleportWhenUpdatingTransform = true;
 
   /**
-   * The WGS84 latitude in degrees of this actor, in the range [-90, 90]
+   * The latitude in degrees of the Georeference of this component, in the range [-90, 90]
    */
-  UPROPERTY(
-      EditAnywhere,
-      Category = "Cesium",
-      meta = (ClampMin = -90.0, ClampMax = 90.0))
+  UPROPERTY(VisibleAnywhere, Category = "Cesium", meta = (ClampMin = -90.0, ClampMax = 90.0))
   double Latitude = 0.0;
 
   /**
-   * The WGS84 longitude in degrees of this actor, in the range [-180, 180]
+   * The longitude in degrees of the Georeference of this component, in the range [-180, 180]
    */
-  UPROPERTY(
-      EditAnywhere,
-      Category = "Cesium",
-      meta = (ClampMin = -180.0, ClampMax = 180.0))
+  UPROPERTY(VisibleAnywhere, Category = "Cesium", meta = (ClampMin = -180.0, ClampMax = 180.0))
   double Longitude = 0.0;
 
   /**
-   * The height in meters (above the WGS84 ellipsoid) of this actor.
+   * The height in meters (above the ellipsoid) of the Georeference of this component.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium")
+  UPROPERTY(VisibleAnywhere, Category = "Cesium")
   double Height = 0.0;
 
   /**
-   * The Earth-Centered Earth-Fixed X-coordinate of this actor.
+   * The Earth-Centered Earth-Fixed X-coordinate of the Georeference of this component.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium")
+  UPROPERTY(VisibleAnywhere, Category = "Cesium")
   double ECEF_X = 0.0;
 
   /**
-   * The Earth-Centered Earth-Fixed Y-coordinate of this actor.
+   * The Earth-Centered Earth-Fixed Y-coordinate of the Georeference of this component.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium")
+  UPROPERTY(VisibleAnywhere, Category = "Cesium")
   double ECEF_Y = 0.0;
 
   /**
-   * The Earth-Centered Earth-Fixed Z-coordinate of this actor.
+   * The Earth-Centered Earth-Fixed Z-coordinate of the Georeference of this component.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium")
+  UPROPERTY(VisibleAnywhere, Category = "Cesium")
   double ECEF_Z = 0.0;
 
   /**
@@ -111,39 +105,48 @@ public:
   UFUNCTION(BlueprintCallable, CallInEditor, Category = "Cesium")
   void SnapToEastSouthUp();
 
-  /**
-   * Move the actor to the specified WGS84 longitude in degrees (x), latitude
-   * in degrees (y), and height in meters (z).
-   */
-  void MoveToLongitudeLatitudeHeight(
-      const glm::dvec3& TargetLongitudeLatitudeHeight,
-      bool MaintainRelativeOrientation = true);
 
   /**
    * Move the actor to the specified WGS84 longitude in degrees (x), latitude
    * in degrees (y), and height in meters (z).
    */
-  UFUNCTION(BlueprintCallable, Category = "Cesium")
-  void InaccurateMoveToLongitudeLatitudeHeight(
-      const FVector& TargetLongitudeLatitudeHeight,
-      bool MaintainRelativeOrientation = true);
+  // TODO GEOREF_REFACTORING This was only used in GlobeAnchorPanrent, 
+  // and should be removed
+  //void MoveToLongitudeLatitudeHeight(
+  //    const glm::dvec3& TargetLongitudeLatitudeHeight,
+  //    bool MaintainRelativeOrientation = true);
+
+  /**
+   * Move the actor to the specified WGS84 longitude in degrees (x), latitude
+   * in degrees (y), and height in meters (z).
+   */
+  // TODO GEOREF_REFACTORING This was only used in GlobeAnchorPanrent, 
+  // and should be removed
+  //UFUNCTION(BlueprintCallable, Category = "Cesium")
+  //void InaccurateMoveToLongitudeLatitudeHeight(
+  //    const FVector& TargetLongitudeLatitudeHeight,
+  //    bool MaintainRelativeOrientation = true);
 
   /**
    * Move the actor to the specified Earth-Centered, Earth-Fixed (ECEF)
    * coordinates.
    */
-  void MoveToECEF(
-      const glm::dvec3& TargetEcef,
-      bool MaintainRelativeOrientation = true);
+  // TODO GEOREF_REFACTORING This was not used at all. Movement should
+  // be done on the Georeference
+  //void MoveToECEF(
+  //    const glm::dvec3& TargetEcef,
+  //    bool MaintainRelativeOrientation = true);
 
   /**
    * Move the actor to the specified Earth-Centered, Earth-Fixed (ECEF)
    * coordinates.
    */
-  UFUNCTION(BlueprintCallable, Category = "Cesium")
-  void InaccurateMoveToECEF(
-      const FVector& TargetEcef,
-      bool MaintainRelativeOrientation = true);
+  // TODO GEOREF_REFACTORING This was not used at all. Movement should
+  // be done on the Georeference
+  //UFUNCTION(BlueprintCallable, Category = "Cesium")
+  //void InaccurateMoveToECEF(
+  //    const FVector& TargetEcef,
+  //    bool MaintainRelativeOrientation = true);
 
   /**
    * Delegate implementation to recieve a notification when the owner's root

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -292,7 +292,9 @@ private:
    * properties, and call `_updateActorTransform`.
    *
    * @param targetEcef The ECEF coordinates.
-   * @param maintainRelativeOrientation TODO Explain that...
+   * @param maintainRelativeOrientation Whether the actor should be
+   * rotated during this movement, so that the orientation relative
+   * to the earth surface remains the same.
    */
   void _setECEF(const glm::dvec3& targetEcef, bool maintainRelativeOrientation);
 
@@ -370,13 +372,13 @@ private:
   // This is currently no longer used, but removing this messes up
   // the deserialization (unless we handle different versions)
   // Note: this is done to allow Unreal to recognize and serialize _actorToECEF
-  //UPROPERTY()
-  //double _actorToECEF_Array[16];
-  //glm::dmat4& _actorToECEF = *(glm::dmat4*)_actorToECEF_Array;
+  // UPROPERTY()
+  // double _actorToECEF_Array[16];
+  // glm::dmat4& _actorToECEF = *(glm::dmat4*)_actorToECEF_Array;
 
   // TODO GEOREF_REFACTORING
   // This was only set to "true" from CesiumGlobeAnchorParent (deprecated)
   // In all other cases, the flag had always been "false"
-  //UPROPERTY()
-  //bool _autoSnapToEastSouthUp;
+  // UPROPERTY()
+  // bool _autoSnapToEastSouthUp;
 };

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -303,6 +303,12 @@ private:
   glm::dvec3 _computeRelativeLocation(const glm::dvec3& ecef);
 
   /**
+   * Computes the normal of the ellipsoid, for the given ECEF position,
+   * and returns it in the absolute unreal coordinate system
+   */
+  glm::dvec3 _computeEllipsoidNormalUnreal(const glm::dvec3& ecef);
+
+  /**
    * Updates the transform of the owning actor.
    *
    * This is intended to be called when the underlying Georeference was

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -195,7 +195,7 @@ protected:
    * Called when a component is created (not loaded).
    * This can happen in the editor or during gameplay.
    *
-   * This is overrideen for initializing the Georeference by calling
+   * This is overriden for initializing the Georeference by calling
    * _initGeoreference. This indeed seems to be called only exactly
    * once, when the component is created in the editor.
    */
@@ -205,7 +205,7 @@ protected:
    * Do any object-specific cleanup required immediately after
    * loading an object.
    *
-   * This is overrideen for initializing the Georeference by calling
+   * This is overriden for initializing the Georeference by calling
    * _initGeoreference. This indeed seems to  be called only exactly
    * once, when the component is loaded as part of a level in the editor.
    */

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -168,6 +168,9 @@ public:
       ETeleportType Teleport) override;
 
   virtual void OnRegister() override;
+  virtual void OnComponentCreated() override;
+  virtual void OnAttachmentChanged() override;
+  virtual void PostLoad() override;
 
   UFUNCTION()
   void HandleGeoreferenceUpdated();
@@ -210,6 +213,8 @@ private:
   void _setECEF(const glm::dvec3& targetEcef, bool maintainRelativeOrientation);
   void _updateDisplayLongitudeLatitudeHeight();
   void _updateDisplayECEF();
+
+  void _initGeoreference();
 
   // TODO GEOREF_REFACTORING I'm somewhat (but not entirely) sure
   // that these properties are redundant and/or not updated when

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -192,10 +192,7 @@ private:
   glm::dvec3 _getRelativeLocationFromActor();
   glm::dvec3 _getAbsoluteLocationFromActor();
 
-  void _updateActorToECEF();
-
-  glm::dmat4 _computeActorToUnrealRelativeWorldTransform();
-  void _applyTransformToActor(const glm::dmat4& actorToUnrealRelativeWorldTransform);
+  glm::dvec3 _computeEcef();
 
   void _updateActorTransform();
 

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -145,11 +145,6 @@ public:
       const FVector& TargetEcef,
       bool MaintainRelativeOrientation = true);
 
-  // TODO GEOREF_REFACTORING 
-  // This was only used in CesiumGlobeAnchorParent (deprecated)
-  // In all other cases, the flag had always been "false"
-  //void SetAutoSnapToEastSouthUp(bool bValue);
-
   /**
    * Called by owner actor on position shifting. The Component should update
    * all relevant data structures to reflect new actor location.
@@ -302,18 +297,18 @@ private:
   void _setECEF(const glm::dvec3& targetEcef, bool maintainRelativeOrientation);
 
   /**
-   * Computes the relative location, from the current ECEF location
+   * Computes the relative location, from the given ECEF location
    * and the world origin location.
    */
-  glm::dvec3 _computeRelativeLocation();
+  glm::dvec3 _computeRelativeLocation(const glm::dvec3& ecef);
 
   /**
    * Updates the transform of the owning actor.
    *
    * This is intended to be called when the underlying Georeference was
-   * updated. It will use the (high-precision) `ECEF_X`, `ECEF_Y`, and 
-   * `ECEF_Z` coordinates of this instance, as well as the rotation 
-   * component of the current actor transform, and pass them to 
+   * updated. It will use the (high-precision) `ECEF_X`, `ECEF_Y`, and
+   * `ECEF_Z` coordinates of this instance, as well as the rotation
+   * component of the current actor transform, and pass them to
    * `_updateActorTransform(rotation, translation)`
    */
   void _updateActorTransform();
@@ -321,7 +316,7 @@ private:
   /**
    * Updates the transform of the owning actor.
    *
-   * This will compute an updated transform matrix that is applied 
+   * This will compute an updated transform matrix that is applied
    * to the owner by calling `SetWorldTransform`.
    *
    * @param rotation The rotation component
@@ -352,15 +347,15 @@ private:
 
   /**
    * The current ECEF coordinates.
-   * 
+   *
    * This reflects the `ECEF_X`, `ECEF_Y`, and `ECEF_Z` properties and is
    * updated whenever `_setECEF` is called.
-   * 
-   * It is only used for tracking a change in the ECEF properties, so 
+   *
+   * It is only used for tracking a change in the ECEF properties, so
    * that when `_setECEF` is called due to a change in the editor
    * and `maintainRelativeOrientation` is `true`, the orientation
    * can be updated based on this (previous) ECEF position, before
-   * it is assigned with the new `ECEF_X`, `ECEF_Y`, and `ECEF_Z` 
+   * it is assigned with the new `ECEF_X`, `ECEF_Y`, and `ECEF_Z`
    * property values.
    */
   glm::dvec3 _currentEcef;

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -310,9 +310,10 @@ private:
   /**
    * Updates the transform of the owning actor.
    *
-   * This will use the (high-precision) `ECEF_X`, `ECEF_Y`, and `ECEF_Z`
-   * coordinates of this instance, as well as the rotation component of
-   * the current actor transform, and pass them to 
+   * This is intended to be called when the underlying Georeference was
+   * updated. It will use the (high-precision) `ECEF_X`, `ECEF_Y`, and 
+   * `ECEF_Z` coordinates of this instance, as well as the rotation 
+   * component of the current actor transform, and pass them to 
    * `_updateActorTransform(rotation, translation)`
    */
   void _updateActorTransform();
@@ -348,6 +349,21 @@ private:
    * should be ignored
    */
   bool _updatingActorTransform;
+
+  /**
+   * The current ECEF coordinates.
+   * 
+   * This reflects the `ECEF_X`, `ECEF_Y`, and `ECEF_Z` properties and is
+   * updated whenever `_setECEF` is called.
+   * 
+   * It is only used for tracking a change in the ECEF properties, so 
+   * that when `_setECEF` is called due to a change in the editor
+   * and `maintainRelativeOrientation` is `true`, the orientation
+   * can be updated based on this (previous) ECEF position, before
+   * it is assigned with the new `ECEF_X`, `ECEF_Y`, and `ECEF_Z` 
+   * property values.
+   */
+  glm::dvec3 _currentEcef;
 
   // TODO GEOREF_REFACTORING
   // This is currently no longer used, but removing this messes up

--- a/Source/CesiumRuntime/Public/GeoTransforms.h
+++ b/Source/CesiumRuntime/Public/GeoTransforms.h
@@ -32,10 +32,13 @@ public:
   }
 
   /**
-   * @brief Creates a new instance
+   * @brief Creates a new instance.
+   *
+   * The center position is the position of the origin of the
+   * local coordinate system that is established by this instance.
    *
    * @param ellipsoid The ellipsoid to use for the georeferenced coordinates
-   * @param center The center position (TODO Explain...)
+   * @param center The center position.
    */
   GeoTransforms(
       const CesiumGeospatial::Ellipsoid& ellipsoid,
@@ -65,20 +68,12 @@ public:
   /**
    * @brief Set the center position of this instance
    *
-   * @param center The center position (TODO Explain...)
+   * The center position is the position of the origin of the
+   * local coordinate system that is established by this instance.
+   *
+   * @param center The center position.
    */
   void setCenter(const glm::dvec3& center) noexcept;
-
-  /**
-   * @brief Returns the center of this instance
-   *
-   * @return The center
-   */
-  /* // TODO Not required yet?
-  const glm::dvec3& getCenter() const noexcept {
-    return this->_center;
-  }
-  */
 
   /**
    * @brief Set the ellipsoid of this instance
@@ -86,17 +81,6 @@ public:
    * @param ellipsoid The ellipsoid
    */
   void setEllipsoid(const CesiumGeospatial::Ellipsoid& ellipsoid) noexcept;
-
-  /**
-   * @brief Returns the ellipsoid of this instance
-   *
-   * @return The ellipsoid
-   */
-  /* // TODO Not required yet?
-  const CesiumGeospatial::Ellipsoid& getEllipsoid() const noexcept {
-    return this->_ellipsoid;
-  }
-  */
 
   /**
    * Transforms the given longitude in degrees (x), latitude in
@@ -259,8 +243,6 @@ public:
 private:
   /**
    * @brief Creates a new instance (for copy constructor).
-   * TODO The params are all fields. I think this is NOT auto-generated
-   * by the compiler when there is another constructor...
    */
   GeoTransforms(
       const CesiumGeospatial::Ellipsoid& ellipsoid,


### PR DESCRIPTION
Potentially fixes #422, #494, #498
Copying @javagl's notes:
- The `CesiumGeoreferenceComponent` now an ActorComponent, and no longer a SceneComponent. So it does not have a "transform" on its own. (This transform had to be ignored in the old state).
- It's now using the Ellipsoid of the GeoRef instead of the fixed WGS84
- The representation of the "position" is now solely encoded in the ECEF_X/Y/Z properties. Originally, it had at least 3 (but I think maybe even 5 or 6) representations of "the position", and keeping them consistent was hard.

The goal is to merge into `bp-function-library` after verifying a) correct behavior of georeferenced objects, and b) backwards compatibility with georeferenced actors created with the old version of this component.

@nithinp7 mentioned some issues with the sun sky, there is another PR #497 which refactors the `CesiumSunSky`, which will get merged into `bp-function-library`. Probably best to wait to debug SunSky specific issues until this PR and #497 get merged into `bp-function-library`.