### PR TITLE
Experimental Georeference component improvements

### DIFF
--- a/Documentation/georeference-component-scenarios.md
+++ b/Documentation/georeference-component-scenarios.md
@@ -29,5 +29,5 @@ Actions:
 * `OnRegister`: Update ECEF from Actor if ECEF is not yet valid
 * `HandleActorTransformUpdated`: Update ECEF, and mark it valid.
 * `PostEditChangeProperty`: If ECEF properties were changed, mark ECEF valid.
-* `PostEditUndo`: Nothing special, because ECEF validity state should be undone as well as necessary.
+* `PostEditUndo`: Nothing special, because ECEF validity state should be undone as well, as necessary.
 * `OnComponentCreated`: ECEF is marked invalid

--- a/Documentation/georeference-component-scenarios.md
+++ b/Documentation/georeference-component-scenarios.md
@@ -1,0 +1,33 @@
+
+# CesiumGeoreferenceComopnent expected behavior
+
+Explanation of the "authority" column in the table below:
+* `Unreal`: The Unreal Location and Rotation properties are the authority, and the ECEF translation and rotation are computed from those properties.
+* `ECEF`: The ECEF translation and rotation are the authority, and the Unreal Location and Rotation properties are computed from the ECEF translation and rotation.
+* `Both`: Both the ECEF translation and rotation and the Unreal Location and Rotation properties are authoritative, and neither should be computed from the other
+
+| *Operation* | *Authority* | *Sequence* | *Notes* |
+|--------------|---------------|---------------|----|
+| 1. The CesiumGeoreferenceComponent is added to an existing Actor | `Unreal` | 1. PostInitProperties<br/>2. OnComponentCreated<br/>3. OnRegister | |
+| 2. The Unreal location or rotation is changed in the editor | `Unreal` | 1. HandleActorTransformUpdated | |
+| 3. The Unreal location or rotation is changed by physics | `Unreal` | 1. HandleActorTransformUpdated | |
+| 4. The Unreal location or rotation is changed by Blueprints or by C++ code (e.g. SetWorldTransform) | `Unreal` | 1. HandleActorTransformUpdated | |
+| 5. The world OriginLocation is changed (i.e. an origin rebase) | `ECEF` | 1. ApplyWorldOffset<br/>2. HandleActorTransformUpdated (only when recomputing from ECEF actually changes the position) | |
+| 6. The Georeference Actor's origin is changed | `ECEF` | 1. HandleGeoreferenceUpdated<br/>2. HandleActorTransformUpdated<br/>3. HandleGeoreferenceUpdated<br/>4. HandleActorTransformUpdated | |
+| 7. Any of the Longitude/Latitude/Height/X/Y/Z properties of the component are changed in the Editor | `ECEF` | 1. PreEditChange<br/>2. OnUnregister<br/>3. PostEditChangeChainProperty<br/>4. PostEditChangeProperty<br/>5. OnRegister | |
+| 8. Actor with an attached Component is loaded. | `Both` | 1. PostInitProperties<br/>2. PostLoad<br/>3. OnRegister | |
+| 9. Actor with an attached Component is pasted. | `Both` | 1. PostInitProperties<br/>2. PreEditChange<br/>3. PostEditChangeProperty<br/>4. PreEditChange<br/>5. PostEditChangeProperty<br/>6. OnComponentCreated<br/>7. OnRegister<br/>8. OnUnregister<br/>9. OnRegister<br/>10. OnUnregister<br/>11. OnRegister | |
+| 10. Actor with an attached Component is restored by an undo/repo. | `Both` | 1. PreEditUndo<br/>2. PreEditChange<br/>3. PostEditUndo<br/>4. PostEditChangeProperty<br/>5. OnRegister | |
+| 11. An existing CesiumGeoreferenceComponent is copy/pasted onto an existing Actor | `Unreal` | 1. PostInitProperties<br/>2. PreEditChange<br/>3. PostEditChangeProperty<br/>4. PostInitProperties<br/>5. PreEditChange<br/>6. PostEditChangeProperty<br/>7. PostInitProperties<br/>8. PreEditChange<br/>9.PostEditChangeProperty<br/>10. OnComponentCreated<br/>11. OnRegister | This one is arguable (versus the alternative where the Actor jumps to the ECEF location/rotation embodied in the new Component), but I think "don't change the Actor's position just by attaching a component" is a good policy, and the symmetry with (1) is likely to make it easier to implement than the alternative. |
+| 12. A CesiumGeoreferenceComponent is deleted from an Actor, and then the user Undoes that operation. | `Both` | 1. PreEditUndo<br/>2. PreEditChange<br/>3. PostEditUndo<br/>4. PostEditChangeProperty<br/>5. OnRegister | Ideally both the Actor Location/Rotation and the ECEF translation/rotation would be preserved in this scenario. This way the Undo would actually restore the exact state rather than an approximation of it. |
+| 13. A CesiumGeoreferenceComponent is Cut from an Actor, and then Pasted into the same Actor. | `Unreal` | 1. PostInitProperties<br/>2. PreEditChange<br/>3. PostEditChangeProperty<br/>4. PostInitProperties<br/>5. PreEditChange<br/>6. PostEditChangeProperty<br/>7. PostInitProperties<br/>8. PreEditChange<br/>9. PostEditChangeProperty<br/>10. OnComponentCreated<br/>11. OnRegister | It might be nice to preserve both sets of properties in this scenario when neither has changed in between the Cut and Paste, but that's likely to be difficult. Just treating the Unreal properties as the authority, consistent with (1) and (11) is unlikely to surprise anyone. |
+| 14. Begin Play-in-Editor | `Both` | 1. PostInitProperties<br/>2. PostLoad<br/>3. OnRegister<br/>4. HandleGeoreferenceUpdated<br/>5. HandleActorTransformUpdated | Both sets of properties should be preserved. |
+
+Actions:
+
+* `PostLoad`: Mark ECEF valid
+* `OnRegister`: Update ECEF from Actor if ECEF is not yet valid
+* `HandleActorTransformUpdated`: Update ECEF, and mark it valid.
+* `PostEditChangeProperty`: If ECEF properties were changed, mark ECEF valid.
+* `PostEditUndo`: Nothing special, because ECEF validity state should be undone as well as necessary.
+* `OnComponentCreated`: ECEF is marked invalid

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -598,17 +598,20 @@ void ACesiumGeoreference::Tick(float DeltaTime) {
   _performOriginRebasing();
 }
 
-void ACesiumGeoreference::PostLoad() {
-  Super::PostLoad();
+void ACesiumGeoreference::Serialize(FArchive& Ar) {
+  Super::Serialize(Ar);
 
-  glm::dvec3 center(0.0, 0.0, 0.0);
-  if (this->OriginPlacement == EOriginPlacement::CartographicOrigin) {
-    center = _geoTransforms.TransformLongitudeLatitudeHeightToEcef(glm::dvec3(
-        this->OriginLongitude,
-        this->OriginLatitude,
-        this->OriginHeight));
+  // Recompute derived values on load.
+  if (Ar.IsLoading()) {
+    glm::dvec3 center(0.0, 0.0, 0.0);
+    if (this->OriginPlacement == EOriginPlacement::CartographicOrigin) {
+      center = _geoTransforms.TransformLongitudeLatitudeHeightToEcef(glm::dvec3(
+          this->OriginLongitude,
+          this->OriginLatitude,
+          this->OriginHeight));
+    }
+    _geoTransforms.setCenter(center);
   }
-  _geoTransforms.setCenter(center);
 }
 
 /**

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -598,6 +598,19 @@ void ACesiumGeoreference::Tick(float DeltaTime) {
   _performOriginRebasing();
 }
 
+void ACesiumGeoreference::PostLoad() {
+  Super::PostLoad();
+
+  glm::dvec3 center(0.0, 0.0, 0.0);
+  if (this->OriginPlacement == EOriginPlacement::CartographicOrigin) {
+    center = _geoTransforms.TransformLongitudeLatitudeHeightToEcef(glm::dvec3(
+        this->OriginLongitude,
+        this->OriginLatitude,
+        this->OriginHeight));
+  }
+  _geoTransforms.setCenter(center);
+}
+
 /**
  * Useful Conversion Functions
  */

--- a/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreferenceComponent.cpp
@@ -329,10 +329,6 @@ void UCesiumGeoreferenceComponent::OnComponentCreated() {
   this->_ecefIsValid = false;
 }
 
-void UCesiumGeoreferenceComponent::PostInitProperties() {
-  Super::PostInitProperties();
-}
-
 void UCesiumGeoreferenceComponent::PostLoad() {
   UE_LOG(
       LogCesium,
@@ -417,22 +413,7 @@ void UCesiumGeoreferenceComponent::ApplyWorldOffset(
   _updateActorTransform(actorRotation, newRelativeLocation);
 }
 
-void UCesiumGeoreferenceComponent::InitializeComponent() {
-  Super::InitializeComponent();
-}
-
 #if WITH_EDITOR
-void UCesiumGeoreferenceComponent::PreEditChange(
-    FProperty* PropertyThatWillChange) {
-  Super::PreEditChange(PropertyThatWillChange);
-
-  UE_LOG(
-      LogCesium,
-      Verbose,
-      TEXT("Called PreEditChange for %s"),
-      *this->GetName());
-}
-
 void UCesiumGeoreferenceComponent::PostEditChangeProperty(
     FPropertyChangedEvent& event) {
   Super::PostEditChangeProperty(event);
@@ -468,11 +449,6 @@ void UCesiumGeoreferenceComponent::PostEditChangeProperty(
     this->MoveToECEF(glm::dvec3(this->ECEF_X, this->ECEF_Y, this->ECEF_Z));
     return;
   }
-}
-
-void UCesiumGeoreferenceComponent::PostEditChangeChainProperty(
-    FPropertyChangedChainEvent& PropertyChangedEvent) {
-  Super::PostEditChangeChainProperty(PropertyChangedEvent);
 }
 
 void UCesiumGeoreferenceComponent::PreEditUndo() { Super::PreEditUndo(); }

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -614,4 +614,10 @@ private:
    * or `OriginRebaseInsideSublevels` is enabled.
    */
   void _performOriginRebasing();
+
+  /**
+   * Updates _geoTransforms based on the current ellipsoid and center, and
+   * returns the old transforms.
+   */
+  void _updateGeoTransforms();
 };

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -500,6 +500,8 @@ public:
    */
   virtual void Tick(float DeltaTime) override;
 
+  virtual void PostLoad() override;
+
   /**
    * Returns the GeoTransforms that offers the same conversion
    * functions as this class, but performs the computations

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -500,7 +500,7 @@ public:
    */
   virtual void Tick(float DeltaTime) override;
 
-  virtual void PostLoad() override;
+  virtual void Serialize(FArchive& Ar) override;
 
   /**
    * Returns the GeoTransforms that offers the same conversion

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -164,8 +164,6 @@ public:
   virtual void
   ApplyWorldOffset(const FVector& InOffset, bool bWorldShift) override;
 
-  virtual void InitializeComponent();
-
 protected:
   /**
    * Called when a component is registered.
@@ -211,8 +209,6 @@ protected:
    */
   virtual void OnComponentCreated() override;
 
-  virtual void PostInitProperties() override;
-
   /**
    * Do any object-specific cleanup required immediately after
    * loading an object.
@@ -224,15 +220,6 @@ protected:
   virtual void PostLoad() override;
 
 #if WITH_EDITOR
-
-  /**
-   * This is called when a property is about to be modified externally.
-   *
-   * When the georeference is about to be modified, then this will
-   * remove the `HandleGeoreferenceUpdated` callback from the
-   * `OnGeoreferenceUpdated` delegate of the current georeference.
-   */
-  virtual void PreEditChange(FProperty* PropertyThatWillChange) override;
 
   /**
    * Called when a property on this object has been modified externally
@@ -254,8 +241,6 @@ protected:
   virtual void
   PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
 
-  virtual void PostEditChangeChainProperty(
-      FPropertyChangedChainEvent& PropertyChangedEvent) override;
   virtual void PreEditUndo() override;
   virtual void PostEditUndo() override;
 #endif

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -121,6 +121,8 @@ public:
    * Returns the longitude in degrees (x), latitude in degrees (y),
    * and height in meters (z) of the actor, downcasted to a
    * single-precision floating point vector.
+   *
+   * The returned value may be invalid if this component is not yet registered.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateGetLongitudeLatitudeHeight() const;
@@ -143,9 +145,10 @@ public:
       bool MaintainRelativeOrientation = true);
 
   /**
-   * Returns the Earth-Centered, Earth-Fixed (ECEF)
-   * coordinates of the actor, downcasted to a
-   * single-precision floating point vector.
+   * Returns the Earth-Centered, Earth-Fixed (ECEF) coordinates of the actor,
+   * downcasted to a single-precision floating point vector.
+   *
+   * The returned value may be invalid if this component is not yet registered.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   FVector InaccurateGetECEF() const;

--- a/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreferenceComponent.h
@@ -364,26 +364,6 @@ private:
   void _debugLogState();
 
   /**
-   * Synchronizes the ECEF position from the Actor's current Location, but only
-   * if the current ECEF position is wrong.
-   *
-   * The current ECEF position is converted to Unreal coordinates and truncated
-   * to single-precision. If this matches the Actor's Location already, then
-   * this method does nothing more, because the ECEF is already correct and
-   * recomputing it would potentially cause loss of precision.
-   *
-   * If the computed Location is different, however, then the Actor's current
-   * Location is assumed to be correct and the ECEF position is assumed to be
-   * incorrect, so the ECEF position is recomputed from the Actor's Location.
-   *
-   * In other words, this method sets the ECEF position _unless_ we can prove
-   * that the Actor's Location was derived from the ECEF position.
-   *
-   * This method never modifies the Actor's transform, no matter what.
-   */
-  void _syncEcefFromActor();
-
-  /**
    * Whether an update of the actor transform is currently in progress,
    * and further calls that are issued by HandleActorTransformUpdated
    * should be ignored
@@ -418,6 +398,9 @@ private:
    * between the old and the new rotation is applied to the actor
    * rotation, to keep its orientation consistent despite the change
    * of the underlying Georeference.
+   *
+   * This property is only valid while the Component is registered (i.e. when
+   * IsRegistered() returns true).
    */
   glm::dmat3 _currentUnrealToEcef;
 


### PR DESCRIPTION
This is an alternative to #590 that also fixes the orientation bug Nithin observed in https://github.com/CesiumGS/cesium-unreal/pull/459#issuecomment-894515102.

First, it involves only a minor (and hopefully not too scary) change to the `CesiumGeoreference` Actor: `_geoTransforms` is updated on the `Serialize` method on load, so that it is always in sync with the loaded `OriginLongitude` etc. Previously it could be out of sync until either `OnConstruction` or `BeginPlay` was called.

On the Georeference Component side, there are more changes:

* We keep track of an `_ecefIsValid` flag, which indicates whether the ECEF_X/Longitude/_currentEcef properties are valid.
* This flag only goes true (indicating our ECEF representation is trustworthy) in a few scenarios:
  * The ECEF values are loaded (i.e. PostLoad)
  * The ECEF values are set explicitly.
  * The ECEF values are computed from the Actor Transform.
* If `_ecefIsValid` is still false in `OnRegister`, the ECEF values will be computed from the Actor Transform.
* It's also set to `false` on `OnComponentCreated`. This handles the case that a georeference component is pasted onto another Actor. The old ECEF cannot be trusted because it potentially refers to a different Actor.

I certainly haven't tested every scenario, and it still needs a fair bit of cleanup (especially of the doc comments, some of which are probably wrong now), but I _think_ the overall approach is sound.