### PR TITLE
Get camera parameters using GetCameraViewPoint and GetFOVAngle instead of ViewTarget

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -817,10 +817,10 @@ ACesium3DTileset::GetPlayerCamera() const {
     return std::optional<UnrealCameraParameters>();
   }
 
-  const FMinimalViewInfo& pov = pCameraManager->ViewTarget.POV;
-  const FVector& location = pov.Location;
-  const FRotator& rotation = pCameraManager->ViewTarget.POV.Rotation;
-  double fov = pov.FOV;
+  FVector location;
+  FRotator rotation;
+  pCameraManager->GetCameraViewPoint(location, rotation);
+  double fov = pCameraManager->GetFOVAngle();
 
   FVector2D size;
   pViewport->GetViewportSize(size);


### PR DESCRIPTION
Fixes #487 
~(maybe)~ (the original reporter has confirmed it fixes the issue)
