### PR TITLE
Include Engine.ini in plugin package.

### DIFF
--- a/Config/FilterPlugin.ini
+++ b/Config/FilterPlugin.ini
@@ -1,5 +1,6 @@
 [FilterPlugin]
 /Config/FilterPlugin.ini
+/Config/Engine.ini
 /LICENSE
 /README.md
 /ThirdParty.json


### PR DESCRIPTION
Without this change, the Engine.ini with our CoreRedirects doesn't get included in the plugin package. Which means a broken level blueprint in the Metadata sample and elsewhere.