### PR TITLE
Manually release tile resources when the tile is unloaded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - `Cesium3DTileset` now has options for enabling custom depth and stencil buffer.
 
+##### Fixes :wrench:
+
+- Cesium for Unreal now does a much better job of releasing memory when the Unreal Engine garbage collector is not active, such as in the Editor.
+
 ### v1.7.0 - 2021-11-01
 
 ##### Breaking Changes :mega:

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -18,6 +18,7 @@
 #include "CesiumGeospatial/Transforms.h"
 #include "CesiumGltfComponent.h"
 #include "CesiumGltfPrimitiveComponent.h"
+#include "CesiumLifetime.h"
 #include "CesiumRasterOverlay.h"
 #include "CesiumRuntime.h"
 #include "CesiumTextureUtility.h"
@@ -620,10 +621,8 @@ public:
 
     if (pMainThreadResult) {
       UTexture2D* pTexture = static_cast<UTexture2D*>(pMainThreadResult);
-      pTexture->ConditionalBeginDestroy();
-      delete pTexture->PlatformData;
-      pTexture->PlatformData = nullptr;
       pTexture->RemoveFromRoot();
+      CesiumLifetime::destroy(pTexture);
     }
   }
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -620,7 +620,7 @@ public:
 
     if (pMainThreadResult) {
       UTexture2D* pTexture = static_cast<UTexture2D*>(pMainThreadResult);
-      pTexture->ReleaseResource();
+      pTexture->ConditionalBeginDestroy();
       delete pTexture->PlatformData;
       pTexture->PlatformData = nullptr;
       pTexture->RemoveFromRoot();
@@ -693,6 +693,7 @@ private:
 
     pComponent->DestroyPhysicsState();
     pComponent->DestroyComponent();
+    pComponent->ConditionalBeginDestroy();
 
     UE_LOG(LogCesium, VeryVerbose, TEXT("Destroying scene component done"));
   }

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1970,11 +1970,6 @@ void UCesiumGltfComponent::SetCollisionEnabled(
   }
 }
 
-void UCesiumGltfComponent::FinishDestroy() {
-  UE_LOG(LogCesium, VeryVerbose, TEXT("UCesiumGltfComponent::FinishDestroy"));
-  Super::FinishDestroy();
-}
-
 #if !PHYSICS_INTERFACE_PHYSX
 // This is copied from FChaosDerivedDataCooker::BuildTriangleMeshes in
 // C:\Program Files\Epic

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.h
@@ -100,8 +100,6 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Collision")
   virtual void SetCollisionEnabled(ECollisionEnabled::Type NewType);
 
-  virtual void FinishDestroy() override;
-
 private:
   UPROPERTY()
   UTexture2D* Transparent1x1;

--- a/Source/CesiumRuntime/Private/CesiumGltfPrimitiveComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfPrimitiveComponent.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 CesiumGS, Inc. and Contributors
 
 #include "CesiumGltfPrimitiveComponent.h"
+#include "CesiumLifetime.h"
 #include "Engine/StaticMesh.h"
 #include "PhysicsEngine/BodySetup.h"
 
@@ -45,20 +46,19 @@ void UCesiumGltfPrimitiveComponent::BeginDestroy() {
                   0),
               pBaseColorTexture,
               true)) {
-        pBaseColorTexture->ConditionalBeginDestroy();
+        CesiumLifetime::destroy(pBaseColorTexture);
       }
 
-      pMaterial->ConditionalBeginDestroy();
+      // TODO: destroy other textures
+
+      CesiumLifetime::destroy(pMaterial);
     }
 
     if (pMesh->BodySetup) {
-      pMesh->BodySetup->ConditionalBeginDestroy();
+      CesiumLifetime::destroy(pMesh->BodySetup);
     }
 
-    if (pMesh->HasPendingInitOrStreaming()) {
-      pMesh->ConditionalBeginDestroy();
-    }
-    pMesh->ConditionalBeginDestroy();
+    CesiumLifetime::destroy(pMesh);
   }
 
   Super::BeginDestroy();

--- a/Source/CesiumRuntime/Private/CesiumGltfPrimitiveComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfPrimitiveComponent.h
@@ -41,4 +41,6 @@ public:
    * @param CesiumToUnrealTransform The new transformation.
    */
   void UpdateTransformFromCesium(const glm::dmat4& CesiumToUnrealTransform);
+
+  virtual void BeginDestroy() override;
 };

--- a/Source/CesiumRuntime/Private/CesiumLifetime.cpp
+++ b/Source/CesiumRuntime/Private/CesiumLifetime.cpp
@@ -69,6 +69,11 @@
 }
 
 /*static*/ void CesiumLifetime::finalizeDestroy(UObject* pObject) {
+  // The freeing/clearing/destroying done here is normally done in these
+  // objects' FinishDestroy method, but unfortunately we can't call that
+  // directly without confusing the garbage collector if and when it _does_
+  // run. So instead we manually release some critical resources here.
+
   UTexture2D* pTexture2D = Cast<UTexture2D>(pObject);
   if (pTexture2D) {
     delete pTexture2D->PlatformData;

--- a/Source/CesiumRuntime/Private/CesiumLifetime.cpp
+++ b/Source/CesiumRuntime/Private/CesiumLifetime.cpp
@@ -1,0 +1,87 @@
+#include "CesiumLifetime.h"
+#include "Async/Async.h"
+#include "Engine/StaticMesh.h"
+#include "Engine/Texture2D.h"
+#include "PhysicsEngine/BodySetup.h"
+#include "UObject/Object.h"
+
+/*static*/ TArray<TWeakObjectPtr<UObject>> CesiumLifetime::_pending;
+/*static*/ TArray<TWeakObjectPtr<UObject>> CesiumLifetime::_nextPending;
+/*static*/ bool CesiumLifetime::_isScheduled = false;
+
+/*static*/ void CesiumLifetime::destroy(UObject* pObject) {
+  if (!runDestruction(pObject)) {
+    // Object is not finished being destroyed, so add it to the pending list.
+    addToPending(pObject);
+  }
+}
+
+/*static*/ bool CesiumLifetime::runDestruction(UObject* pObject) {
+  if (!pObject) {
+    return true;
+  }
+
+  if (!pObject->IsPendingKill()) {
+    pObject->MarkPendingKill();
+  }
+
+  if (pObject->HasAnyFlags(RF_FinishDestroyed)) {
+    // Already done being destroyed.
+    return true;
+  }
+
+  if (!pObject->HasAnyFlags(RF_BeginDestroyed)) {
+    pObject->ConditionalBeginDestroy();
+  }
+
+  if (!pObject->HasAnyFlags(RF_FinishDestroyed) &&
+      pObject->IsReadyForFinishDestroy()) {
+    // Don't actually call ConditionalFinishDestroy here, because if we do the
+    // UE garbage collector will freak out that it's already been called. The
+    // IsReadyForFinishDestroy call is important, though. In some objects,
+    // calling that actually continues the async destruction!
+    finalizeDestroy(pObject);
+    return true;
+  }
+
+  return false;
+}
+
+/*static*/ void CesiumLifetime::addToPending(UObject* pObject) {
+  _pending.Add(pObject);
+  if (!_isScheduled) {
+    _isScheduled = true;
+    AsyncTask(ENamedThreads::GameThread, []() {
+      CesiumLifetime::processPending();
+    });
+  }
+}
+
+/*static*/ void CesiumLifetime::processPending() {
+  _isScheduled = false;
+
+  std::swap(_nextPending, _pending);
+  _pending.Empty();
+
+  for (TWeakObjectPtr<UObject> pObject : _nextPending) {
+    destroy(pObject.Get(true));
+  }
+}
+
+/*static*/ void CesiumLifetime::finalizeDestroy(UObject* pObject) {
+  UTexture2D* pTexture2D = Cast<UTexture2D>(pObject);
+  if (pTexture2D) {
+    delete pTexture2D->PlatformData;
+    pTexture2D->PlatformData = nullptr;
+  }
+
+  UStaticMesh* pMesh = Cast<UStaticMesh>(pObject);
+  if (pMesh) {
+    pMesh->RenderData.Reset();
+  }
+
+  UBodySetup* pBodySetup = Cast<UBodySetup>(pObject);
+  if (pBodySetup) {
+    pBodySetup->ClearPhysicsMeshes();
+  }
+}

--- a/Source/CesiumRuntime/Private/CesiumLifetime.h
+++ b/Source/CesiumRuntime/Private/CesiumLifetime.h
@@ -1,0 +1,21 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+class UObject;
+class UTexture;
+
+class CesiumLifetime {
+public:
+  static void destroy(UObject* pObject);
+
+private:
+  static bool runDestruction(UObject* pObject);
+  static void addToPending(UObject* pObject);
+  static void processPending();
+  static void finalizeDestroy(UObject* pObject);
+
+  static TArray<TWeakObjectPtr<UObject>> _pending;
+  static TArray<TWeakObjectPtr<UObject>> _nextPending;
+  static bool _isScheduled;
+};


### PR DESCRIPTION
When a 3D Tiles tile is no longer needed, cesium-native tells Cesium for Unreal to unload it. We call `DestroyComponent` on the tile's `UCesiumGltfComponent` as well as any `UCesiumGltfPrimitiveComponent`s. But unfortunately (and surprisingly) this leaves all the texture and mesh data in memory until the garbage collector runs. And when we're running in the Editor, the garbage collector isn't run at all, so the resources never get freed! 😱 It doesn't take long flying around a big photogrammetry model to run out of memory and crash this way.

The reason that destroying the component doesn't destroy the corresponding meshes and textures is that meshes and textures are UObject's, and they're allowed to be shared between components. There's no ownership or reference counting, only the garbage collector. And in the Editor, there's not even that.

So the first step is to explicitly free all of the exclusively-owned resources that are created as part of a tile. Specifically:

1. The UStaticMesh for each glTF primitive.
2. The UBodySetup containing the physics data.
3. The Material Instances used to render each glTF primitive.
3. The textures embedded in the glTF and assigned to the material instances.

And how do we explicitly free these things? [Err](https://answers.unrealengine.com/questions/219430/explicitely-delete-a-uobject.html)... [uh](https://www.oreilly.com/library/view/unreal-engine-4/9781785885549/ch02s08.html)... [ok](https://unrealcommunity.wiki/memory-management-6rlf3v4i)... `ConditionalBeginDestroy` maybe? 

That sort of works! It definitely helps. Here's how I tested it...

1. Load Melbourne level in the samples.
2. Set the Maximum Cached Bytes properties of both Cesium World Terrain and Melbourne Photogrammetry to 1 so that all tiles not not needed for traversal/rendering are immediately unloaded.
3. Wait until the initial scene loads, then run `obj gc` in the console to force garbage collection.
4. Run `obj list` in the console and copy the output to a diff program. It lists the number of instances of each UObject and how much memory they're using (measuring several different kinds of memory).
5. Look up at the sky so that no tiles are in view. The vast majority of the tiles should be unloaded.
6. Run `obj list` again and copy the output to the other pane of the diff tool.

If the explicit unloading is working well, all of the object types using large amounts of memory in the left plane should use drastically less memory in the right pane. Specifically this should be true of `BodySetup`, `StaticMesh`, and `Texture2D`.

And more subjectively, we should be able to fly around all we want in the editor without the memory going up _much_. I say "much" rather than "at all" because without the garbage collector the UObjects themselves will never be freed. But these should be very tiny compared to the large mesh, physics, and texture assets.

But unfortunately with just a `ConditionalBeginDestroy`, not all of the resources are freed and memory keeps going up quickly when flying around. There are two reasons for this (deduced by painstakingly reading the UE source code):

1. If an asset is in the process of being sent to the renderer thread / uploaded to the GPU, `ConditionalBeginDestroy` won't free it.
2. Some resources are not freed at all until `ConditionalFinishDestroy`.

The garbage collector deals with (1) by repeatedly calling `IsReadyForFinishDestroy` until it returns true. You might read that name and think, as I did, that it's a nice const method that just returns a status, but you (and I) would be wrong. That method also has a cheeky side effect that it _continues the destroy process_. 😆 So if we want to deterministratically destroy a `UObject` the way the GC does, we need to a) call `ConditionalBeginDestroy`, and b) periodically call `IsReadyForFinishDestroy` until it returns true.

Now for (2), I initially thought we could wait until `IsReadyForFinishDestroy` returned true and then call `ConditionalFinishDestroy` ourselves. This doesn't work, though, because the garbage collector will complain (assert) that `ConditionalFinishDestroy` has already been called if and when it gets around to running. Even in the Editor, the garbage collector does run once in awhile, such as when deleting an Actor from the World Outliner or switching levels. So instead, this PR _manually_ does part of what `ConditionalFinishDestroy` does for the objects we care about, without actually calling `ConditionalFinishDestroy`.

Long story short, this is unbelievably ugly, but I can't see a better solution. The results, at least, are excellent. In the procedure described above in a release build of cesium-native and a Development Editor build of Cesium for Unreal, the editor uses 15GB of memory on my system for the initial Melbourne scene both before and after this PR. However, when I look up at the sky in this branch, the memory usage drops to under 5GB while it stays at 15 in main. And we can fly around all we want while the memory usage remains steady.

Even in Play-in-Editor mode (which benefits from the garbage collector running periodically), this branch has two major benefits over main:
1. The memory usage stays lower and more consistent when flying around because we don't have to wait for GC cycles to release textures, etc.
2. It doesn't have the big GC pauses once in awhile caused by freeing gigabytes of data all at once.

A reasonable person might see this PR and ask two questions:
1. _Can we pool our UObjects rather than creating and destroying them all the time?_ Probably! UE objects aren't always awesome about responding to the types of dynamic changes that would be required for object recycling, though, so I'd expect some bugs and hassles on the way to getting this working.
2. _Why does the the default Melbourne scene require 10 GB of RAM more than the "looking up at the sky" view?!_ Yeah... that's a good question. A partial answer is that the Samples project sets the SSE to 6 which is unreasonably low and so we load a _ton_ of tiles. Another partial answer is that we keep too many copies of mesh and texture data in memory: cesium-native has one, Unreal has two, on the CPU side and one on the GPU. But mostly the answer is "we need to look into that."
