### PR TITLE
Added some basic automated tests

### DIFF
--- a/CesiumForUnreal.uplugin
+++ b/CesiumForUnreal.uplugin
@@ -42,6 +42,18 @@
 		{
 			"Name": "Water",
 			"Enabled": true
+		},
+		{
+			"Name": "EditorTests",
+			"Enabled": true
+		},
+ 		{
+			"Name": "FunctionalTestingEditor",
+			"Enabled": true
+		},
+		{
+			"Name": "RuntimeTests",
+			"Enabled": true
 		}
 	]
 }

--- a/Source/CesiumRuntime/Tests/CesiumAutomationCommon.h
+++ b/Source/CesiumRuntime/Tests/CesiumAutomationCommon.h
@@ -1,0 +1,11 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+
+#if WITH_AUTOMATION_TESTS
+
+DECLARE_LOG_CATEGORY_EXTERN(LogCesiumTests, Log, All);
+
+#endif // WITH_AUTOMATION_TESTS

--- a/Source/CesiumRuntime/Tests/CesiumFunctionalTestExample.cpp
+++ b/Source/CesiumRuntime/Tests/CesiumFunctionalTestExample.cpp
@@ -1,0 +1,41 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#include "Editor.h"
+#include "EditorModeManager.h"
+#include "Engine.h"
+#include "Misc/AutomationTest.h"
+
+#include "Tests/AutomationCommon.h"
+#include "Tests/AutomationEditorCommon.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+/*
+ * A trivial example of a functional test that just creates
+ * a new world and an actor.
+ */
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FCesiumFunctionalTestExample,
+    "Cesium.Examples.FunctionalTestExample",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter);
+
+bool FCesiumFunctionalTestExample::RunTest(const FString& Parameters) {
+  const FTransform IdentityTransform(FVector(0.0f, 0.0f, 0.0f));
+
+  UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+  ULevel* currentLevel = World->GetCurrentLevel();
+
+  UClass* sunSkyClass = LoadClass<AActor>(
+      nullptr,
+      TEXT("/CesiumForUnreal/CesiumSunSky.CesiumSunSky_C"));
+  AActor* sunSky =
+      GEditor->AddActor(currentLevel, sunSkyClass, IdentityTransform);
+  TestNotNull(TEXT("A CesiumSunSky instance could be created"), sunSky);
+
+  FAutomationEditorCommonUtils::CreateNewMap();
+  // GLevelEditorModeTools().MapChangeNotify();
+
+  return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/CesiumRuntime/Tests/CesiumGeoreferenceTests.cpp
+++ b/Source/CesiumRuntime/Tests/CesiumGeoreferenceTests.cpp
@@ -1,0 +1,177 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#include "Editor.h"
+#include "EditorModeManager.h"
+#include "Engine.h"
+#include "Misc/AutomationTest.h"
+
+#include "Tests/AutomationCommon.h"
+#include "Tests/AutomationEditorCommon.h"
+
+#include "CesiumTestClasses.h"
+
+#include <Cesium3DTileset.h>
+#include <GlobeAwareDefaultPawn.h>
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+//============================================================================
+
+/*
+ * A test for https://github.com/CesiumGS/cesium-unreal/issues/242 :
+ *
+ * - Creates a Tileset and adds it to the level
+ * - Expects the default Georererence to be created and valid
+ * - Deletes the Tileset and the Georeference
+ * - Expects the deleted objects to be invalid
+ * - Creates a second Tileset
+ * - Expects a new default Georeference to be created and valid
+ */
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FCesiumGeoreferenceAutoCreation,
+    "Cesium.Georeference.AutoCreation",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter);
+
+bool FCesiumGeoreferenceAutoCreation::RunTest(const FString& Parameters) {
+  const FTransform IdentityTransform(FVector(0.0f, 0.0f, 0.0f));
+
+  UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+  ULevel* currentLevel = World->GetCurrentLevel();
+
+  // TODO Each Error message will cause the test to fail - OUCH.
+  // We can work around that for now, by expecting the error
+  // message, but we certainly do NOT want to rely on certain
+  // error messages from cesium-native!
+  int32 occurrences = 0; // Means one or more times
+  AddExpectedError(
+      TEXT(".*Received status code 401 for asset response.*"),
+      EAutomationExpectedErrorFlags::Contains,
+      occurrences);
+
+  // Create a tileset, expect the default Georeference to be
+  // created, and then delete them both
+  {
+    AActor* tileset = GEditor->AddActor(
+        currentLevel,
+        ACesium3DTileset::StaticClass(),
+        IdentityTransform);
+    TestNotNull(TEXT("The Cesium3DTileset instance could be created"), tileset);
+
+    ACesiumGeoreference* georeference = FindObject<ACesiumGeoreference>(
+        currentLevel,
+        TEXT("CesiumGeoreferenceDefault"));
+    TestNotNull(
+        TEXT("The default CesiumGeoreference instance was created"),
+        georeference);
+    TestTrue(
+        TEXT("The default CesiumGeoreference instance is valid"),
+        IsValid(georeference));
+
+    World->DestroyActor(georeference);
+    TestFalse(
+        TEXT(
+            "After deletion, the default CesiumGeoreference instance is NOT valid"),
+        IsValid(georeference));
+
+    World->DestroyActor(tileset);
+    TestFalse(
+        TEXT("After deletion, the Cesium3DTileset instance is NOT valid"),
+        IsValid(tileset));
+  }
+
+  // Create a new tileset, and expect a new default
+  // Georeference to be created
+  {
+    AActor* secondTileset = GEditor->AddActor(
+        currentLevel,
+        ACesium3DTileset::StaticClass(),
+        IdentityTransform);
+    TestNotNull(
+        TEXT("The second Cesium3DTileset instance could be created"),
+        secondTileset);
+
+    // NOTE (TODO?) : We're relying on the default suffix "_0" for the name
+    // here!
+    ACesiumGeoreference* secondGeoreference = FindObject<ACesiumGeoreference>(
+        currentLevel,
+        TEXT("CesiumGeoreferenceDefault_0"));
+    TestNotNull(
+        TEXT("The second default CesiumGeoreference instance was created"),
+        secondGeoreference);
+    TestTrue(
+        TEXT("The second default CesiumGeoreference instance is valid"),
+        IsValid(secondGeoreference));
+  }
+
+  // Clean up by creating a new map.
+  // (TODO: Does this make sense?)
+  FAutomationEditorCommonUtils::CreateNewMap();
+  // GLevelEditorModeTools().MapChangeNotify();
+
+  return true;
+}
+
+//============================================================================
+
+/*
+ * A test for https://github.com/CesiumGS/cesium-unreal/issues/498
+ *
+ * - Spawns two Georeferenced actors at different locations
+ * - Checks that they indeed end up at their spawn location
+ *
+ */
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FCesiumGeoreferenceComponentSpawningTest,
+    "Cesium.Georeference.SpawningGeorefActors",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter);
+
+bool FCesiumGeoreferenceComponentSpawningTest::RunTest(
+    const FString& Parameters) {
+
+  UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+  ULevel* currentLevel = World->GetCurrentLevel();
+
+  {
+    const FVector expectedLocation0(100.0, 200.0f, 300.0f);
+    AActor* actor0 = GEditor->AddActor(
+        currentLevel,
+        ACesiumGeoreferenceComponentTestActor::StaticClass(),
+        FTransform(expectedLocation0));
+    TestNotNull(
+        TEXT(
+            "The CesiumGeoreferenceComponentTestActor instance 0 could be created"),
+        actor0);
+
+    const FVector expectedLocation1(400.0, 500.0f, 600.0f);
+    AActor* actor1 = GEditor->AddActor(
+        currentLevel,
+        ACesiumGeoreferenceComponentTestActor::StaticClass(),
+        FTransform(expectedLocation1));
+    TestNotNull(
+        TEXT(
+            "The CesiumGeoreferenceComponentTestActor instance 1 could be created"),
+        actor1);
+
+    const FVector actualLocation0 = actor0->GetTransform().GetLocation();
+    TestEqual(
+        TEXT(
+            "The CesiumGeoreferenceComponentTestActor instance 0 is at the expected location"),
+        actualLocation0,
+        expectedLocation0);
+
+    const FVector actualLocation1 = actor1->GetTransform().GetLocation();
+    TestEqual(
+        TEXT(
+            "The CesiumGeoreferenceComponentTestActor instance 1 is at the expected location"),
+        actualLocation1,
+        expectedLocation1);
+  }
+
+  // Clean up by creating a new map.
+  // (TODO: Does this make sense?)
+  FAutomationEditorCommonUtils::CreateNewMap();
+
+  return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/CesiumRuntime/Tests/CesiumOriginRebasing.spec.cpp
+++ b/Source/CesiumRuntime/Tests/CesiumOriginRebasing.spec.cpp
@@ -1,0 +1,67 @@
+
+#include "EditorModeManager.h"
+#include "Kismet/GameplayStatics.h"
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationCommon.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "Tests/AutomationEditorPromotionCommon.h"
+
+#include <CesiumGeoreference.h>
+#include <CesiumGeoreferenceComponent.h>
+#include <GlobeAwareDefaultPawn.h>
+
+class CesiumOriginRebasing {
+public:
+  CesiumOriginRebasing() {}
+  ~CesiumOriginRebasing() {}
+};
+
+BEGIN_DEFINE_SPEC(
+    CesiumOriginRebasingSpec,
+    "Cesium.Georeference.OriginRebasing",
+    EAutomationTestFlags::ProductFilter | EAutomationTestFlags::EditorContext)
+END_DEFINE_SPEC(CesiumOriginRebasingSpec)
+
+void CesiumOriginRebasingSpec::Define() {
+  Describe("When starting PIE", [this]() {
+    BeforeEach([this]() {
+      UWorld* editorWorld = FAutomationEditorCommonUtils::CreateNewMap();
+      ULevel* editorLevel = editorWorld->GetCurrentLevel();
+      AActor* editorPawn = GEditor->AddActor(
+          editorLevel,
+          AGlobeAwareDefaultPawn::StaticClass(),
+          FTransform(FVector(0.0, 0.0f, 0.0f)));
+      TestNotNull(
+          TEXT("The AGlobeAwareDefaultPawn instance could be created"),
+          editorPawn);
+
+      FEditorPromotionTestUtilities::StartPIE(true);
+    });
+
+    It("it should cause an origin rebasing when moving the pawn", [this]() {
+      FPlatformProcess::Sleep(1.0f);
+
+      UWorld* world = GEditor->PlayWorld;
+      TestNotNull(TEXT("The PIE world could be obtained"), world);
+
+      TArray<AActor*> ActorList;
+      UGameplayStatics::GetAllActorsOfClass(
+          world,
+          AGlobeAwareDefaultPawn::StaticClass(),
+          ActorList);
+
+      TestEqual(TEXT("There was one PIE pawn"), ActorList.Num(), 1);
+
+      // AActor* pawn = ActorList[0];
+      // TestNotNull(TEXT("The PIE pawn could be obtained"), pawn);
+      // pawn->SetActorLocation(FVector(100000.0f, 100000.0f, 100000.0f));
+
+      FPlatformProcess::Sleep(1.0f);
+    });
+
+    AfterEach([this]() {
+      FEditorPromotionTestUtilities::EndPIE();
+      FAutomationEditorCommonUtils::CreateNewMap();
+    });
+  });
+}

--- a/Source/CesiumRuntime/Tests/CesiumTestClasses.h
+++ b/Source/CesiumRuntime/Tests/CesiumTestClasses.h
@@ -1,0 +1,34 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include <CesiumGeoreferenceComponent.h>
+
+#include "CesiumTestClasses.generated.h"
+
+/**
+ * A trivial actor for tests, that has a GeoreferenceComponent
+ */
+UCLASS()
+class ACesiumGeoreferenceComponentTestActor : public AActor {
+  GENERATED_BODY()
+public:
+  ACesiumGeoreferenceComponentTestActor() {
+
+    RootComponent = CreateDefaultSubobject<USceneComponent>("Root");
+
+    _georeferenceComponent =
+        CreateDefaultSubobject<UCesiumGeoreferenceComponent>(
+            TEXT("Georeference"));
+
+    // NOTE: This call will no longer be necessary after the
+    // Georeference refactoring, because the GeoreferenceComponent
+    // then is only an actor component, and no scene component
+    _georeferenceComponent->SetupAttachment(RootComponent);
+  }
+
+  UPROPERTY(VisibleAnywhere)
+  UCesiumGeoreferenceComponent* _georeferenceComponent;
+};

--- a/Source/CesiumRuntime/Tests/CesiumUnitTestExample.cpp
+++ b/Source/CesiumRuntime/Tests/CesiumUnitTestExample.cpp
@@ -1,0 +1,54 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#include "CoreTypes.h"
+#include "Misc/AutomationTest.h"
+
+// TODO Is it OK to hop through paths to test private classes?
+#include "../Private/CesiumTransforms.h"
+
+#if WITH_DEV_AUTOMATION_TESTS
+
+/*
+ * A trivial example for unit/API tests that do not require any
+ * of the actual Unreal Editor infrastructure. These are
+ * essentially tests for objects that can be instantiated
+ * and where methods can be called, to check the pre- and
+ * postconditions.
+ */
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FCesiumUnitTestExample,
+    "Cesium.Examples.UnitTestExample",
+    EAutomationTestFlags::ApplicationContextMask |
+        EAutomationTestFlags::SmokeFilter)
+
+bool FCesiumUnitTestExample::RunTest(const FString& Parameters) {
+  // A trivial unit test for equality (that passes)
+  {
+    const double centimeters = 123.456;
+    const double actualMeters =
+        CesiumTransforms::centimetersToMeters * centimeters;
+    const double expectedMeters = 1.23456;
+
+    TestEqual(
+        TEXT("Converting centimeters to meters scaled with 0.01"),
+        actualMeters,
+        expectedMeters);
+  }
+
+  // A trivial unit test for equality (that INTENTIONALLY fails)
+  /*
+  {
+          const double centimeters = 123.456;
+          // INTENTIONALLY using the wrong factor here:
+          const double actualMeters = CesiumTransforms::metersToCentimeters *
+  centimeters; const double expectedMeters = 1.23456;
+
+          TestEqual(TEXT("Converting centimeters to meters, INTENTIONALLY
+  failing"), actualMeters, expectedMeters);
+  }
+  */
+  return true;
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS


### PR DESCRIPTION
First experiments with automated tests. 

Insights so far:

- Unit-testing C++ is a pain in the back
- Unit-testing Unreal code adds a whole new dimension of pain to that. Unbelievable.
- A basic intro is at https://docs.unrealengine.com/4.26/en-US/TestingAndOptimization/Automation/
- Certain plugins must be enabled for these tests. I added them to the UPLUGIN file. If this has any undesired side-effects for users of the plugin (that is, if they have to be added to the UPROJECT instead), then we should _really_ set up some "cesium-unreal-dev-project" repo
- Any `UE_LOG(..., Error, ...)` causes a unit test to count as "failed".  So we'll have to revise our error messages like the `Received 
  status code 401 for asset response https://api.cesium.com/v1/assets/0/endpoint` one. We can work arund that with `AddExpectedError` for now, but we don't want these tests to depend on certain error messages that are generated by `cesium-native`.


There are different "classes" of tests. I wanted to create a basic "template" for each type:

- The [`CesiumUnitTestExample.cpp`](https://github.com/CesiumGS/cesium-unreal/blob/basic-automated-tests/Source/CesiumRuntime/Tests/CesiumUnitTestExample.cpp) shows a basic unit test (although we might in fact not really want these... ). They are plain, API-level tests, not really specific for Unreal (although they show up in the tests list in the editor). 
- The [`CesiumFunctionalTestExample.cpp`](https://github.com/CesiumGS/cesium-unreal/blob/basic-automated-tests/Source/CesiumRuntime/Tests/CesiumFunctionalTestExample.cpp) shows "functional" tests, consisting of some steps like creating a world and adding an actor.
- The [`CesiumOriginRebasing.spec.cpp`](https://github.com/CesiumGS/cesium-unreal/blob/basic-automated-tests/Source/CesiumRuntime/Tests/CesiumOriginRebasing.spec.cpp) was supposed to become an example of a so-called "spec". These are higher-level tests, and consist of setting up a level and starting to actually play the level (because otherwise, things like Origin Rebasing are not happening).

First "actual" functional tests are contained in [`CesiumGeoreferenceTests.cpp`](https://github.com/CesiumGS/cesium-unreal/blob/basic-automated-tests/Source/CesiumRuntime/Tests/CesiumGeoreferenceTests.cpp), which are supposed to cover certain issues that are related to Georeferences, but of course, not all of them can sensibly be reproduced on this level.

If somebody wants to take over from here, that would be great 😬 However, maybe we can at least skip the "spec"-level tests, if we find a way to break the functionality down in a way  so that it can be tested without having to programmatically bootstrap the whole engine. 

