### PR TITLE
Sneakily force C++17 mode in Android builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,8 @@ jobs:
     - npm install
     - npm run format -- --dry-run -Werror
   - stage: Build OS Packages
-    name: Windows + VS2017
+    name: Windows
     os: windows
-    cache:
-      timeout: 1000
-      directories:
-      - /C/Program\ Files/Epic\ Games/UE_4.26
-      - /C/Program\ Files\ \(x86\)/Epic\ Games/Launcher
     install:
     - choco install 7zip.portable
     - choco install python --version 3.9.2
@@ -51,8 +46,6 @@ jobs:
     cache:
       timeout: 1000
       directories:
-      - /C/Program\ Files/Epic\ Games/UE_4.26
-      - /C/Program\ Files\ \(x86\)/Epic\ Games/Launcher
       - $HOME/android-ndk-r21e
     install:
     - choco install 7zip.portable
@@ -70,24 +63,18 @@ jobs:
     - export NDKROOT=$ANDROID_NDK_ROOT
     - export CESIUM_UNREAL_VERSION=$(git describe)
     - export BUILD_CESIUM_UNREAL_PACKAGE_NAME=CesiumForUnreal-android-${CESIUM_UNREAL_VERSION}
-    - mkdir -p extern/build-win64
     - mkdir -p extern/build-android
-    - cd extern/build-win64
-    - cmake .. -A x64
-    - cd ../../extern/build-android
+    - cd extern/build-android
     - cmake .. -G Ninja -DCMAKE_TOOLCHAIN_FILE="unreal-android-toolchain.cmake" -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release
     - cd ../..
     script:
-    - cd extern/build-win64
-    - cmake --build . --config Release --target install -- /maxcpucount:4
-    - cd ../../extern/build-android
+    - cd extern/build-android
     - cmake --build . --config Release --target install
     - cd ../..
     - rm -rf extern
     - export CLONEDIR=$PWD
     - cd /c/Program\ Files/Epic\ Games/UE_4.26/Engine/Build/BatchFiles
-    - ./RunUAT.bat BuildPlugin -Plugin="$CLONEDIR/CesiumForUnreal.uplugin" -Package="$CLONEDIR/../packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Win64+Android
-    - cat "C:\Users\travis\AppData\Roaming\Unreal Engine\AutomationTool\Logs\C+Program+Files+Epic+Games+UE_4.26\UBT-UE4Game-Android-Development.txt"
+    - ./RunUAT.bat BuildPlugin -Plugin="$CLONEDIR/CesiumForUnreal.uplugin" -Package="$CLONEDIR/../packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Android -NoHostPlatform
     - cd "$CLONEDIR/../packages"
     - 7z a ${BUILD_CESIUM_UNREAL_PACKAGE_NAME}.zip CesiumForUnreal/
     - aws s3 cp ${BUILD_CESIUM_UNREAL_PACKAGE_NAME}.zip s3://builds-cesium-unreal/

--- a/Source/CesiumEditor/CesiumEditor.Build.cs
+++ b/Source/CesiumEditor/CesiumEditor.Build.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 public class CesiumEditor : ModuleRules
 {
@@ -132,5 +133,24 @@ public class CesiumEditor : ModuleRules
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
         PrivatePCHHeaderFile = "Private/PCH.h";
         CppStandard = CppStandardVersion.Cpp17;
+
+        if (Target.Platform == UnrealTargetPlatform.Android &&
+            Target.Version.MajorVersion == 4 &&
+            Target.Version.MinorVersion == 26 &&
+            Target.Version.PatchVersion < 2)
+        {
+            // In UE versions prior to 4.26.2, the Unreal Build Tool on Android
+            // (AndroidToolChain.cs) ignores the CppStandard property and just
+            // always uses C++14. Our plugin can't be compiled with C++14.
+            //
+            // So this hack uses reflection to add an additional argument to
+            // the compiler command-line to force C++17 mode. Clang ignores all
+            // but the last `-std=` argument, so the `-std=c++14` added by the
+            // UBT is ignored.
+            Type type = Target.GetType();
+            FieldInfo innerField = type.GetField("Inner", BindingFlags.Instance | BindingFlags.NonPublic);
+            TargetRules inner = (TargetRules)innerField.GetValue(Target);
+            inner.AdditionalCompilerArguments += " -std=c++17";
+        }
     }
 }

--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -178,18 +178,23 @@ public class CesiumRuntime : ModuleRules
         CppStandard = CppStandardVersion.Cpp17;
         bEnableExceptions = true;
 
-        if (Target.Platform == UnrealTargetPlatform.Android)
+        if (Target.Platform == UnrealTargetPlatform.Android &&
+            Target.Version.MajorVersion == 4 &&
+            Target.Version.MinorVersion == 26 &&
+            Target.Version.PatchVersion < 2)
         {
-          // This line is just to force C++14 even on UE 4.262, so we can test what follows.
-          CppStandard = CppStandardVersion.Cpp14;
-
-          // Use reflection to force C++17 mode even though the UBT in UE
-          // versions prior to 4.26.2 ignore the CppStandard property
-          // and just always use C++14.
-          Type type = Target.GetType();
-          FieldInfo innerField = type.GetField("Inner", BindingFlags.Instance | BindingFlags.NonPublic);
-          TargetRules inner = (TargetRules)innerField.GetValue(Target);
-          inner.AdditionalCompilerArguments += " -std=c++17";
+            // In UE versions prior to 4.26.2, the Unreal Build Tool on Android
+            // (AndroidToolChain.cs) ignores the CppStandard property and just
+            // always uses C++14. Our plugin can't be compiled with C++14.
+            //
+            // So this hack uses reflection to add an additional argument to
+            // the compiler command-line to force C++17 mode. Clang ignores all
+            // but the last `-std=` argument, so the `-std=c++14` added by the
+            // UBT is ignored.
+            Type type = Target.GetType();
+            FieldInfo innerField = type.GetField("Inner", BindingFlags.Instance | BindingFlags.NonPublic);
+            TargetRules inner = (TargetRules)innerField.GetValue(Target);
+            inner.AdditionalCompilerArguments += " -std=c++17";
         }
-  }
+    }
 }

--- a/travis/travis-get-ue.sh
+++ b/travis/travis-get-ue.sh
@@ -1,16 +1,12 @@
-if [[ $TRAVIS_OS_NAME == "windows" && ! -d "/c/Program Files/Epic Games/UE_4.26" ]]
+if [[ $TRAVIS_OS_NAME == "windows" ]]
 then
     # Enable compression because disk space is limited on Travis.
     mkdir "C:\Program Files\Epic Games"
-    compact //c "//s:C:\Program Files\Epic Games"
-    mkdir "C:\Program Files (x86)\Epic Games"
-    compact //c "//s:C:\Program Files (x86)\Epic Games"
-    AWS_ACCESS_KEY_ID=${GOOGLE_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${GOOGLE_SECRET_ACCESS_KEY} aws s3 --endpoint-url https://storage.googleapis.com cp s3://cesium-unreal-engine/windows-2021-05-19/UE_4.26.zip .
-    7z x UE_4.26.zip "-oC:\Program Files\Epic Games"
-    rm UE_4.26.zip
-    AWS_ACCESS_KEY_ID=${GOOGLE_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${GOOGLE_SECRET_ACCESS_KEY} aws s3 --endpoint-url https://storage.googleapis.com cp s3://cesium-unreal-engine/windows-2021-05-07/Launcher.zip .
-    7z x Launcher.zip "-oC:\Program Files (x86)\Epic Games"
-    rm Launcher.zip
+    mkdir "C:\Program Files\Epic Games\UE_4.26"
+    compact //c "//s:C:\Program Files\Epic Games\UE_4.26"
+    AWS_ACCESS_KEY_ID=${GOOGLE_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${GOOGLE_SECRET_ACCESS_KEY} aws s3 --endpoint-url https://storage.googleapis.com cp s3://cesium-unreal-engine/windows-2021-07-12/UnrealEngine-4-26-0-minimal.zip .
+    7z x UnrealEngine-4-26-0-minimal.zip "-oC:\Program Files\Epic Games\UE_4.26"
+    rm UnrealEngine-4-26-0-minimal.zip
 elif [[ $TRAVIS_OS_NAME == "osx" ]]
 then
     aws s3 cp s3://cesium-unreal-engine/macos-2021-04-13/UE_4.26.tar.gz .


### PR DESCRIPTION
If you all loved my hacky approach to compiling cesium-native with C++14, wait til ya get a load of this! :laughing: 

So the problem is that, prior to UE 4.26.2, the Unreal Build Tool ignores the CppStandard option on the plugin and instead just always passes `-std=c++14` to clang. Well, after tracing through the `AndroidToolChain.cs` file in the UE source where the Android build process is implemented, I realized that there's an `AdditionalArguments` property passed into there on a `CompileEnvironment` object. And I also learned that clang, conveniently, doesn't care if you pass multiple -std=c++X arguments and it just uses the last one. So if I could just figure out how to set that `AdditionalArguments` property, we could force clang to compile in C++17 mode even though UE is trying to specify C++14.

Well, there might be control of that at the project level, but we don't control the project when Epic is building our plugin for the Marketplace (or when users are building our plugin, for that matter). But our plugin's .build.cs file receives a `ReadOnlyTargetRules` instance, and that instance has a `AdditionalCompilerArguments` property. Perfect! Except it's read-only. Hmmm...

Well, the `ReadOnlyTargetRules` has an `Inner` field which is the non-read-only `TargetRules` instance it wraps. And `TargetRules` has a read/write version of `AdditionalCompilerArguments`. Small problem: the Inner property is protected.

No problem, I'll just bust out my C# hacking skills (😆) and use reflection to read the protected property. And once I have that, I can add the `-std=c++17` to the `AdditionalCompilerArguments`. All from CesiumRuntime.Build.cs.

This PR is the result. And I think it works! I don't have a copy of UE 4.26.0 or .1 (I wrote https://udn.unrealengine.com/s/question/0D54z000073a47JCAQ/where-to-get-4260-or-4261 to try to get it), which I need in order to _really_ test this, but I mostly tested it by setting CppStandard to 14, and then overriding it with my cheeky hack. And it compiles with C++17 as expected!

Ok, who wants to be first in line to tell me this is a horrible idea?

Fixes #472