### PR TITLE
Find scene capture frustums for tile selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+### Next Release - ?
+
+##### Additions :tada:
+
+- Added support for using `ASceneCapture2D` with `ACesium3DTileset` actors.
+
+
 ### v1.5.1 - 2021-08-09
 
 ##### Breaking :mega:
@@ -17,7 +24,6 @@
 
 - Added support for reading per-feature metadata from glTFs with the `EXT_feature_metadata` extension or from 3D Tiles with a B3DM batch table and accessing it from Blueprints.
 - Added support for using multiple view frustums in `ACesium3DTileset` to inform the tile selection algorithm.
-- Added support for using `ASceneCapture2D` with `ACesium3DTileset` actors.
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 
 - Added support for reading per-feature metadata from glTFs with the `EXT_feature_metadata` extension or from 3D Tiles with a B3DM batch table and accessing it from Blueprints.
 - Added support for using multiple view frustums in `ACesium3DTileset` to inform the tile selection algorithm.
+- Added support for using `ASceneCapture2D` with `ACesium3DTileset` actors.
 
 ##### Fixes :wrench:
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 CesiumGS, Inc. and Contributors
 
 #include "Cesium3DTileset.h"
+#include "Camera/CameraTypes.h"
 #include "Camera/PlayerCameraManager.h"
 #include "Cesium3DTilesSelection/BingMapsRasterOverlay.h"
 #include "Cesium3DTilesSelection/CreditSystem.h"
@@ -20,10 +21,13 @@
 #include "CesiumRasterOverlay.h"
 #include "CesiumRuntime.h"
 #include "CesiumTransforms.h"
+#include "Components/SceneCaptureComponent2D.h"
 #include "CreateModelOptions.h"
 #include "Engine/Engine.h"
 #include "Engine/GameViewportClient.h"
+#include "Engine/SceneCapture2D.h"
 #include "Engine/Texture2D.h"
+#include "Engine/TextureRenderTarget2D.h"
 #include "Engine/World.h"
 #include "EngineUtils.h"
 #include "GameFramework/Controller.h"
@@ -782,6 +786,12 @@ std::vector<ACesium3DTileset::UnrealCameraParameters>
 ACesium3DTileset::GetCameras() const {
   std::vector<UnrealCameraParameters> cameras = this->GetPlayerCameras();
 
+  std::vector<UnrealCameraParameters> sceneCaptures = this->GetSceneCaptures();
+  cameras.insert(
+      cameras.end(),
+      std::make_move_iterator(sceneCaptures.begin()),
+      std::make_move_iterator(sceneCaptures.end()));
+
 #if WITH_EDITOR
   std::vector<UnrealCameraParameters> editorCameras = this->GetEditorCameras();
   cameras.insert(
@@ -931,6 +941,62 @@ ACesium3DTileset::GetPlayerCameras() const {
     } else {
       cameras.push_back(UnrealCameraParameters{size, location, rotation, fov});
     }
+  }
+
+  return cameras;
+}
+
+std::vector<ACesium3DTileset::UnrealCameraParameters>
+ACesium3DTileset::GetSceneCaptures() const {
+  // TODO: really USceneCaptureComponent2D can be attached to any actor, is it
+  // worth searching every actor? Might it be better to provide an interface
+  // where users can volunteer cameras to be used with the tile selection as
+  // needed?
+  TArray<AActor*> sceneCaptures;
+  static TSubclassOf<ASceneCapture2D> SceneCapture2D =
+      ASceneCapture2D::StaticClass();
+  UGameplayStatics::GetAllActorsOfClass(this, SceneCapture2D, sceneCaptures);
+
+  std::vector<ACesium3DTileset::UnrealCameraParameters> cameras;
+  cameras.reserve(sceneCaptures.Num());
+
+  for (AActor* pActor : sceneCaptures) {
+    ASceneCapture2D* pSceneCapture = static_cast<ASceneCapture2D*>(pActor);
+    if (!pSceneCapture) {
+      continue;
+    }
+
+    USceneCaptureComponent2D* pSceneCaptureComponent =
+        pSceneCapture->GetCaptureComponent2D();
+    if (!pSceneCaptureComponent) {
+      continue;
+    }
+
+    if (pSceneCaptureComponent->ProjectionType !=
+        ECameraProjectionMode::Type::Perspective) {
+      continue;
+    }
+
+    UTextureRenderTarget2D* pRenderTarget =
+        pSceneCaptureComponent->TextureTarget;
+    if (!pRenderTarget) {
+      continue;
+    }
+
+    FVector2D renderTargetSize(pRenderTarget->SizeX, pRenderTarget->SizeY);
+    if (renderTargetSize.X < 1.0 || renderTargetSize.Y < 1.0) {
+      continue;
+    }
+
+    FVector captureLocation = pSceneCaptureComponent->GetComponentLocation();
+    FRotator captureRotation = pSceneCaptureComponent->GetComponentRotation();
+    float captureFov = pSceneCaptureComponent->FOVAngle;
+
+    cameras.push_back(UnrealCameraParameters{
+        renderTargetSize,
+        captureLocation,
+        captureRotation,
+        captureFov});
   }
 
   return cameras;

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -539,6 +539,7 @@ private:
 
   std::vector<UnrealCameraParameters> GetCameras() const;
   std::vector<UnrealCameraParameters> GetPlayerCameras() const;
+  std::vector<UnrealCameraParameters> GetSceneCaptures() const;
 
   /**
    * Writes the values of all properties of this actor into the


### PR DESCRIPTION
Adds tile-selection compatibility for using `ASceneCapture2D` actors. The scene capture actor can now be used for things such as mini-maps, security cameras, mirrors, etc. alongside Cesium tilesets. 


###### Here the scene capture is being rendered to a small canvas UI and also to the material of the large cube in the scene.
https://user-images.githubusercontent.com/6706316/129304569-562382ec-63af-4dc7-aa1a-36c0326fc5d7.mp4

