### PR TITLE
Use xcode 12, cause the travis 11.3 doesn't work anymore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,7 +154,7 @@ jobs:
     env: PATH=/c/Python39:/c/Python39/Scripts:$PATH
   - name: MacOS 4.26
     os: osx
-    osx_image: xcode11.3
+    osx_image: xcode12
     addons:
       homebrew:
         packages:

--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -149,6 +149,9 @@ public class CesiumRuntime : ModuleRules
             {
                 "SPDLOG_COMPILED_LIB",
                 "LIBASYNC_STATIC",
+                "GLM_FORCE_XYZW_ONLY",
+                "GLM_FORCE_EXPLICIT_CTOR",
+                "GLM_FORCE_SIZE_T_LENGTH",
                 // "CESIUM_TRACING_ENABLED"
             }
         );

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -315,9 +315,12 @@ void ACesium3DTileset::OnFocusEditorViewportOnThis() {
 
     glm::dvec3 operator()(const CesiumGeometry::BoundingSphere& sphere) {
       const glm::dvec3& center = sphere.getCenter();
-      glm::dmat4 ENU = localGeoTransforms.ComputeEastNorthUpToEcef(center);
+      glm::dmat4 ENU =
+          glm::dmat4(localGeoTransforms.ComputeEastNorthUpToEcef(center));
       glm::dvec3 offset =
-          sphere.getRadius() * glm::normalize(ENU[0] + ENU[1] + ENU[2]);
+          sphere.getRadius() *
+          glm::normalize(
+              glm::dvec3(ENU[0]) + glm::dvec3(ENU[1]) + glm::dvec3(ENU[2]));
       glm::dvec3 position = center + offset;
       return position;
     }
@@ -325,10 +328,13 @@ void ACesium3DTileset::OnFocusEditorViewportOnThis() {
     glm::dvec3
     operator()(const CesiumGeometry::OrientedBoundingBox& orientedBoundingBox) {
       const glm::dvec3& center = orientedBoundingBox.getCenter();
-      glm::dmat4 ENU = localGeoTransforms.ComputeEastNorthUpToEcef(center);
+      glm::dmat4 ENU =
+          glm::dmat4(localGeoTransforms.ComputeEastNorthUpToEcef(center));
       const glm::dmat3& halfAxes = orientedBoundingBox.getHalfAxes();
-      glm::dvec3 offset = glm::length(halfAxes[0] + halfAxes[1] + halfAxes[2]) *
-                          glm::normalize(ENU[0] + ENU[1] + ENU[2]);
+      glm::dvec3 offset =
+          glm::length(halfAxes[0] + halfAxes[1] + halfAxes[2]) *
+          glm::normalize(
+              glm::dvec3(ENU[0]) + glm::dvec3(ENU[1]) + glm::dvec3(ENU[2]));
       glm::dvec3 position = center + offset;
       return position;
     }
@@ -363,12 +369,12 @@ void ACesium3DTileset::OnFocusEditorViewportOnThis() {
           this->ResolveGeoreference()->GetGeoTransforms()},
       boundingVolume);
   glm::dvec3 unrealCameraPosition =
-      transform * glm::dvec4(ecefCameraPosition, 1.0);
+      glm::dvec3(transform * glm::dvec4(ecefCameraPosition, 1.0));
 
   // calculate unreal camera orientation
   glm::dvec3 ecefCenter =
       Cesium3DTilesSelection::getBoundingVolumeCenter(boundingVolume);
-  glm::dvec3 unrealCenter = transform * glm::dvec4(ecefCenter, 1.0);
+  glm::dvec3 unrealCenter = glm::dvec3(transform * glm::dvec4(ecefCenter, 1.0));
   glm::dvec3 unrealCameraFront =
       glm::normalize(unrealCenter - unrealCameraPosition);
   glm::dvec3 unrealCameraRight =
@@ -1078,14 +1084,14 @@ ACesium3DTileset::CreateViewStateFromViewParameters(
   FVector direction = camera.rotation.RotateVector(FVector(1.0f, 0.0f, 0.0f));
   FVector up = camera.rotation.RotateVector(FVector(0.0f, 0.0f, 1.0f));
 
-  glm::dvec3 tilesetCameraLocation =
+  glm::dvec3 tilesetCameraLocation = glm::dvec3(
       unrealWorldToTileset *
-      glm::dvec4(camera.location.X, camera.location.Y, camera.location.Z, 1.0);
-  glm::dvec3 tilesetCameraFront = glm::normalize(
+      glm::dvec4(camera.location.X, camera.location.Y, camera.location.Z, 1.0));
+  glm::dvec3 tilesetCameraFront = glm::normalize(glm::dvec3(
       unrealWorldToTileset *
-      glm::dvec4(direction.X, direction.Y, direction.Z, 0.0));
-  glm::dvec3 tilesetCameraUp =
-      glm::normalize(unrealWorldToTileset * glm::dvec4(up.X, up.Y, up.Z, 0.0));
+      glm::dvec4(direction.X, direction.Y, direction.Z, 0.0)));
+  glm::dvec3 tilesetCameraUp = glm::normalize(
+      glm::dvec3(unrealWorldToTileset * glm::dvec4(up.X, up.Y, up.Z, 0.0)));
 
   return Cesium3DTilesSelection::ViewState::create(
       tilesetCameraLocation,

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -164,7 +164,8 @@ void ACesiumGeoreference::PlaceGeoreferenceOriginHere() {
   // georeference origin) When the location is too close to the center of the
   // earth, the result will be (0,0,0)
   glm::dvec3 targetGeoreferenceOrigin =
-      _geoTransforms.TransformEcefToLongitudeLatitudeHeight(cameraToECEF[3]);
+      _geoTransforms.TransformEcefToLongitudeLatitudeHeight(
+          glm::dvec3(cameraToECEF[3]));
 
   this->_setGeoreferenceOrigin(
       targetGeoreferenceOrigin.x,
@@ -183,7 +184,7 @@ void ACesiumGeoreference::PlaceGeoreferenceOriginHere() {
       this->_geoTransforms
           .GetEllipsoidCenteredToAbsoluteUnrealWorldTransform() *
       cameraToECEF;
-  glm::dvec3 cameraFront = glm::normalize(newCameraTransform[0]);
+  glm::dvec3 cameraFront = glm::normalize(glm::dvec3(newCameraTransform[0]));
   glm::dvec3 cameraRight =
       glm::normalize(glm::cross(glm::dvec3(0.0, 0.0, 1.0), cameraFront));
   glm::dvec3 cameraUp = glm::normalize(glm::cross(cameraFront, cameraRight));
@@ -612,10 +613,10 @@ void ACesiumGeoreference::_handleViewportOriginEditing() {
   glm::dvec4 grabbedLocationAbs =
       VecMath::add4D(grabbedLocation, originLocation);
 
-  glm::dvec3 grabbedLocationECEF =
+  glm::dvec3 grabbedLocationECEF = glm::dvec3(
       this->_geoTransforms
           .GetAbsoluteUnrealWorldToEllipsoidCenteredTransform() *
-      grabbedLocationAbs;
+      grabbedLocationAbs);
 
   glm::dvec3 cartographic =
       _geoTransforms.TransformEcefToLongitudeLatitudeHeight(
@@ -676,10 +677,10 @@ bool ACesiumGeoreference::_updateSublevelState() {
 
   glm::dvec4 cameraAbsolute = VecMath::add4D(cameraLocation, originLocation);
 
-  glm::dvec3 cameraECEF =
+  glm::dvec3 cameraECEF = glm::dvec3(
       this->_geoTransforms
           .GetAbsoluteUnrealWorldToEllipsoidCenteredTransform() *
-      cameraAbsolute;
+      cameraAbsolute);
 
   int32 activeLevel = -1;
   double closestLevelDistance = std::numeric_limits<double>::max();
@@ -828,14 +829,14 @@ FVector ACesiumGeoreference::InaccurateTransformEcefToLongitudeLatitudeHeight(
 glm::dvec3 ACesiumGeoreference::TransformLongitudeLatitudeHeightToUnreal(
     const glm::dvec3& longitudeLatitudeHeight) const {
   return this->_geoTransforms.TransformLongitudeLatitudeHeightToUnreal(
-      CesiumActors::getWorldOrigin4D(this),
+      glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       longitudeLatitudeHeight);
 }
 
 FVector ACesiumGeoreference::InaccurateTransformLongitudeLatitudeHeightToUnreal(
     const FVector& longitudeLatitudeHeight) const {
   glm::dvec3 ue = this->_geoTransforms.TransformLongitudeLatitudeHeightToUnreal(
-      CesiumActors::getWorldOrigin4D(this),
+      glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       VecMath::createVector3D(longitudeLatitudeHeight));
   return FVector(ue.x, ue.y, ue.z);
 }
@@ -843,7 +844,7 @@ FVector ACesiumGeoreference::InaccurateTransformLongitudeLatitudeHeightToUnreal(
 glm::dvec3 ACesiumGeoreference::TransformUnrealToLongitudeLatitudeHeight(
     const glm::dvec3& ue) const {
   return this->_geoTransforms.TransformUnrealToLongitudeLatitudeHeight(
-      CesiumActors::getWorldOrigin4D(this),
+      glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       ue);
 }
 
@@ -851,7 +852,7 @@ FVector ACesiumGeoreference::InaccurateTransformUnrealToLongitudeLatitudeHeight(
     const FVector& ue) const {
   glm::dvec3 llh =
       this->_geoTransforms.TransformUnrealToLongitudeLatitudeHeight(
-          CesiumActors::getWorldOrigin4D(this),
+          glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
           VecMath::createVector3D(ue));
   return FVector(llh.x, llh.y, llh.z);
 }
@@ -859,14 +860,14 @@ FVector ACesiumGeoreference::InaccurateTransformUnrealToLongitudeLatitudeHeight(
 glm::dvec3
 ACesiumGeoreference::TransformEcefToUnreal(const glm::dvec3& ecef) const {
   return this->_geoTransforms.TransformEcefToUnreal(
-      CesiumActors::getWorldOrigin4D(this),
+      glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       ecef);
 }
 
 FVector ACesiumGeoreference::InaccurateTransformEcefToUnreal(
     const FVector& ecef) const {
   glm::dvec3 ue = this->_geoTransforms.TransformEcefToUnreal(
-      CesiumActors::getWorldOrigin4D(this),
+      glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       VecMath::createVector3D(ecef));
   return FVector(ue.x, ue.y, ue.z);
 }
@@ -874,14 +875,14 @@ FVector ACesiumGeoreference::InaccurateTransformEcefToUnreal(
 glm::dvec3
 ACesiumGeoreference::TransformUnrealToEcef(const glm::dvec3& ue) const {
   return this->_geoTransforms.TransformUnrealToEcef(
-      CesiumActors::getWorldOrigin4D(this),
+      glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       ue);
 }
 
 FVector
 ACesiumGeoreference::InaccurateTransformUnrealToEcef(const FVector& ue) const {
   glm::dvec3 ecef = this->_geoTransforms.TransformUnrealToEcef(
-      CesiumActors::getWorldOrigin4D(this),
+      glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       glm::dvec3(ue.X, ue.Y, ue.Z));
   return FVector(ecef.x, ecef.y, ecef.z);
 }
@@ -890,7 +891,7 @@ glm::dquat ACesiumGeoreference::TransformRotatorUnrealToEastNorthUp(
     const glm::dquat& UeRotator,
     const glm::dvec3& UeLocation) const {
   return this->_geoTransforms.TransformRotatorUnrealToEastNorthUp(
-      CesiumActors::getWorldOrigin4D(this),
+      glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       UeRotator,
       UeLocation);
 }
@@ -908,7 +909,7 @@ glm::dquat ACesiumGeoreference::TransformRotatorEastNorthUpToUnreal(
     const glm::dquat& EnuRotator,
     const glm::dvec3& UeLocation) const {
   return this->_geoTransforms.TransformRotatorEastNorthUpToUnreal(
-      CesiumActors::getWorldOrigin4D(this),
+      glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       EnuRotator,
       UeLocation);
 }
@@ -925,14 +926,14 @@ FRotator ACesiumGeoreference::InaccurateTransformRotatorEastNorthUpToUnreal(
 glm::dmat3
 ACesiumGeoreference::ComputeEastNorthUpToUnreal(const glm::dvec3& ue) const {
   return _geoTransforms.ComputeEastNorthUpToUnreal(
-      CesiumActors::getWorldOrigin4D(this),
+      glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       ue);
 }
 
 FMatrix ACesiumGeoreference::InaccurateComputeEastNorthUpToUnreal(
     const FVector& ue) const {
   glm::dmat3 enuToUnreal = this->_geoTransforms.ComputeEastNorthUpToUnreal(
-      CesiumActors::getWorldOrigin4D(this),
+      glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       glm::dvec3(ue.X, ue.Y, ue.Z));
   return VecMath::createMatrix(enuToUnreal);
 }

--- a/Source/CesiumRuntime/Private/CesiumGlobeAnchorComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGlobeAnchorComponent.cpp
@@ -148,7 +148,7 @@ void UCesiumGlobeAnchorComponent::SnapToEastSouthUp() {
   // Compute the desired new orientation.
   glm::dmat3 newOrientation =
       this->ResolvedGeoreference->GetGeoTransforms().ComputeEastNorthUpToEcef(
-          translation) *
+          glm::dvec3(translation)) *
       glm::dmat3(CesiumTransforms::unrealToOrFromCesium);
 
   // Scale the new orientation

--- a/Source/CesiumRuntime/Private/GeoTransforms.cpp
+++ b/Source/CesiumRuntime/Private/GeoTransforms.cpp
@@ -119,7 +119,7 @@ glm::dvec3 GeoTransforms::TransformUnrealToLongitudeLatitudeHeight(
 glm::dvec3 GeoTransforms::TransformEcefToUnreal(
     const glm::dvec3& origin,
     const glm::dvec3& ecef) const noexcept {
-  glm::dvec3 ueAbs = this->_ecefToUeAbs * glm::dvec4(ecef, 1.0);
+  glm::dvec3 ueAbs = glm::dvec3(this->_ecefToUeAbs * glm::dvec4(ecef, 1.0));
   return ueAbs - origin;
 }
 
@@ -128,7 +128,7 @@ glm::dvec3 GeoTransforms::TransformUnrealToEcef(
     const glm::dvec3& ue) const noexcept {
 
   glm::dvec3 ueAbs = ue + origin;
-  return this->_ueAbsToEcef * glm::dvec4(ueAbs, 1.0);
+  return glm::dvec3(this->_ueAbsToEcef * glm::dvec4(ueAbs, 1.0));
 }
 
 glm::dquat GeoTransforms::TransformRotatorUnrealToEastNorthUp(

--- a/Source/CesiumRuntime/Private/VecMath.cpp
+++ b/Source/CesiumRuntime/Private/VecMath.cpp
@@ -185,8 +185,8 @@ VecMath::add4D(const FIntVector& i, const FVector& f) noexcept {
 }
 
 inline glm::dvec4
-VecMath::add4D(const glm::vec4& d, const FIntVector& i) noexcept {
-  return glm::dvec4(VecMath::add3D(d, i), 1.0);
+VecMath::add4D(const glm::dvec4& d, const FIntVector& i) noexcept {
+  return glm::dvec4(VecMath::add3D(glm::dvec3(d), i), d.w);
 }
 
 inline glm::dvec3
@@ -206,7 +206,7 @@ VecMath::add3D(const FVector& f, const FIntVector& i) noexcept {
 }
 
 inline glm::dvec3
-VecMath::add3D(const glm::vec3& f, const FIntVector& i) noexcept {
+VecMath::add3D(const glm::dvec3& f, const FIntVector& i) noexcept {
   return glm::dvec3(f.x + i.X, f.y + i.Y, f.z + i.Z);
 }
 

--- a/Source/CesiumRuntime/Private/VecMath.h
+++ b/Source/CesiumRuntime/Private/VecMath.h
@@ -240,7 +240,7 @@ public:
    * @param i The `FIntVector`
    * @return The `glm` vector
    */
-  static glm::dvec4 add4D(const glm::vec4& d, const FIntVector& i) noexcept;
+  static glm::dvec4 add4D(const glm::dvec4& d, const FIntVector& i) noexcept;
 
   /**
    * @brief Add the given `FVector` and `FIntVector`, to create a `glm` vector.
@@ -271,7 +271,7 @@ public:
    * @param i The `FIntVector`
    * @return The `glm` vector
    */
-  static glm::dvec3 add3D(const glm::vec3& d, const FIntVector& i) noexcept;
+  static glm::dvec3 add3D(const glm::dvec3& d, const FIntVector& i) noexcept;
 
   /**
    * @brief Subtract the given `FIntVector` from the given `FVector`, to create


### PR DESCRIPTION
Cherry picked from #679. My comment from there:

> This PR also switches our Travis macOS build to use xcode 12 instead of 11.3, because 11.3 uses macOS 10.14 and is apparently not supported by homebrew anymore, so it does a bunch of compilation from source and times out. 🙄 Using xcode 12 might be ok (it's the "recommended" xcode version for UE 4.26), or it might cause our Epic Marketplace submissions to start failing because cesium-native is built against the wrong xcode. In the latter case... I guess we'll have to figure something out.


