### PR TITLE
Compute tangents after UVs are set, and initialize LoadModelResult fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,6 +159,7 @@ jobs:
       homebrew:
         packages:
         - p7zip
+        update: true
     install:
     - python -m pip install --upgrade pip
     - pip3 install --upgrade pip

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+### v1.6.3 - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that caused incorrect tangents to be generated based on uninitialized texture coordinates.
+- Fixed a bug that could cause vertices to be duplicated and tangents calculated even when not needed.
+
 ### v1.6.2 - 2021-09-14
 
 This release only updates [cesium-native](https://github.com/CesiumGS/cesium-native) from v0.7.1 to v0.7.2. See the [changelog](https://github.com/CesiumGS/cesium-native/blob/main/CHANGES.md) for a complete list of changes in cesium-native.

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -57,36 +57,36 @@ using namespace CesiumGltf;
 static uint32_t nextMaterialId = 0;
 
 struct LoadModelResult {
-  FCesiumMetadataPrimitive Metadata;
-  FStaticMeshRenderData* RenderData;
-  const CesiumGltf::Model* pModel;
-  const CesiumGltf::MeshPrimitive* pMeshPrimitive;
-  const CesiumGltf::Material* pMaterial;
-  glm::dmat4x4 transform;
+  FCesiumMetadataPrimitive Metadata{};
+  FStaticMeshRenderData* RenderData = nullptr;
+  const CesiumGltf::Model* pModel = nullptr;
+  const CesiumGltf::MeshPrimitive* pMeshPrimitive = nullptr;
+  const CesiumGltf::Material* pMaterial = nullptr;
+  glm::dmat4x4 transform{1.0};
 #if PHYSICS_INTERFACE_PHYSX
-  PxTriangleMesh* pCollisionMesh;
+  PxTriangleMesh* pCollisionMesh = nullptr;
 #else
   TSharedPtr<Chaos::FTriangleMeshImplicitObject, ESPMode::ThreadSafe>
-      pCollisionMesh;
+      pCollisionMesh = nullptr;
 #endif
-  std::string name;
+  std::string name{};
 
-  CesiumTextureUtility::LoadedTextureResult* baseColorTexture;
-  CesiumTextureUtility::LoadedTextureResult* metallicRoughnessTexture;
-  CesiumTextureUtility::LoadedTextureResult* normalTexture;
-  CesiumTextureUtility::LoadedTextureResult* emissiveTexture;
-  CesiumTextureUtility::LoadedTextureResult* occlusionTexture;
-  CesiumTextureUtility::LoadedTextureResult* waterMaskTexture;
+  CesiumTextureUtility::LoadedTextureResult* baseColorTexture = nullptr;
+  CesiumTextureUtility::LoadedTextureResult* metallicRoughnessTexture = nullptr;
+  CesiumTextureUtility::LoadedTextureResult* normalTexture = nullptr;
+  CesiumTextureUtility::LoadedTextureResult* emissiveTexture = nullptr;
+  CesiumTextureUtility::LoadedTextureResult* occlusionTexture = nullptr;
+  CesiumTextureUtility::LoadedTextureResult* waterMaskTexture = nullptr;
   std::unordered_map<std::string, uint32_t> textureCoordinateParameters;
 
-  bool onlyLand;
-  bool onlyWater;
+  bool onlyLand = true;
+  bool onlyWater = false;
 
-  double waterMaskTranslationX;
-  double waterMaskTranslationY;
-  double waterMaskScale;
+  double waterMaskTranslationX = 0.0;
+  double waterMaskTranslationY = 0.0;
+  double waterMaskScale = 1.0;
 
-  OverlayTextureCoordinateIDMap overlayTextureCoordinateIDToUVIndex;
+  OverlayTextureCoordinateIDMap overlayTextureCoordinateIDToUVIndex{};
 };
 
 template <class... T> struct IsAccessorView;
@@ -740,12 +740,6 @@ static void loadPrimitive(
   StaticMeshBuildVertices.SetNum(
       duplicateVertices ? indices.Num() : positionView.size());
 
-  // The static mesh we construct will _not_ be indexed, even if the incoming
-  // glTF is. This allows us to compute flat normals if the glTF doesn't include
-  // them already, and it allows us to compute a correct tangent space basis
-  // according to the MikkTSpace algorithm when tangents are not included in the
-  // glTF.
-
   {
     if (duplicateVertices) {
       CESIUM_TRACE("copy duplicated positions");
@@ -771,63 +765,6 @@ static void loadPrimitive(
             RenderData->Bounds.SphereRadius);
       }
     }
-  }
-
-  // TangentX: Tangent
-  // TangentY: Bi-tangent
-  // TangentZ: Normal
-
-  if (hasNormals) {
-    if (duplicateVertices) {
-      CESIUM_TRACE("copy normals for duplicated vertices");
-      for (int64_t i = 0; i < indices.Num(); ++i) {
-        FStaticMeshBuildVertex& vertex = StaticMeshBuildVertices[i];
-        uint32 vertexIndex = indices[i];
-        vertex.TangentX = FVector(0.0f, 0.0f, 0.0f);
-        vertex.TangentY = FVector(0.0f, 0.0f, 0.0f);
-        vertex.TangentZ = normalAccessor[vertexIndex];
-      }
-    } else {
-      CESIUM_TRACE("copy normals");
-      for (int64_t i = 0; i < StaticMeshBuildVertices.Num(); ++i) {
-        FStaticMeshBuildVertex& vertex = StaticMeshBuildVertices[i];
-        vertex.TangentX = FVector(0.0f, 0.0f, 0.0f);
-        vertex.TangentY = FVector(0.0f, 0.0f, 0.0f);
-        vertex.TangentZ = normalAccessor[i];
-      }
-    }
-  } else {
-    CESIUM_TRACE("compute flat normals");
-    computeFlatNormals(indices, StaticMeshBuildVertices);
-  }
-
-  if (hasTangents) {
-    if (duplicateVertices) {
-      CESIUM_TRACE("copy tangents for duplicated vertices");
-      for (int64_t i = 0; i < indices.Num(); ++i) {
-        FStaticMeshBuildVertex& vertex = StaticMeshBuildVertices[i];
-        uint32 vertexIndex = indices[i];
-        const FVector4& tangent = tangentAccessor[vertexIndex];
-        vertex.TangentX = tangent;
-        vertex.TangentY =
-            FVector::CrossProduct(vertex.TangentZ, vertex.TangentX) * tangent.W;
-      }
-    } else {
-      CESIUM_TRACE("copy tangents");
-      for (int64_t i = 0; i < StaticMeshBuildVertices.Num(); ++i) {
-        FStaticMeshBuildVertex& vertex = StaticMeshBuildVertices[i];
-        const FVector4& tangent = tangentAccessor[i];
-        vertex.TangentX = tangent;
-        vertex.TangentY =
-            FVector::CrossProduct(vertex.TangentZ, vertex.TangentX) * tangent.W;
-      }
-    }
-  }
-
-  if (needsTangents && !hasTangents) {
-    // Use mikktspace to calculate the tangents
-    CESIUM_TRACE("compute tangents");
-    computeTangentSpace(StaticMeshBuildVertices);
   }
 
   bool hasVertexColors = false;
@@ -933,6 +870,64 @@ static void loadPrimitive(
         primitiveResult.overlayTextureCoordinateIDToUVIndex[i] = 0;
       }
     }
+  }
+
+  // TangentX: Tangent
+  // TangentY: Bi-tangent
+  // TangentZ: Normal
+
+  if (hasNormals) {
+    if (duplicateVertices) {
+      CESIUM_TRACE("copy normals for duplicated vertices");
+      for (int64_t i = 0; i < indices.Num(); ++i) {
+        FStaticMeshBuildVertex& vertex = StaticMeshBuildVertices[i];
+        uint32 vertexIndex = indices[i];
+        vertex.TangentX = FVector(0.0f, 0.0f, 0.0f);
+        vertex.TangentY = FVector(0.0f, 0.0f, 0.0f);
+        vertex.TangentZ = normalAccessor[vertexIndex];
+      }
+    } else {
+      CESIUM_TRACE("copy normals");
+      for (int64_t i = 0; i < StaticMeshBuildVertices.Num(); ++i) {
+        FStaticMeshBuildVertex& vertex = StaticMeshBuildVertices[i];
+        vertex.TangentX = FVector(0.0f, 0.0f, 0.0f);
+        vertex.TangentY = FVector(0.0f, 0.0f, 0.0f);
+        vertex.TangentZ = normalAccessor[i];
+      }
+    }
+  } else {
+    CESIUM_TRACE("compute flat normals");
+    computeFlatNormals(indices, StaticMeshBuildVertices);
+  }
+
+  if (hasTangents) {
+    if (duplicateVertices) {
+      CESIUM_TRACE("copy tangents for duplicated vertices");
+      for (int64_t i = 0; i < indices.Num(); ++i) {
+        FStaticMeshBuildVertex& vertex = StaticMeshBuildVertices[i];
+        uint32 vertexIndex = indices[i];
+        const FVector4& tangent = tangentAccessor[vertexIndex];
+        vertex.TangentX = tangent;
+        vertex.TangentY =
+            FVector::CrossProduct(vertex.TangentZ, vertex.TangentX) * tangent.W;
+      }
+    } else {
+      CESIUM_TRACE("copy tangents");
+      for (int64_t i = 0; i < StaticMeshBuildVertices.Num(); ++i) {
+        FStaticMeshBuildVertex& vertex = StaticMeshBuildVertices[i];
+        const FVector4& tangent = tangentAccessor[i];
+        vertex.TangentX = tangent;
+        vertex.TangentY =
+            FVector::CrossProduct(vertex.TangentZ, vertex.TangentX) * tangent.W;
+      }
+    }
+  }
+
+  if (needsTangents && !hasTangents) {
+    // Use mikktspace to calculate the tangents.
+    // Note that this assumes normals and UVs are already populated.
+    CESIUM_TRACE("compute tangents");
+    computeTangentSpace(StaticMeshBuildVertices);
   }
 
   {


### PR DESCRIPTION
Fixes #652 

In addition to fix the tangent computation order, I noticed and fixed a bug where an unitialized `LoadModelResult::waterMaskTexture` pointer, if it happened to not be null, would make us erroneously think we needed to duplicate vertices and generate tangents.