### PR TITLE
Add missing category specifiers

### DIFF
--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -74,16 +74,20 @@ private:
    *
    * This property will be null before ResolveGeoreference is called.
    */
-  UPROPERTY(Transient, BlueprintReadOnly, Meta = (AllowPrivateAccess))
+  UPROPERTY(
+      Transient,
+      BlueprintReadOnly,
+      Category = "Cesium",
+      Meta = (AllowPrivateAccess))
   ACesiumGeoreference* ResolvedGeoreference = nullptr;
 
 public:
   /** @copydoc ACesium3DTileset::Georeference */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   ACesiumGeoreference* GetGeoreference() const;
 
   /** @copydoc ACesium3DTileset::Georeference */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   void SetGeoreference(ACesiumGeoreference* NewGeoreference);
 
   /**
@@ -129,16 +133,20 @@ private:
    *
    * This property will be null before ResolveCreditSystem is called.
    */
-  UPROPERTY(Transient, BlueprintReadOnly, Meta = (AllowPrivateAccess))
+  UPROPERTY(
+      Transient,
+      BlueprintReadOnly,
+      Category = "Cesium",
+      Meta = (AllowPrivateAccess))
   ACesiumCreditSystem* ResolvedCreditSystem = nullptr;
 
 public:
   /** @copydoc ACesium3DTileset::CreditSystem */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   ACesiumCreditSystem* GetCreditSystem() const;
 
   /** @copydoc ACesium3DTileset::CreditSystem */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   void SetCreditSystem(ACesiumCreditSystem* NewCreditSystem);
 
   /**

--- a/Source/CesiumRuntime/Public/CesiumGlobeAnchorComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGlobeAnchorComponent.h
@@ -50,16 +50,20 @@ private:
    * This property will be null before ResolveGeoreference is called, which
    * happens automatically when the component is registered.
    */
-  UPROPERTY(Transient, BlueprintReadOnly, Meta = (AllowPrivateAccess))
+  UPROPERTY(
+      Transient,
+      BlueprintReadOnly,
+      Category = "Cesium",
+      Meta = (AllowPrivateAccess))
   ACesiumGeoreference* ResolvedGeoreference = nullptr;
 
 public:
   /** @copydoc UCesiumGlobeAnchorComponent::Georeference */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   ACesiumGeoreference* GetGeoreference() const;
 
   /** @copydoc UCesiumGlobeAnchorComponent::Georeference */
-  UFUNCTION(BlueprintCallable)
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   void SetGeoreference(ACesiumGeoreference* NewGeoreference);
 
   /**

--- a/Source/CesiumRuntime/Public/CesiumSubLevel.h
+++ b/Source/CesiumRuntime/Public/CesiumSubLevel.h
@@ -77,6 +77,6 @@ struct FCesiumSubLevel {
       meta = (ClampMin = 0.0, EditCondition = "Enabled"))
   double LoadRadius = 0.0;
 
-  UPROPERTY(VisibleDefaultsOnly)
+  UPROPERTY(VisibleDefaultsOnly, Category = "Cesium")
   bool CanBeEnabled = false;
 };


### PR DESCRIPTION
Without these, installing the plugin as an engine plugin and attempting to package fails with a bunch of errors, as seen in #673.