### PR TITLE
Make raster overlay options configurable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,7 @@ jobs:
     env: PATH=/c/Python39:/c/Python39/Scripts:$PATH
   - name: MacOS 4.26
     os: osx
-    osx_image: xcode11.3
+    osx_image: xcode12
     addons:
       homebrew:
         packages:

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1498,6 +1498,15 @@ void ACesium3DTileset::PostEditChangeProperty(
   } else if (
       PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, CreditSystem)) {
     this->InvalidateResolvedCreditSystem();
+  } else if (
+      PropName ==
+      GET_MEMBER_NAME_CHECKED(ACesium3DTileset, MaximumScreenSpaceError)) {
+    TArray<UCesiumRasterOverlay*> rasterOverlays;
+    this->GetComponents<UCesiumRasterOverlay>(rasterOverlays);
+
+    for (UCesiumRasterOverlay* pOverlay : rasterOverlays) {
+      pOverlay->Refresh();
+    }
   }
 }
 

--- a/Source/CesiumRuntime/Private/CesiumBingMapsRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumBingMapsRasterOverlay.cpp
@@ -5,7 +5,8 @@
 #include "Cesium3DTilesSelection/Tileset.h"
 
 std::unique_ptr<Cesium3DTilesSelection::RasterOverlay>
-UCesiumBingMapsRasterOverlay::CreateOverlay() {
+UCesiumBingMapsRasterOverlay::CreateOverlay(
+    const Cesium3DTilesSelection::RasterOverlayOptions& options) {
   std::string mapStyle;
 
   switch (this->MapStyle) {
@@ -42,5 +43,6 @@ UCesiumBingMapsRasterOverlay::CreateOverlay() {
       TCHAR_TO_UTF8(*this->BingMapsKey),
       mapStyle,
       "",
-      CesiumGeospatial::Ellipsoid::WGS84);
+      CesiumGeospatial::Ellipsoid::WGS84,
+      options);
 }

--- a/Source/CesiumRuntime/Private/CesiumIonRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumIonRasterOverlay.cpp
@@ -5,9 +5,11 @@
 #include "Cesium3DTilesSelection/Tileset.h"
 
 std::unique_ptr<Cesium3DTilesSelection::RasterOverlay>
-UCesiumIonRasterOverlay::CreateOverlay() {
+UCesiumIonRasterOverlay::CreateOverlay(
+    const Cesium3DTilesSelection::RasterOverlayOptions& options) {
   return std::make_unique<Cesium3DTilesSelection::IonRasterOverlay>(
       TCHAR_TO_UTF8(*this->MaterialLayerKey),
       this->IonAssetID,
-      TCHAR_TO_UTF8(*this->IonAccessToken));
+      TCHAR_TO_UTF8(*this->IonAccessToken),
+      options);
 }

--- a/Source/CesiumRuntime/Private/CesiumPolygonRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPolygonRasterOverlay.cpp
@@ -16,7 +16,8 @@ UCesiumPolygonRasterOverlay::UCesiumPolygonRasterOverlay()
 }
 
 std::unique_ptr<Cesium3DTilesSelection::RasterOverlay>
-UCesiumPolygonRasterOverlay::CreateOverlay() {
+UCesiumPolygonRasterOverlay::CreateOverlay(
+    const Cesium3DTilesSelection::RasterOverlayOptions& options) {
   std::vector<CartographicPolygon> polygons;
   polygons.reserve(this->Polygons.Num());
 
@@ -33,7 +34,8 @@ UCesiumPolygonRasterOverlay::CreateOverlay() {
       TCHAR_TO_UTF8(*this->MaterialLayerKey),
       polygons,
       CesiumGeospatial::Ellipsoid::WGS84,
-      CesiumGeospatial::GeographicProjection());
+      CesiumGeospatial::GeographicProjection(),
+      options);
 }
 
 void UCesiumPolygonRasterOverlay::OnAdd(

--- a/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
@@ -22,8 +22,7 @@ void UCesiumRasterOverlay::PostEditChangeProperty(
     FPropertyChangedEvent& PropertyChangedEvent) {
   Super::PostEditChangeProperty(PropertyChangedEvent);
 
-  this->RemoveFromTileset();
-  this->AddToTileset();
+  this->Refresh();
 }
 #endif
 
@@ -37,8 +36,14 @@ void UCesiumRasterOverlay::AddToTileset() {
     return;
   }
 
+  Cesium3DTilesSelection::RasterOverlayOptions options{};
+  options.maximumScreenSpaceError = this->MaximumScreenSpaceError;
+  options.maximumSimultaneousTileLoads = this->MaximumSimultaneousTileLoads;
+  options.maximumTextureSize = this->MaximumTextureSize;
+  options.subTileCacheBytes = this->SubTileCacheBytes;
+
   std::unique_ptr<Cesium3DTilesSelection::RasterOverlay> pOverlay =
-      this->CreateOverlay();
+      this->CreateOverlay(options);
   this->_pOverlay = pOverlay.get();
 
   pTileset->getOverlays().add(std::move(pOverlay));
@@ -59,6 +64,53 @@ void UCesiumRasterOverlay::RemoveFromTileset() {
   this->OnRemove(pTileset, this->_pOverlay);
   pTileset->getOverlays().remove(this->_pOverlay);
   this->_pOverlay = nullptr;
+}
+
+void UCesiumRasterOverlay::Refresh() {
+  this->RemoveFromTileset();
+  this->AddToTileset();
+}
+
+float UCesiumRasterOverlay::GetMaximumScreenSpaceError() const {
+  return this->MaximumScreenSpaceError;
+}
+
+void UCesiumRasterOverlay::SetMaximumScreenSpaceError(float Value) {
+  this->MaximumScreenSpaceError = Value;
+  this->Refresh();
+}
+
+int32 UCesiumRasterOverlay::GetMaximumTextureSize() const {
+  return this->MaximumTextureSize;
+}
+
+void UCesiumRasterOverlay::SetMaximumTextureSize(int32 Value) {
+  this->MaximumTextureSize = Value;
+  this->Refresh();
+}
+
+int32 UCesiumRasterOverlay::GetMaximumSimultaneousTileLoads() const {
+  return this->MaximumSimultaneousTileLoads;
+}
+
+void UCesiumRasterOverlay::SetMaximumSimultaneousTileLoads(int32 Value) {
+  this->MaximumSimultaneousTileLoads = Value;
+
+  if (this->_pOverlay) {
+    this->_pOverlay->getOptions().maximumSimultaneousTileLoads = Value;
+  }
+}
+
+int64 UCesiumRasterOverlay::GetSubTileCacheBytes() const {
+  return this->SubTileCacheBytes;
+}
+
+void UCesiumRasterOverlay::SetSubTileCacheBytes(int64 Value) {
+  this->SubTileCacheBytes = Value;
+
+  if (this->_pOverlay) {
+    this->_pOverlay->getOptions().subTileCacheBytes = Value;
+  }
 }
 
 void UCesiumRasterOverlay::Activate(bool bReset) {

--- a/Source/CesiumRuntime/Private/CesiumTileMapServiceRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTileMapServiceRasterOverlay.cpp
@@ -5,15 +5,17 @@
 #include "CesiumRuntime.h"
 
 std::unique_ptr<Cesium3DTilesSelection::RasterOverlay>
-UCesiumTileMapServiceRasterOverlay::CreateOverlay() {
-  Cesium3DTilesSelection::TileMapServiceRasterOverlayOptions Options;
+UCesiumTileMapServiceRasterOverlay::CreateOverlay(
+    const Cesium3DTilesSelection::RasterOverlayOptions& options) {
+  Cesium3DTilesSelection::TileMapServiceRasterOverlayOptions tmsOptions;
   if (MaximumLevel > MinimumLevel && bSpecifyZoomLevels) {
-    Options.minimumLevel = MinimumLevel;
-    Options.maximumLevel = MaximumLevel;
+    tmsOptions.minimumLevel = MinimumLevel;
+    tmsOptions.maximumLevel = MaximumLevel;
   }
   return std::make_unique<Cesium3DTilesSelection::TileMapServiceRasterOverlay>(
       TCHAR_TO_UTF8(*this->MaterialLayerKey),
       TCHAR_TO_UTF8(*this->Url),
       std::vector<CesiumAsync::IAssetAccessor::THeader>(),
-      Options);
+      tmsOptions,
+      options);
 }

--- a/Source/CesiumRuntime/Public/CesiumBingMapsRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumBingMapsRasterOverlay.h
@@ -41,6 +41,7 @@ public:
   EBingMapsStyle MapStyle = EBingMapsStyle::Aerial;
 
 protected:
-  virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay>
-  CreateOverlay() override;
+  virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay> CreateOverlay(
+      const Cesium3DTilesSelection::RasterOverlayOptions& options = {})
+      override;
 };

--- a/Source/CesiumRuntime/Public/CesiumIonRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumIonRasterOverlay.h
@@ -33,6 +33,7 @@ public:
   FString IonAccessToken;
 
 protected:
-  virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay>
-  CreateOverlay() override;
+  virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay> CreateOverlay(
+      const Cesium3DTilesSelection::RasterOverlayOptions& options = {})
+      override;
 };

--- a/Source/CesiumRuntime/Public/CesiumPolygonRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumPolygonRasterOverlay.h
@@ -42,8 +42,10 @@ public:
   bool ExcludeTilesInside = true;
 
 protected:
-  virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay>
-  CreateOverlay() override;
+  virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay> CreateOverlay(
+      const Cesium3DTilesSelection::RasterOverlayOptions& options = {})
+      override;
+
   virtual void OnAdd(
       Cesium3DTilesSelection::Tileset* pTileset,
       Cesium3DTilesSelection::RasterOverlay* pOverlay) override;

--- a/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
@@ -51,11 +51,102 @@ public:
    */
   void RemoveFromTileset();
 
+  /**
+   * Refreshes this tileset by removing and re-adding it.
+   */
+  void Refresh();
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  float GetMaximumScreenSpaceError() const;
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  void SetMaximumScreenSpaceError(float Value);
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  int32 GetMaximumTextureSize() const;
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  void SetMaximumTextureSize(int32 Value);
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  int32 GetMaximumSimultaneousTileLoads() const;
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  void SetMaximumSimultaneousTileLoads(int32 Value);
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  int64 GetSubTileCacheBytes() const;
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  void SetSubTileCacheBytes(int64 Value);
+
   virtual void Activate(bool bReset) override;
   virtual void Deactivate() override;
   virtual void OnComponentDestroyed(bool bDestroyingHierarchy) override;
 
 protected:
+  /**
+   * The maximum number of pixels of error when rendering this overlay.
+   * This is used to select an appropriate level-of-detail.
+   *
+   * When this property has its default value, 2.0, it means that raster overlay
+   * images will be sized so that, when zoomed in closest, a single pixel in
+   * the raster overlay maps to approximately 2x2 pixels on the screen.
+   */
+  UPROPERTY(
+      EditAnywhere,
+      BlueprintReadWrite,
+      BlueprintGetter = GetMaximumScreenSpaceError,
+      BlueprintSetter = SetMaximumScreenSpaceError,
+      Category = "Cesium")
+  float MaximumScreenSpaceError = 2.0;
+
+  /**
+   * The maximum texel size of raster overlay textures, in either
+   * direction.
+   *
+   * Images created by this overlay will be no more than this number of texels
+   * in either direction. This may result in reduced raster overlay detail in
+   * some cases.
+   */
+  UPROPERTY(
+      EditAnywhere,
+      BlueprintReadWrite,
+      BlueprintGetter = GetMaximumTextureSize,
+      BlueprintSetter = SetMaximumTextureSize,
+      Category = "Cesium")
+  int32 MaximumTextureSize = 2048;
+
+  /**
+   * The maximum number of overlay tiles that may simultaneously be in
+   * the process of loading.
+   */
+  UPROPERTY(
+      EditAnywhere,
+      BlueprintReadWrite,
+      BlueprintGetter = GetMaximumSimultaneousTileLoads,
+      BlueprintSetter = SetMaximumSimultaneousTileLoads,
+      Category = "Cesium")
+  int32 MaximumSimultaneousTileLoads = 20;
+
+  /**
+   * The maximum number of bytes to use to cache sub-tiles in memory.
+   *
+   * This is used by provider types, that have an underlying tiling
+   * scheme that may not align with the tiling scheme of the geometry tiles on
+   * which the raster overlay tiles are draped. Because a single sub-tile may
+   * overlap multiple geometry tiles, it is useful to cache loaded sub-tiles
+   * in memory in case they're needed again soon. This property controls the
+   * maximum size of that cache.
+   */
+  UPROPERTY(
+      EditAnywhere,
+      BlueprintReadWrite,
+      BlueprintGetter = GetSubTileCacheBytes,
+      BlueprintSetter = SetSubTileCacheBytes,
+      Category = "Cesium")
+  int64 SubTileCacheBytes = 16 * 1024 * 1024;
+
 #if WITH_EDITOR
   // Called when properties are changed in the editor
   virtual void
@@ -64,8 +155,10 @@ protected:
 
   Cesium3DTilesSelection::Tileset* FindTileset() const;
 
-  virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay> CreateOverlay()
+  virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay> CreateOverlay(
+      const Cesium3DTilesSelection::RasterOverlayOptions& options = {})
       PURE_VIRTUAL(UCesiumRasterOverlay::CreateOverlay, return nullptr;);
+
   virtual void OnAdd(
       Cesium3DTilesSelection::Tileset* pTileset,
       Cesium3DTilesSelection::RasterOverlay* pOverlay) {}

--- a/Source/CesiumRuntime/Public/CesiumTileMapServiceRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumTileMapServiceRasterOverlay.h
@@ -51,6 +51,7 @@ public:
   int32 MaximumLevel = 10;
 
 protected:
-  virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay>
-  CreateOverlay() override;
+  virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay> CreateOverlay(
+      const Cesium3DTilesSelection::RasterOverlayOptions& options = {})
+      override;
 };


### PR DESCRIPTION
Most importantly the screen-space error, which is now independent of the geometry SSE.

Requires CesiumGS/cesium-native#327.
