### PR TITLE
Fixed "Drape Over Terrain Tileset" deleting existing overlays.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 ##### Fixes :wrench:
 
 - Fixed indexed vertices being duplicated unnecessarily in certain situations in `UCesiumGltfComponent`.
+- Fixed an issue where the "Drape Over Terrain Tileset" button in the Cesium Ion Asset panel deleted all existing overlays.
 
 ### v1.5.1 - 2021-08-09
 

--- a/Source/CesiumEditor/Private/CesiumEditor.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditor.cpp
@@ -374,16 +374,6 @@ UCesiumIonRasterOverlay* FCesiumEditorModule::AddOverlay(
     ACesium3DTileset* pTilesetActor,
     const std::string& name,
     int64_t assetID) {
-  // Remove any existing overlays and add the new one.
-  // TODO: ideally we wouldn't remove the old overlays but the number of overlay
-  // textures we can support is currently very limited.
-  TArray<UCesiumRasterOverlay*> rasterOverlays;
-  pTilesetActor->GetComponents<UCesiumRasterOverlay>(rasterOverlays);
-
-  for (UCesiumRasterOverlay* pOverlay : rasterOverlays) {
-    pOverlay->DestroyComponent(false);
-  }
-
   UCesiumIonRasterOverlay* pOverlay = NewObject<UCesiumIonRasterOverlay>(
       pTilesetActor,
       FName(name.c_str()),


### PR DESCRIPTION
Fixes #613 

It is still awkward to add new overlays with the drape button since new overlays require a different material layer key to be entered. Since the default material layer key is "Overlay0", the new overlay may appear to replace parts of the existing overlay. This PR only makes sure that the old overlays aren't outright deleted from the tileset's components list. 