### PR TITLE
Improvements to tileset life cycle, undo/redo, and copy/paste

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1240,6 +1240,13 @@ void ACesium3DTileset::PostEditUndo() {
   // recreate the tileset.
   this->DestroyTileset();
 }
+
+void ACesium3DTileset::PostEditImport() {
+  Super::PostEditImport();
+
+  // Recreate the tileset on Paste.
+  this->DestroyTileset();
+}
 #endif
 
 void ACesium3DTileset::BeginDestroy() {

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1474,8 +1474,10 @@ bool applyTexture(
     return false;
   }
 
-  UTexture2D* pTexture =
-      NewObject<UTexture2D>(GetTransientPackage(), NAME_None, RF_Transient);
+  UTexture2D* pTexture = NewObject<UTexture2D>(
+      GetTransientPackage(),
+      NAME_None,
+      RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
 
   pTexture->PlatformData = loadedTexture->pTextureData;
   pTexture->AddressX = loadedTexture->addressX;
@@ -1499,7 +1501,8 @@ static void loadModelGameThreadPart(
 
   pMesh->bUseDefaultCollision = false;
   pMesh->SetCollisionObjectType(ECollisionChannel::ECC_WorldStatic);
-  pMesh->SetFlags(RF_Transient);
+  pMesh->SetFlags(
+      RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
   pMesh->Metadata = std::move(loadResult.Metadata);
   pMesh->pModel = loadResult.pModel;
   pMesh->pMeshPrimitive = loadResult.pMeshPrimitive;
@@ -1508,6 +1511,8 @@ static void loadModelGameThreadPart(
       NewObject<UStaticMesh>(pMesh, FName(loadResult.name.c_str()));
   pMesh->SetStaticMesh(pStaticMesh);
 
+  pStaticMesh->SetFlags(
+      RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
   pStaticMesh->bIsBuiltAtRuntime = true;
   pStaticMesh->NeverStream = true;
   pStaticMesh->RenderData =
@@ -1555,6 +1560,8 @@ static void loadModelGameThreadPart(
     break;
   }
 
+  pMaterial->SetFlags(
+      RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
   pMaterial->OpacityMaskClipValue = material.alphaCutoff;
 
   for (auto& textureCoordinateSet : loadResult.textureCoordinateParameters) {
@@ -1690,7 +1697,7 @@ UCesiumGltfComponent::CreateOffGameThread(
 
   UCesiumGltfComponent* Gltf = NewObject<UCesiumGltfComponent>(pParentActor);
   Gltf->SetUsingAbsoluteLocation(true);
-  Gltf->SetFlags(RF_Transient);
+  Gltf->SetFlags(RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
 
   if (pBaseMaterial) {
     Gltf->BaseMaterial = pBaseMaterial;

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -495,6 +495,7 @@ public:
   virtual void
   PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
   virtual void PostEditUndo() override;
+  virtual void PostEditImport() override;
 #endif
 
 protected:

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -494,6 +494,7 @@ public:
 #if WITH_EDITOR
   virtual void
   PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
+  virtual void PostEditUndo() override;
 #endif
 
 protected:
@@ -520,7 +521,6 @@ protected:
 private:
   void LoadTileset();
   void DestroyTileset();
-  void MarkTilesetDirty();
   Cesium3DTiles::ViewState CreateViewStateFromViewParameters(
       const FVector2D& viewportSize,
       const FVector& location,
@@ -586,12 +586,6 @@ private:
 
 private:
   Cesium3DTiles::Tileset* _pTileset;
-
-  /**
-   * Marks whether tileset should be updated in LoadTileset.
-   * Default to true so that tileset is created on construction.
-   */
-  bool _tilesetIsDirty = true;
 
   // For debug output
   uint32_t _lastTilesRendered;


### PR DESCRIPTION
Fixes #573

* Remove the `_tilesetIsDirty` is flag. Instead, just destroy the Cesium3DTiles::Tileset when necessary.
* Create all of our components and materials with flags `RF_Transient | RF_DuplicateTransient | RF_TextExportTransient`. This prevents all the transient glTF components a tileset creates on the fly from being included when doing a cut/copy/paste, which in turn prevents warnings when pasting a tileset.
* Implemented `PostEditUndo` and `PostEditImport` to recreate the tileset after undo/redo and paste, respectively.

Things I tested (and found to work):
* Delete a tileset, then undo (it comes back).
* Edit a tileset's asset ID, then undo the change (the original asset ID is loaded successfully).
* Edit a tileset's SSE, and then undo the change (the tileset is recreated with the new SSE. It would be nice to avoid recreating, but I can't immediately see how to do it with UE's Transaction system and it's not worth spending a lot of time on.)
* Add a tileset using the Quick Add, undo it, then redo (it comes back).
* Cut a tileset (it goes away), paste it back in the same level (it comes back).
* Copy a tileset and paste it in the same level (you get two, and they both work).
* Copy a tileset and paste it into a new, blank level (georeference and credits get created automatically, and the tileset works in the new level)
* Copy a tileset and paste it into a different level that already has a tileset (it works, and uses the existing georeference and credits)
* Switching between levels with Tilesets.
* Saving a level with a tileset.