### PR TITLE
Updated broken link in build docs

### DIFF
--- a/Documentation/developer-setup-windows.md
+++ b/Documentation/developer-setup-windows.md
@@ -106,7 +106,7 @@ Or the debug version:
 
 ## CMake command-line for Android
 
-To cross-compile Cesium Native for Android, ensure that you have [installed Android Studio and Android NDK, and configured ANDROID_NDK_ROOT](https://github.com/CesiumGS/cesium-unreal/blob/android-build-docs-update/Documentation/developer-setup-windows.md#for-cross-compiling-android-on-windows). Then you will need to have Ninja installed. With [chocolatey](https://chocolatey.org/install), you can run:
+To cross-compile Cesium Native for Android, ensure that you have [installed Android Studio and Android NDK, and configured ANDROID_NDK_ROOT](https://github.com/CesiumGS/cesium-unreal/blob/main/Documentation/developer-setup-windows.md#for-cross-compiling-android-on-windows). Then you will need to have Ninja installed. With [chocolatey](https://chocolatey.org/install), you can run:
 
       choco install ninja
 

--- a/Documentation/packaging-guide.md
+++ b/Documentation/packaging-guide.md
@@ -21,7 +21,7 @@ To package the plugin, follow the steps below:
         ```cmd
         "C:\Program Files\Epic Games\UE_4.26\Engine\Build\BatchFiles\RunUAT.bat" BuildPlugin -Plugin="C:\workspace\cesium-unreal\CesiumForUnreal.uplugin" -Package="C:\workspace\Packages\CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Win64
         ```
-    * Windows+Android Example (ensure you have completed the [Android-specific cross-compilation steps](https://github.com/CesiumGS/cesium-unreal/blob/android-build-docs-update/Documentation/developer-setup-windows.md#cmake-command-line-for-android) first):
+    * Windows+Android Example (ensure you have completed the [Android-specific cross-compilation steps](https://github.com/CesiumGS/cesium-unreal/blob/main/Documentation/developer-setup-windows.md#cmake-command-line-for-android) first):
         ```cmd
         "C:\Program Files\Epic Games\UE_4.26\Engine\Build\BatchFiles\RunUAT.bat" BuildPlugin -Plugin="C:\workspace\cesium-unreal\CesiumForUnreal.uplugin" -Package="C:\workspace\Packages\CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Win64+Android
         ```


### PR DESCRIPTION
Saw I had originally included a broken link in the docs that was pointing to an old branch instead of main. Fixed it.