### PR TITLE
Add homebrew update to fix macos build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,6 +159,7 @@ jobs:
       homebrew:
         packages:
         - p7zip
+        update: true
     install:
     - python -m pip install --upgrade pip
     - pip3 install --upgrade pip


### PR DESCRIPTION
The Travis macOS image doesn't automatically update homebrew, and its p7zip record has a URL that has recently become invalid. This makes all our macOS builds fail to install 7zip, which in turn makes them fail to publish the built package. This PR fixes that by telling homebrew to update.