### PR TITLE
Set C_Cpp.default.configurationProvider VSCode setting.

### DIFF
--- a/extern/.vscode/settings.json
+++ b/extern/.vscode/settings.json
@@ -104,5 +104,6 @@
         "*.idl": "cpp",
         "string_view": "cpp",
         "xmemory0": "cpp"
-    }
+    },
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
 }


### PR DESCRIPTION
Without this, Intellisense doesn't work on my system for cesium-native opened on the extern directory. It shows red squiggles for most `#include` lines because it apparently can't resolve the include directory. It used to work, so I'm not sure what changed, but we already have this setting in cesium-native itself and there should be no harm in adding it here, too.