### PR TITLE
Added custom depth and stencil support to Cesium3DTileset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ???
+
+##### Additions :tada:
+
+- `Cesium3DTileset` now has options for enabling custom depth and stencil buffer.
+
 ### v1.7.0 - 2021-11-01
 
 ##### Breaking Changes :mega:

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -269,6 +269,14 @@ void ACesium3DTileset::SetWaterMaterial(UMaterialInterface* InMaterial) {
   }
 }
 
+void ACesium3DTileset::SetCustomDepthParameters(
+    FCustomDepthParameters InCustomDepthParameters) {
+  if(this->CustomDepthParameters != InCustomDepthParameters) {
+    this->CustomDepthParameters = InCustomDepthParameters;
+    this->DestroyTileset();
+  }
+}
+
 void ACesium3DTileset::PlayMovieSequencer() {
   this->_beforeMoviePreloadAncestors = this->PreloadAncestors;
   this->_beforeMoviePreloadSiblings = this->PreloadSiblings;
@@ -539,7 +547,8 @@ public:
           std::move(pHalf),
           _pActor->GetCesiumTilesetToUnrealRelativeWorldTransform(),
           this->_pActor->GetMaterial(),
-          this->_pActor->GetWaterMaterial());
+          this->_pActor->GetWaterMaterial(),
+          this->_pActor->GetCustomDepthParameters());
     }
     // UE_LOG(LogCesium, VeryVerbose, TEXT("No content for tile"));
     return nullptr;
@@ -1477,6 +1486,7 @@ void ACesium3DTileset::PostEditChangeProperty(
   }
 
   FName PropName = PropertyChangedEvent.Property->GetFName();
+  FString PropNameAsString = PropertyChangedEvent.Property->GetName();
 
   if (PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, TilesetSource) ||
       PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, Url) ||
@@ -1490,7 +1500,12 @@ void ACesium3DTileset::PostEditChangeProperty(
           GET_MEMBER_NAME_CHECKED(ACesium3DTileset, GenerateSmoothNormals) ||
       PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, EnableWaterMask) ||
       PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, Material) ||
-      PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, WaterMaterial)) {
+      PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, WaterMaterial) ||
+      // For properties nested in structs, GET_MEMBER_NAME_CHECKED will prefix
+      // with the struct name, so just do a manual string comparison.
+      PropNameAsString == TEXT("RenderCustomDepth") ||
+      PropNameAsString == TEXT("CustomDepthStencilValue") ||
+      PropNameAsString == TEXT("CustomDepthStencilWriteMask")) {
     this->DestroyTileset();
   } else if (
       PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, Georeference)) {

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -271,7 +271,7 @@ void ACesium3DTileset::SetWaterMaterial(UMaterialInterface* InMaterial) {
 
 void ACesium3DTileset::SetCustomDepthParameters(
     FCustomDepthParameters InCustomDepthParameters) {
-  if(this->CustomDepthParameters != InCustomDepthParameters) {
+  if (this->CustomDepthParameters != InCustomDepthParameters) {
     this->CustomDepthParameters = InCustomDepthParameters;
     this->DestroyTileset();
   }

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1560,6 +1560,9 @@ static void loadModelGameThreadPart(
   pMesh->Metadata = std::move(loadResult.Metadata);
   pMesh->pModel = loadResult.pModel;
   pMesh->pMeshPrimitive = loadResult.pMeshPrimitive;
+  pMesh->SetRenderCustomDepth(pGltf->CustomDepthParameters.RenderCustomDepth);
+  pMesh->SetCustomDepthStencilWriteMask(pGltf->CustomDepthParameters.CustomDepthStencilWriteMask);
+  pMesh->SetCustomDepthStencilValue(pGltf->CustomDepthParameters.CustomDepthStencilValue);
 
   UStaticMesh* pStaticMesh = NewObject<UStaticMesh>(pMesh, meshName);
   pMesh->SetStaticMesh(pStaticMesh);
@@ -1741,7 +1744,8 @@ UCesiumGltfComponent::CreateOffGameThread(
     std::unique_ptr<HalfConstructed> pHalfConstructed,
     const glm::dmat4x4& cesiumToUnrealTransform,
     UMaterialInterface* pBaseMaterial,
-    UMaterialInterface* pBaseWaterMaterial) {
+    UMaterialInterface* pBaseWaterMaterial,
+    FCustomDepthParameters CustomDepthParameters) {
   HalfConstructedReal* pReal =
       static_cast<HalfConstructedReal*>(pHalfConstructed.get());
   std::vector<LoadModelResult>& result = pReal->loadModelResult;
@@ -1760,6 +1764,8 @@ UCesiumGltfComponent::CreateOffGameThread(
   if (pBaseWaterMaterial) {
     Gltf->BaseMaterialWithWater = pBaseWaterMaterial;
   }
+
+  Gltf->CustomDepthParameters = CustomDepthParameters;
 
   for (LoadModelResult& model : result) {
     loadModelGameThreadPart(Gltf, model, cesiumToUnrealTransform);

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1561,8 +1561,10 @@ static void loadModelGameThreadPart(
   pMesh->pModel = loadResult.pModel;
   pMesh->pMeshPrimitive = loadResult.pMeshPrimitive;
   pMesh->SetRenderCustomDepth(pGltf->CustomDepthParameters.RenderCustomDepth);
-  pMesh->SetCustomDepthStencilWriteMask(pGltf->CustomDepthParameters.CustomDepthStencilWriteMask);
-  pMesh->SetCustomDepthStencilValue(pGltf->CustomDepthParameters.CustomDepthStencilValue);
+  pMesh->SetCustomDepthStencilWriteMask(
+      pGltf->CustomDepthParameters.CustomDepthStencilWriteMask);
+  pMesh->SetCustomDepthStencilValue(
+      pGltf->CustomDepthParameters.CustomDepthStencilValue);
 
   UStaticMesh* pStaticMesh = NewObject<UStaticMesh>(pMesh, meshName);
   pMesh->SetStaticMesh(pStaticMesh);

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
+#include "Components/PrimitiveComponent.h"
 #include "Components/SceneComponent.h"
 #include "CoreMinimal.h"
 #include "CustomDepthParameters.h"
-#include "Components/PrimitiveComponent.h"
 #include "Interfaces/IHttpRequest.h"
 #include <glm/mat4x4.hpp>
 #include <memory>
@@ -79,7 +79,7 @@ public:
   UPROPERTY(EditAnywhere, Category = "Cesium")
   UMaterialInterface* BaseMaterialWithWater;
 
-  UPROPERTY(EditAnywhere, Category= "Rendering")
+  UPROPERTY(EditAnywhere, Category = "Rendering")
   FCustomDepthParameters CustomDepthParameters;
 
   void UpdateTransformFromCesium(const glm::dmat4& CesiumToUnrealTransform);

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.h
@@ -4,6 +4,8 @@
 
 #include "Components/SceneComponent.h"
 #include "CoreMinimal.h"
+#include "CustomDepthParameters.h"
+#include "Components/PrimitiveComponent.h"
 #include "Interfaces/IHttpRequest.h"
 #include <glm/mat4x4.hpp>
 #include <memory>
@@ -65,7 +67,8 @@ public:
       std::unique_ptr<HalfConstructed> HalfConstructed,
       const glm::dmat4x4& CesiumToUnrealTransform,
       UMaterialInterface* BaseMaterial,
-      UMaterialInterface* BaseWaterMaterial);
+      UMaterialInterface* BaseWaterMaterial,
+      FCustomDepthParameters CustomDepthParameters);
 
   UCesiumGltfComponent();
   virtual ~UCesiumGltfComponent();
@@ -75,6 +78,9 @@ public:
 
   UPROPERTY(EditAnywhere, Category = "Cesium")
   UMaterialInterface* BaseMaterialWithWater;
+
+  UPROPERTY(EditAnywhere, Category= "Rendering")
+  FCustomDepthParameters CustomDepthParameters;
 
   void UpdateTransformFromCesium(const glm::dmat4& CesiumToUnrealTransform);
 

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -8,6 +8,7 @@
 #include "CesiumExclusionZone.h"
 #include "CesiumGeoreference.h"
 #include "CoreMinimal.h"
+#include "CustomDepthParameters.h"
 #include "GameFramework/Actor.h"
 #include "Interfaces/IHttpRequest.h"
 #include <PhysicsEngine/BodyInstance.h>
@@ -541,6 +542,14 @@ private:
       Category = "Cesium|Rendering")
   UMaterialInterface* WaterMaterial = nullptr;
 
+  UPROPERTY(
+    EditAnywhere,
+    BlueprintGetter = GetCustomDepthParameters,
+    BlueprintSetter = SetCustomDepthParameters,
+    Category = "Rendering",
+    meta = (ShowOnlyInnerProperties))
+  FCustomDepthParameters CustomDepthParameters;
+
 protected:
   UPROPERTY()
   FString PlatformName;
@@ -605,6 +614,12 @@ public:
 
   UFUNCTION(BlueprintSetter, Category = "Cesium|Rendering")
   void SetWaterMaterial(UMaterialInterface* InMaterial);
+
+  UFUNCTION(BlueprintGetter, Category = "Rendering")
+  FCustomDepthParameters GetCustomDepthParameters() const {return CustomDepthParameters;}
+
+  UFUNCTION(BlueprintSetter, Category = "Rendering")
+  void SetCustomDepthParameters(FCustomDepthParameters InCustomDepthParameters);
 
   UFUNCTION(BlueprintCallable, Category = "Cesium|Rendering")
   void PlayMovieSequencer();

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -543,11 +543,11 @@ private:
   UMaterialInterface* WaterMaterial = nullptr;
 
   UPROPERTY(
-    EditAnywhere,
-    BlueprintGetter = GetCustomDepthParameters,
-    BlueprintSetter = SetCustomDepthParameters,
-    Category = "Rendering",
-    meta = (ShowOnlyInnerProperties))
+      EditAnywhere,
+      BlueprintGetter = GetCustomDepthParameters,
+      BlueprintSetter = SetCustomDepthParameters,
+      Category = "Rendering",
+      meta = (ShowOnlyInnerProperties))
   FCustomDepthParameters CustomDepthParameters;
 
 protected:
@@ -616,7 +616,9 @@ public:
   void SetWaterMaterial(UMaterialInterface* InMaterial);
 
   UFUNCTION(BlueprintGetter, Category = "Rendering")
-  FCustomDepthParameters GetCustomDepthParameters() const {return CustomDepthParameters;}
+  FCustomDepthParameters GetCustomDepthParameters() const {
+    return CustomDepthParameters;
+  }
 
   UFUNCTION(BlueprintSetter, Category = "Rendering")
   void SetCustomDepthParameters(FCustomDepthParameters InCustomDepthParameters);

--- a/Source/CesiumRuntime/Public/CustomDepthParameters.h
+++ b/Source/CesiumRuntime/Public/CustomDepthParameters.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <CoreMinimal.h>
 #include <Components/PrimitiveComponent.h>
+#include <CoreMinimal.h>
 
 #include "CustomDepthParameters.generated.h"
 
@@ -10,26 +10,42 @@ struct CESIUMRUNTIME_API FCustomDepthParameters {
   GENERATED_USTRUCT_BODY()
 
 public:
-  /** If true, this component will be rendered in the CustomDepth pass (usually used for outlines) */
-  UPROPERTY(EditAnywhere, AdvancedDisplay, BlueprintReadOnly, Category=Rendering, meta=(DisplayName = "Render CustomDepth Pass"))
+  /** If true, this component will be rendered in the CustomDepth pass (usually
+   * used for outlines) */
+  UPROPERTY(
+      EditAnywhere,
+      AdvancedDisplay,
+      BlueprintReadOnly,
+      Category = Rendering,
+      meta = (DisplayName = "Render CustomDepth Pass"))
   bool RenderCustomDepth;
 
   /** Mask used for stencil buffer writes. */
-  UPROPERTY(EditAnywhere, AdvancedDisplay, BlueprintReadOnly, Category = "Rendering", meta = (EditCondition = "RenderCustomDepth"))
+  UPROPERTY(
+      EditAnywhere,
+      AdvancedDisplay,
+      BlueprintReadOnly,
+      Category = "Rendering",
+      meta = (EditCondition = "RenderCustomDepth"))
   ERendererStencilMask CustomDepthStencilWriteMask;
 
-  /** Optionally write this 0-255 value to the stencil buffer in CustomDepth pass (Requires project setting or r.CustomDepth == 3) */
-  UPROPERTY(EditAnywhere, AdvancedDisplay, BlueprintReadOnly, Category=Rendering,  meta=(UIMin = "0", UIMax = "255", EditCondition = "RenderCustomDepth"))
+  /** Optionally write this 0-255 value to the stencil buffer in CustomDepth
+   * pass (Requires project setting or r.CustomDepth == 3) */
+  UPROPERTY(
+      EditAnywhere,
+      AdvancedDisplay,
+      BlueprintReadOnly,
+      Category = Rendering,
+      meta = (UIMin = "0", UIMax = "255", EditCondition = "RenderCustomDepth"))
   int32 CustomDepthStencilValue;
 
   bool operator==(const FCustomDepthParameters& other) const {
     return RenderCustomDepth == other.RenderCustomDepth &&
-      CustomDepthStencilWriteMask == other.CustomDepthStencilWriteMask &&
-        CustomDepthStencilValue == other.CustomDepthStencilValue;
+           CustomDepthStencilWriteMask == other.CustomDepthStencilWriteMask &&
+           CustomDepthStencilValue == other.CustomDepthStencilValue;
   }
 
   bool operator!=(const FCustomDepthParameters& other) const {
     return !(*this == other);
   }
-
 };

--- a/Source/CesiumRuntime/Public/CustomDepthParameters.h
+++ b/Source/CesiumRuntime/Public/CustomDepthParameters.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <CoreMinimal.h>
+#include <Components/PrimitiveComponent.h>
+
+#include "CustomDepthParameters.generated.h"
+
+USTRUCT(BlueprintType)
+struct CESIUMRUNTIME_API FCustomDepthParameters {
+  GENERATED_USTRUCT_BODY()
+
+public:
+  /** If true, this component will be rendered in the CustomDepth pass (usually used for outlines) */
+  UPROPERTY(EditAnywhere, AdvancedDisplay, BlueprintReadOnly, Category=Rendering, meta=(DisplayName = "Render CustomDepth Pass"))
+  bool RenderCustomDepth;
+
+  /** Mask used for stencil buffer writes. */
+  UPROPERTY(EditAnywhere, AdvancedDisplay, BlueprintReadOnly, Category = "Rendering", meta = (EditCondition = "RenderCustomDepth"))
+  ERendererStencilMask CustomDepthStencilWriteMask;
+
+  /** Optionally write this 0-255 value to the stencil buffer in CustomDepth pass (Requires project setting or r.CustomDepth == 3) */
+  UPROPERTY(EditAnywhere, AdvancedDisplay, BlueprintReadOnly, Category=Rendering,  meta=(UIMin = "0", UIMax = "255", EditCondition = "RenderCustomDepth"))
+  int32 CustomDepthStencilValue;
+
+  bool operator==(const FCustomDepthParameters& other) const {
+    return RenderCustomDepth == other.RenderCustomDepth &&
+      CustomDepthStencilWriteMask == other.CustomDepthStencilWriteMask &&
+        CustomDepthStencilValue == other.CustomDepthStencilValue;
+  }
+
+  bool operator!=(const FCustomDepthParameters& other) const {
+    return !(*this == other);
+  }
+
+};


### PR DESCRIPTION
UE4 has a pretty handy custom depth buffer and stencil buffer. They're settings available on any primitive component, but so far it hasn't been exposed to the Cesium3DTileset actor. I added this setting and passed it to the `GltfComponent` so it gets applied when creating the `GltfPrimitiveComponent`.

I figured that setting it on creation would be a better idea than setting it on Tick (even though the engine calls do check if there's a change before marking the component's render state dirty) because of the number of components that might exist in a scene, and I would doubt that users would need to change it at runtime.

To test this feature, you will need to configure the project to support Custom Depth, or Custom Depth with Stencil if you want to test out the stencil feature. Here's a helpful tutorial:
https://medium.com/unreal-engine-material-guides/overlapping-custom-depth-stencils-a084aa763f10

The settings I added are available in the `Rendering` (not `Cesium|Rendering`) section of the actor. After enabling Custom Depth, you should be able to see its output by going to the viewport -> Show -> Buffer Visualization -> Custom Depth or Custom Stencil.