### PR TITLE
Improved UX for adding raster overlays with the Cesium panels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,11 +20,11 @@
 - Multiple raster overlays per tileset are now supported.
 - Consolidated texture preparation code. Now raster overlay textures can generate mip-maps and the overlay texture preparation can happen partially on the load thread.
 - Added the ability to define a "Cesium Cartographic Polygon" and then use it to clip away part of a Cesium 3D Tileset.
+- The Cesium ion Assets panel now has two buttons for imagery assets, allowing the user to select whether the asset should replace the base overlay or be added on top.
 
 ##### Fixes :wrench:
 
 - Fixed indexed vertices being duplicated unnecessarily in certain situations in `UCesiumGltfComponent`.
-- Fixed an issue where the "Drape Over Terrain Tileset" button in the Cesium Ion Asset panel deleted all existing overlays.
 
 ### v1.5.1 - 2021-08-09
 

--- a/Source/CesiumEditor/Private/CesiumEditor.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditor.cpp
@@ -22,6 +22,8 @@
 #include "UnrealAssetAccessor.h"
 #include "UnrealTaskProcessor.h"
 
+constexpr int MaximumOverlaysWithDefaultMaterial = 3;
+
 IMPLEMENT_MODULE(FCesiumEditorModule, CesiumEditor)
 DEFINE_LOG_CATEGORY(LogCesiumEditor);
 
@@ -374,10 +376,51 @@ UCesiumIonRasterOverlay* FCesiumEditorModule::AddOverlay(
     ACesium3DTileset* pTilesetActor,
     const std::string& name,
     int64_t assetID) {
+  // Remove an existing component with the same name.
+  // This is necessary because UE will die immediately if we create two
+  // components with the same name.
+  FName newName = FName(name.c_str());
+  UObject* pExisting = static_cast<UObject*>(
+      FindObjectWithOuter(pTilesetActor, nullptr, newName));
+  if (pExisting) {
+    UCesiumRasterOverlay* pCesiumOverlay =
+        Cast<UCesiumRasterOverlay>(pExisting);
+    if (pCesiumOverlay) {
+      pCesiumOverlay->DestroyComponent();
+    } else {
+      // There's some object using our name, but it's not ours.
+      // We could do complicated things here, but this should be a very uncommon
+      // scenario so let's just log.
+      UE_LOG(
+          LogCesiumEditor,
+          Warning,
+          TEXT(
+              "Cannot create raster overlay component %s because the name is already in use."),
+          *newName.ToString());
+    }
+  }
+
+  // Find the first available `OverlayN` MaterialLayerKey.
+  TArray<UCesiumRasterOverlay*> rasterOverlays;
+  pTilesetActor->GetComponents<UCesiumRasterOverlay>(rasterOverlays);
+
+  FString overlayKey = TEXT("Overlay0");
+  auto materialLayerKeyMatches = [&newName,
+                                  &overlayKey](UCesiumRasterOverlay* pOverlay) {
+    return pOverlay->MaterialLayerKey == overlayKey;
+  };
+
+  int i = 0;
+  while (rasterOverlays.FindByPredicate(materialLayerKeyMatches)) {
+    ++i;
+    overlayKey = FString(TEXT("Overlay")) + FString::FromInt(i);
+  }
+
   UCesiumIonRasterOverlay* pOverlay = NewObject<UCesiumIonRasterOverlay>(
       pTilesetActor,
       FName(name.c_str()),
       RF_Public | RF_Transactional);
+  pOverlay->MaterialLayerKey = overlayKey;
   pOverlay->IonAssetID = assetID;
   pOverlay->IonAccessToken = UTF8_TO_TCHAR(
       FCesiumEditorModule::ion().getAssetAccessToken().token.c_str());
@@ -386,7 +429,34 @@ UCesiumIonRasterOverlay* FCesiumEditorModule::AddOverlay(
 
   pTilesetActor->AddInstanceComponent(pOverlay);
 
+  if (i >= MaximumOverlaysWithDefaultMaterial) {
+    UE_LOG(
+        LogCesiumEditor,
+        Warning,
+        TEXT(
+            "The default material only supports up to %d raster overlays, and your tileset is now using %d, so the extra overlays will be ignored. Consider creating a custom Material Instance with support for more overlays."),
+        MaximumOverlaysWithDefaultMaterial,
+        i + 1);
+  }
+
   return pOverlay;
+}
+
+UCesiumIonRasterOverlay* FCesiumEditorModule::AddBaseOverlay(
+    ACesium3DTileset* pTilesetActor,
+    const std::string& name,
+    int64_t assetID) {
+  // Remove Overlay0 (if it exists) and add the new one.
+  TArray<UCesiumRasterOverlay*> rasterOverlays;
+  pTilesetActor->GetComponents<UCesiumRasterOverlay>(rasterOverlays);
+
+  for (UCesiumRasterOverlay* pOverlay : rasterOverlays) {
+    if (pOverlay->MaterialLayerKey == TEXT("Overlay0")) {
+      pOverlay->DestroyComponent(false);
+    }
+  }
+
+  return FCesiumEditorModule::AddOverlay(pTilesetActor, name, assetID);
 }
 
 namespace {

--- a/Source/CesiumEditor/Private/CesiumEditor.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditor.cpp
@@ -376,7 +376,7 @@ UCesiumIonRasterOverlay* FCesiumEditorModule::AddOverlay(
     ACesium3DTileset* pTilesetActor,
     const std::string& name,
     int64_t assetID) {
-  // Remove an existing component with the same name.
+  // Remove an existing component with the same name but different types.
   // This is necessary because UE will die immediately if we create two
   // components with the same name.
   FName newName = FName(name.c_str());

--- a/Source/CesiumEditor/Private/CesiumEditor.h
+++ b/Source/CesiumEditor/Private/CesiumEditor.h
@@ -38,7 +38,21 @@ public:
   static ACesium3DTileset* FindFirstTilesetWithAssetID(int64_t assetID);
   static ACesium3DTileset*
   CreateTileset(const std::string& name, int64_t assetID);
+
+  /**
+   * Adds an overlay with the the MaterialLayerKey `OverlayN` where N is the
+   * next unused index.
+   */
   static UCesiumIonRasterOverlay* AddOverlay(
+      ACesium3DTileset* pTilesetActor,
+      const std::string& name,
+      int64_t assetID);
+
+  /**
+   * Adds a base overlay, replacing the existing overlay with MaterialLayerKey
+   * Overlay0, if any.
+   */
+  static UCesiumIonRasterOverlay* AddBaseOverlay(
       ACesium3DTileset* pTilesetActor,
       const std::string& name,
       int64_t assetID);

--- a/Source/CesiumEditor/Private/CesiumIonPanel.h
+++ b/Source/CesiumEditor/Private/CesiumIonPanel.h
@@ -36,7 +36,9 @@ private:
       TSharedPtr<CesiumIonClient::Asset> item,
       const TSharedRef<STableViewBase>& list);
   void AddAssetToLevel(TSharedPtr<CesiumIonClient::Asset> item);
-  void AddOverlayToTerrain(TSharedPtr<CesiumIonClient::Asset> item);
+  void AddOverlayToTerrain(
+      TSharedPtr<CesiumIonClient::Asset> item,
+      bool useAsBaseLayer);
   void AddAsset(TSharedPtr<CesiumIonClient::Asset> item);
   void AssetSelected(
       TSharedPtr<CesiumIonClient::Asset> item,

--- a/Source/CesiumEditor/Private/IonQuickAddPanel.cpp
+++ b/Source/CesiumEditor/Private/IonQuickAddPanel.cpp
@@ -210,7 +210,7 @@ void IonQuickAddPanel::AddIonTilesetToLevel(TSharedRef<QuickAddItem> item) {
           FCesiumEditorModule::ion().getAssets();
 
           if (item->overlayID > 0) {
-            FCesiumEditorModule::AddOverlay(
+            FCesiumEditorModule::AddBaseOverlay(
                 pTileset,
                 item->overlayName,
                 item->overlayID);


### PR DESCRIPTION
Following on from #614...

When using the Quick-Add panel, users almost certainly want to _replace_ the base raster overlay rather than adding another on top. When using the Cesium ion Assets panel, either possibility is pretty likely. So in this PR, I've made the Quick Add panel replace `Overlay0` with the new asset. And I've added a second button to the Cesium ion Assets panel allowing the user to choose:

![image](https://user-images.githubusercontent.com/924374/131605533-b6c9b02f-286a-4cc7-a535-06ca2279cfbf.png)

The first button replaces `Overlay0`, just like the Quick-Add does.

The second button assigns the first unused `OverlayN` MaterialLayerKey to the new component.

This still isn't perfect UX-wise, but it's a big improvement I think.