### PR TITLE
Add a tile colorizer and an option to output selection stats.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 ##### Additions :tada:
 
 - `Cesium3DTileset` now has options for enabling custom depth and stencil buffer.
+- Added `CesiumDebugColorizeTilesRasterOverlay` to visualize how a tileset is divided into tiles.
+- Added `Log Selection Stats` debug option to the `Cesium3DTileset` Actor.
 
 ##### Fixes :wrench:
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1306,6 +1306,10 @@ void ACesium3DTileset::updateTilesetOptionsFromProperties() {
 
 void ACesium3DTileset::updateLastViewUpdateResultState(
     const Cesium3DTilesSelection::ViewUpdateResult& result) {
+  if (!this->LogSelectionStats) {
+    return;
+  }
+
   if (result.tilesToRenderThisFrame.size() != this->_lastTilesRendered ||
       result.tilesLoadingLowPriority != this->_lastTilesLoadingLowPriority ||
       result.tilesLoadingMediumPriority !=
@@ -1328,7 +1332,7 @@ void ACesium3DTileset::updateLastViewUpdateResultState(
 
     UE_LOG(
         LogCesium,
-        VeryVerbose,
+        Display,
         TEXT(
             "%s: %d ms, Visited %d, Culled Visited %d, Rendered %d, Culled %d, Max Depth Visited: %d, Loading-Low %d, Loading-Medium %d, Loading-High %d"),
         *this->GetName(),

--- a/Source/CesiumRuntime/Private/CesiumDebugColorizeTilesRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumDebugColorizeTilesRasterOverlay.cpp
@@ -7,7 +7,8 @@
 std::unique_ptr<Cesium3DTilesSelection::RasterOverlay>
 UCesiumDebugColorizeTilesRasterOverlay::CreateOverlay(
     const Cesium3DTilesSelection::RasterOverlayOptions& options) {
-  return std::make_unique<Cesium3DTilesSelection::DebugColorizeTilesRasterOverlay>(
+  return std::make_unique<
+      Cesium3DTilesSelection::DebugColorizeTilesRasterOverlay>(
       TCHAR_TO_UTF8(*this->MaterialLayerKey),
       options);
 }

--- a/Source/CesiumRuntime/Private/CesiumDebugColorizeTilesRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumDebugColorizeTilesRasterOverlay.cpp
@@ -1,0 +1,13 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#include "CesiumDebugColorizeTilesRasterOverlay.h"
+#include "Cesium3DTilesSelection/DebugColorizeTilesRasterOverlay.h"
+#include "Cesium3DTilesSelection/Tileset.h"
+
+std::unique_ptr<Cesium3DTilesSelection::RasterOverlay>
+UCesiumDebugColorizeTilesRasterOverlay::CreateOverlay(
+    const Cesium3DTilesSelection::RasterOverlayOptions& options) {
+  return std::make_unique<Cesium3DTilesSelection::DebugColorizeTilesRasterOverlay>(
+      TCHAR_TO_UTF8(*this->MaterialLayerKey),
+      options);
+}

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -383,6 +383,12 @@ public:
   bool UpdateInEditor = true;
 
   /**
+   * If true, stats about tile selection are printed to the Output Log.
+   */
+  UPROPERTY(EditAnywhere, Category = "Cesium|Debug")
+  bool LogSelectionStats = false;
+
+  /**
    * Define the collision profile for all the 3D tiles created inside this
    * actor.
    */

--- a/Source/CesiumRuntime/Public/CesiumDebugColorizeTilesRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumDebugColorizeTilesRasterOverlay.h
@@ -1,0 +1,26 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "CesiumRasterOverlay.h"
+#include "CoreMinimal.h"
+#include "CesiumDebugColorizeTilesRasterOverlay.generated.h"
+
+/**
+ * A raster overlay that can be used to debug tilesets by shading each tile with
+ * a random color.
+ */
+UCLASS(
+    DisplayName = "Cesium Debug Colorize Tiles Raster Overlay",
+    ClassGroup = (Cesium),
+    meta = (BlueprintSpawnableComponent))
+class CESIUMRUNTIME_API UCesiumDebugColorizeTilesRasterOverlay : public UCesiumRasterOverlay {
+  GENERATED_BODY()
+
+public:
+
+protected:
+  virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay> CreateOverlay(
+      const Cesium3DTilesSelection::RasterOverlayOptions& options = {})
+      override;
+};

--- a/Source/CesiumRuntime/Public/CesiumDebugColorizeTilesRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumDebugColorizeTilesRasterOverlay.h
@@ -14,11 +14,11 @@ UCLASS(
     DisplayName = "Cesium Debug Colorize Tiles Raster Overlay",
     ClassGroup = (Cesium),
     meta = (BlueprintSpawnableComponent))
-class CESIUMRUNTIME_API UCesiumDebugColorizeTilesRasterOverlay : public UCesiumRasterOverlay {
+class CESIUMRUNTIME_API UCesiumDebugColorizeTilesRasterOverlay
+    : public UCesiumRasterOverlay {
   GENERATED_BODY()
 
 public:
-
 protected:
   virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay> CreateOverlay(
       const Cesium3DTilesSelection::RasterOverlayOptions& options = {})


### PR DESCRIPTION
- Added an ActorComponent for the tile colorizing raster overlay added in https://github.com/CesiumGS/cesium-native/pull/396
- Added a new option "Log Selection Stats" to the debug section of the Cesium3DTileset Actor. When enabled, stats about the tile selection process are printed to the output log with `Display` level. Previously these were always logged but effectively never seen because they were printed with the `VeryVerbose` level.