### PR TITLE
Don't show ion assets until we have a token.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v1.6.3 - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that caused the Cesium ion access token to sometimes be blank when adding an asset from the "Cesium ion Assets" panel while the "Cesium" panel is not open.
+
 ### v1.6.2 - 2021-09-14
 
 This release only updates [cesium-native](https://github.com/CesiumGS/cesium-native) from v0.7.1 to v0.7.2. See the [changelog](https://github.com/CesiumGS/cesium-native/blob/main/CHANGES.md) for a complete list of changes in cesium-native.

--- a/Source/CesiumEditor/Private/CesiumIonPanel.h
+++ b/Source/CesiumEditor/Private/CesiumIonPanel.h
@@ -75,6 +75,7 @@ private:
 
   FDelegateHandle _connectionUpdatedDelegateHandle;
   FDelegateHandle _assetsUpdatedDelegateHandle;
+  FDelegateHandle _assetAccessTokenUpdatedDelegateHandle;
   TSharedPtr<SListView<TSharedPtr<CesiumIonClient::Asset>>> _pListView;
   TArray<TSharedPtr<CesiumIonClient::Asset>> _assets;
   TSharedPtr<CesiumIonClient::Asset> _pSelection;

--- a/Source/CesiumEditor/Private/CesiumIonSession.cpp
+++ b/Source/CesiumEditor/Private/CesiumIonSession.cpp
@@ -119,6 +119,7 @@ void CesiumIonSession::disconnect() {
   this->ProfileUpdated.Broadcast();
   this->AssetsUpdated.Broadcast();
   this->TokensUpdated.Broadcast();
+  this->AssetAccessTokenUpdated.Broadcast();
 }
 
 void CesiumIonSession::refreshProfile() {

--- a/Source/CesiumEditor/Private/CesiumIonSession.cpp
+++ b/Source/CesiumEditor/Private/CesiumIonSession.cpp
@@ -237,10 +237,12 @@ void CesiumIonSession::refreshAssetAccessToken() {
       .thenInMainThread([this](CesiumIonClient::Token&& token) {
         this->_assetAccessToken = std::move(token);
         this->_isLoadingAssetAccessToken = false;
+        this->AssetAccessTokenUpdated.Broadcast();
       })
       .catchInMainThread([this](std::exception&& e) {
         this->_assetAccessToken = std::nullopt;
         this->_isLoadingAssetAccessToken = false;
+        this->AssetAccessTokenUpdated.Broadcast();
       });
 }
 

--- a/Source/CesiumEditor/Private/CesiumIonSession.h
+++ b/Source/CesiumEditor/Private/CesiumIonSession.h
@@ -56,6 +56,7 @@ public:
   FIonUpdated ProfileUpdated;
   FIonUpdated AssetsUpdated;
   FIonUpdated TokensUpdated;
+  FIonUpdated AssetAccessTokenUpdated;
 
   const std::optional<CesiumIonClient::Connection>& getConnection() const;
   const CesiumIonClient::Profile& getProfile();


### PR DESCRIPTION
Fixes #647 

Here's how to reproduce it:

1. Launch the Unreal Editor.
2. Either close the Cesium panel or make it hidden (i.e. by selecting another tab in its tab group, like Place Actors).
3. Open the Cesium ion Assets panel and make it active.
4. Close the Editor, then start it up again. The editor should remember your last state, so the Cesium ion Assets panel should be visible but the Cesium panel should not be. The Cesium ion Assets panel should have a list of assets in it.
5. Select any asset from the list and add it.

The new tileset will be created with a blank access token. If you remove and re-add it, it will have the right token the second time.

The problem was that the Assets panel wasn't ensuring we had a valid token (and loading it if necessary) before allowing assets to be added.

