### PR TITLE
Removed functions that had accidentally been public

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -326,8 +326,10 @@ ACesium3DTileset::GetCesiumTilesetToUnrealRelativeWorldTransform() const {
       ->GetCesiumTilesetToUnrealRelativeWorldTransform();
 }
 
-void ACesium3DTileset::UpdateTransformFromCesium(
-    const glm::dmat4& CesiumToUnreal) {
+void ACesium3DTileset::UpdateTransformFromCesium() {
+
+  const glm::dmat4& CesiumToUnreal =
+      this->GetCesiumTilesetToUnrealRelativeWorldTransform();
   TArray<UCesiumGltfComponent*> gltfComponents;
   this->GetComponents<UCesiumGltfComponent>(gltfComponents);
 
@@ -1243,8 +1245,7 @@ void ACesium3DTileset::Tick(float DeltaTime) {
   }
 
   if (pRoot->IsTransformChanged()) {
-    this->UpdateTransformFromCesium(
-        this->GetCesiumTilesetToUnrealRelativeWorldTransform());
+    this->UpdateTransformFromCesium();
     pRoot->MarkTransformUnchanged();
   }
 

--- a/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.cpp
@@ -30,12 +30,6 @@ void UCesium3DTilesetRoot::ApplyWorldOffset(
   this->_updateTilesetToUnrealRelativeWorldTransform();
 }
 
-void UCesium3DTilesetRoot::MarkTransformUnchanged() { this->_isDirty = false; }
-
-void UCesium3DTilesetRoot::RecalculateTransform() {
-  this->_updateTilesetToUnrealRelativeWorldTransform();
-}
-
 void UCesium3DTilesetRoot::HandleGeoreferenceUpdated() {
   UE_LOG(
       LogCesium,

--- a/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.h
+++ b/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.h
@@ -32,13 +32,7 @@ public:
    * After calling this function, {@link IsTransformChanged} will return false
    * until the next time that the transform changes.
    */
-  void MarkTransformUnchanged();
-
-  /**
-   * @brief Recalculates {@link GetCesiumTilesetToUnrealRelativeWorldTransform}
-   * and marks it changed.
-   */
-  void RecalculateTransform();
+  void MarkTransformUnchanged() { this->_isDirty = false; }
 
   /**
    * @brief Gets the transform from the "Cesium Tileset" reference frame to the

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -467,6 +467,13 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Cesium|Rendering")
   void PauseMovieSequencer();
 
+  /**
+   * This method is not supposed to be called by clients. It is currently
+   * only required by the UnrealResourcePreparer.
+   *
+   * See {@link
+   * Cesium3DTilesetRoot::GetCesiumTilesetToUnrealRelativeWorldTransform}.
+   */
   const glm::dmat4& GetCesiumTilesetToUnrealRelativeWorldTransform() const;
 
   Cesium3DTilesSelection::Tileset* GetTileset() { return this->_pTileset; }
@@ -474,9 +481,7 @@ public:
     return this->_pTileset;
   }
 
-  void UpdateTransformFromCesium(const glm::dmat4& CesiumToUnreal);
-
-  // AActor overrides
+  // AActor overrides (some or most of them should be protected)
   virtual bool ShouldTickIfViewportsOnly() const override;
   virtual void Tick(float DeltaTime) override;
   virtual void BeginDestroy() override;
@@ -531,6 +536,15 @@ private:
 
   std::vector<UnrealCameraParameters> GetCameras() const;
   std::vector<UnrealCameraParameters> GetPlayerCameras() const;
+
+  /**
+   * Update the transforms of the glTF components based on the
+   * the transform of the root component.
+   *
+   * This is supposed to be called during Tick, if the transform of
+   * the root component has changed since the previous Tick.
+   */
+  void UpdateTransformFromCesium();
 
   /**
    * Writes the values of all properties of this actor into the


### PR DESCRIPTION
<sup>Stumbled over this while reading (and trying to understand) code for the refactoring, and trying to obey the [Boy Scout Rule](https://clean-code-developer.com/grades/grade-1-red/#Boy_Scout_Rule):</sup> 

There had been some `public` functions that either had been unused, or should have been `private` in the first place. Also: Comments.
