### PR TITLE
Add missing UFunction annotation in metadata blueprint library

### DIFF
--- a/Source/CesiumRuntime/Public/CesiumMetadataFeatureTable.h
+++ b/Source/CesiumRuntime/Public/CesiumMetadataFeatureTable.h
@@ -105,13 +105,21 @@ public:
    *
    * @param FeatureID The ID of the feature.
    */
-  TMap<FString, FString> static GetPropertiesAsStringsForFeatureID(
+  UFUNCTION(
+      BlueprintCallable,
+      BlueprintPure,
+      Category = "Cesium|Metadata|FeatureTable")
+  static TMap<FString, FString> GetPropertiesAsStringsForFeatureID(
       UPARAM(ref) const FCesiumMetadataFeatureTable& featureTable,
       int64 FeatureID);
 
   /**
    * Gets all the properties of the feature table.
    */
+  UFUNCTION(
+      BlueprintCallable,
+      BlueprintPure,
+      Category = "Cesium|Metadata|FeatureTable")
   static const TMap<FString, FCesiumMetadataProperty>&
   GetProperties(UPARAM(ref) const FCesiumMetadataFeatureTable& FeatureTable);
 };

--- a/Source/CesiumRuntime/Public/CesiumMetadataPrimitive.h
+++ b/Source/CesiumRuntime/Public/CesiumMetadataPrimitive.h
@@ -77,6 +77,10 @@ public:
    *
    * @param faceID The ID of the face.
    */
+  UFUNCTION(
+      BlueprintCallable,
+      BlueprintPure,
+      Category = "Cesium|Metadata|Property")
   static int64 GetFirstVertexIDFromFaceID(
       UPARAM(ref) const FCesiumMetadataPrimitive& MetadataPrimitive,
       int64 FaceID);


### PR DESCRIPTION
While looking into metadata tutorial, I just realized we miss UFunction annotations, so blueprint library doesn't display those