### PR TITLE
Fix compilation warnings for UE 4.27

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -287,7 +287,12 @@ void ACesiumGeoreference::AddGeoreferencedObject(
     }
   }
 
+#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27
   this->_georeferencedObjects.Add(*Object);
+#else
+  this->_georeferencedObjects.Add(
+      TWeakInterfacePtr<ICesiumGeoreferenceable>(Object));
+#endif
 
   // If this object is an Actor or UActorComponent, make sure it ticks _after_
   // the CesiumGeoreference.

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1513,10 +1513,17 @@ static void loadModelGameThreadPart(
 
   pStaticMesh->SetFlags(
       RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
-  pStaticMesh->bIsBuiltAtRuntime = true;
   pStaticMesh->NeverStream = true;
+
+#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27
+  pStaticMesh->bIsBuiltAtRuntime = true;
   pStaticMesh->RenderData =
       TUniquePtr<FStaticMeshRenderData>(loadResult.RenderData);
+#else
+  pStaticMesh->SetIsBuiltAtRuntime(true);
+  pStaticMesh->SetRenderData(
+      TUniquePtr<FStaticMeshRenderData>(loadResult.RenderData));
+#endif
 
   const CesiumGltf::Model& model = *loadResult.pModel;
   const CesiumGltf::Material& material =
@@ -1635,7 +1642,11 @@ static void loadModelGameThreadPart(
   // Set up RenderData bounds and LOD data
   pStaticMesh->CalculateExtendedBounds();
 
+#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 27
   pStaticMesh->RenderData->ScreenSize[0].Default = 1.0f;
+#else
+  pStaticMesh->GetRenderData()->ScreenSize[0].Default = 1.0f;
+#endif
   pStaticMesh->CreateBodySetup();
 
   // pMesh->UpdateCollisionFromStaticMesh();


### PR DESCRIPTION
Fixes #600

Note that this is similar to https://github.com/CesiumGS/cesium-unreal/pull/469 , but checks for version 4.27, because the warnings had already been issued in this version. I packaged it with 4.26 and 4.27, and neither caused any warnings.

(It should cover 5.0 as well, of course, but I haven't dedicatedly tested this).



