### PR TITLE
Round feature IDs to the nearest integer so they work in Draco-compressed meshes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### Next Release - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause mis-registration of feature metadata to the wrong features in Draco-compressed meshes.
+
 ### v1.5.0 - 2021-08-02
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Private/CesiumMetadataFeatureTable.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMetadataFeatureTable.cpp
@@ -9,6 +9,10 @@ namespace {
 struct FeatureIDFromAccessor {
   int64 operator()(std::monostate) { return -1; }
 
+  int64 operator()(const CesiumGltf::AccessorView<AccessorTypes::SCALAR<float>>& value) {
+    return static_cast<int64>(glm::round(value[vertexIdx].value[0]));
+  }
+
   template <typename T>
   int64 operator()(const CesiumGltf::AccessorView<T>& value) {
     return static_cast<int64>(value[vertexIdx].value[0]);

--- a/Source/CesiumRuntime/Private/CesiumMetadataFeatureTable.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMetadataFeatureTable.cpp
@@ -9,7 +9,8 @@ namespace {
 struct FeatureIDFromAccessor {
   int64 operator()(std::monostate) { return -1; }
 
-  int64 operator()(const CesiumGltf::AccessorView<AccessorTypes::SCALAR<float>>& value) {
+  int64 operator()(
+      const CesiumGltf::AccessorView<AccessorTypes::SCALAR<float>>& value) {
     return static_cast<int64>(glm::round(value[vertexIdx].value[0]));
   }
 


### PR DESCRIPTION
Fixes #575 
