### PR TITLE
Use C++14 instead of 17 for CesiumRuntime and CesiumEditor.

### DIFF
--- a/Source/CesiumEditor/CesiumEditor.Build.cs
+++ b/Source/CesiumEditor/CesiumEditor.Build.cs
@@ -21,7 +21,6 @@ public class CesiumEditor : ModuleRules
 
         PrivateIncludePaths.AddRange(
             new string[] {
-                Path.Combine(ModuleDirectory, "../ThirdParty/include")
             }
         );
 
@@ -131,6 +130,6 @@ public class CesiumEditor : ModuleRules
 
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
         PrivatePCHHeaderFile = "Private/PCH.h";
-        CppStandard = CppStandardVersion.Cpp17;
+        CppStandard = CppStandardVersion.Cpp14;
     }
 }

--- a/Source/CesiumEditor/Private/PCH.h
+++ b/Source/CesiumEditor/Private/PCH.h
@@ -9,7 +9,7 @@
 // VS2017. See https://github.com/akrzemi1/Optional/issues/57 and
 // https://answers.unrealengine.com/questions/607946/anonymous-union-with-none-trivial-type.html
 #ifdef _MSC_VER
-#if _MSC_VER < 1920
+#if _MSC_VER < 1920 || _MSVC_LANG < 201703L
 #pragma warning(push)
 #pragma warning(disable : 4583)
 #pragma warning(disable : 4582)

--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -14,7 +14,8 @@ public class CesiumRuntime : ModuleRules
 
         PublicIncludePaths.AddRange(
             new string[] {
-                Path.Combine(ModuleDirectory, "../ThirdParty/include")
+                Path.Combine(ModuleDirectory, "../ThirdParty/include"),
+                Path.Combine(ModuleDirectory, "../ThirdParty/include/Cpp14Compatibility")
             }
         );
 
@@ -174,7 +175,7 @@ public class CesiumRuntime : ModuleRules
 
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
         PrivatePCHHeaderFile = "Private/PCH.h";
-        CppStandard = CppStandardVersion.Cpp17;
+        CppStandard = CppStandardVersion.Cpp14;
         bEnableExceptions = true;
     }
 }

--- a/Source/CesiumRuntime/Private/PCH.h
+++ b/Source/CesiumRuntime/Private/PCH.h
@@ -9,7 +9,7 @@
 // VS2017. See https://github.com/akrzemi1/Optional/issues/57 and
 // https://answers.unrealengine.com/questions/607946/anonymous-union-with-none-trivial-type.html
 #ifdef _MSC_VER
-#if _MSC_VER < 1920
+#if _MSC_VER < 1920 || _MSVC_LANG < 201703L
 #pragma warning(push)
 #pragma warning(disable : 4583)
 #pragma warning(disable : 4582)

--- a/Source/CesiumRuntime/Private/SpdlogUnrealLoggerSink.cpp
+++ b/Source/CesiumRuntime/Private/SpdlogUnrealLoggerSink.cpp
@@ -3,6 +3,7 @@
 #include "SpdlogUnrealLoggerSink.h"
 #include "CesiumRuntime.h"
 #include "CoreMinimal.h"
+#include <mutex>
 
 void SpdlogUnrealLoggerSink::sink_it_(const spdlog::details::log_msg& msg) {
   switch (msg.level) {
@@ -36,7 +37,7 @@ FString SpdlogUnrealLoggerSink::formatMessage(
   // Frustratingly, spdlog::formatter isn't thread safe. So even though our sink
   // itself doesn't need to be protected by a mutex, the formatter does.
   // See https://github.com/gabime/spdlog/issues/897
-  std::scoped_lock<std::mutex> lock(this->_formatMutex);
+  std::lock_guard<std::mutex> lock(this->_formatMutex);
 
   spdlog::memory_buf_t formatted;
   this->formatter_->format(msg, formatted);

--- a/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
+++ b/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
@@ -52,7 +52,7 @@ public:
 
   virtual gsl::span<const std::byte> data() const override {
     const TArray<uint8>& content = this->_pResponse->GetContent();
-    return gsl::span(
+    return gsl::span<const std::byte>(
         reinterpret_cast<const std::byte*>(content.GetData()),
         content.Num());
   }

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 # Rename sqlite3* symbols to cesium_sqlite3* so they don't conflict with UE's sqlite3,
 # which has a bunch of limitations and is not considered public.
 set(PRIVATE_CESIUM_SQLITE ON)
-set(CESIUM_CXX_STANDARD 14)
+set(CESIUM_CXX_STANDARD 14 CACHE STRING "The C++ version standard to use. Supports 14 or 17. This option will be removed in the future and cesium-native will only support C++17." FORCE)
 
 set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_LIST_DIR}/../Source/ThirdParty)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 # Rename sqlite3* symbols to cesium_sqlite3* so they don't conflict with UE's sqlite3,
 # which has a bunch of limitations and is not considered public.
 set(PRIVATE_CESIUM_SQLITE ON)
+set(CESIUM_CXX_STANDARD 14)
 
 set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_LIST_DIR}/../Source/ThirdParty)
@@ -40,7 +41,7 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cesium-native/extern/stb/stb_image_res
 
 # Unreal Engine doesn't include MikkTSpace on Android.
 # So add our own.
-if (ANDROID) 
+if (ANDROID)
     add_library(MikkTSpace MikkTSpace/mikktspace.c)
     set_target_properties(MikkTSpace PROPERTIES PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/MikkTSpace/mikktspace.h")
     target_include_directories(MikkTSpace PUBLIC MikkTSpace)


### PR DESCRIPTION
Requires CesiumGS/cesium-native#280

Currently this PR uses C++14 for all platforms. I _may_ change back to C++17 for Windows, macOS, and Linux and only use C++14 for Android (and eventually iOS), but that's still TBD.