### PR TITLE
Small fixes to the quick-add panel 

### DIFF
--- a/Source/CesiumEditor/Private/CesiumPanel.cpp
+++ b/Source/CesiumEditor/Private/CesiumPanel.cpp
@@ -90,7 +90,7 @@ TSharedRef<SWidget> CesiumPanel::LoginPanel() {
 TSharedRef<SWidget> CesiumPanel::MainIonQuickAddPanel() {
   TSharedPtr<IonQuickAddPanel> quickAddPanel =
       SNew(IonQuickAddPanel)
-          .Title(FText::FromString("Add Cesium ion Assets"))
+          .Title(FText::FromString("Quick Add Cesium ion Assets"))
           .Visibility_Lambda([]() {
             return isSignedIn() ? EVisibility::Visible : EVisibility::Collapsed;
           });
@@ -140,7 +140,7 @@ TSharedRef<SWidget> CesiumPanel::MainIonQuickAddPanel() {
 
 TSharedRef<SWidget> CesiumPanel::BasicQuickAddPanel() {
   TSharedPtr<IonQuickAddPanel> quickAddPanel =
-      SNew(IonQuickAddPanel).Title(FText::FromString("Add basic Actors"));
+      SNew(IonQuickAddPanel).Title(FText::FromString("Quick Add Basic Actors"));
   quickAddPanel->AddItem(
       {QuickAddItemType::TILESET,
        "Blank 3D Tiles Tileset",

--- a/Source/CesiumEditor/Private/IonQuickAddPanel.cpp
+++ b/Source/CesiumEditor/Private/IonQuickAddPanel.cpp
@@ -234,6 +234,7 @@ void IonQuickAddPanel::AddCesiumSunSkyToLevel() {
         ACesiumGeoreference::GetDefaultForActor(pActor);
     if (pGeoreference) {
       pGeoreference->SunSky = pActor;
+      pGeoreference->UpdateGeoreference();
     }
 
     GEditor->SelectNone(true, false);


### PR DESCRIPTION
fixes #532 

The SunSky was not initializing to the correct georeference when spawned through the quick add panel. I'm sure the SunSky handling will be improved drastically once the georeference and sunsky refactoring are done, but here is a fix for now.

@argallegos Can you review?