### PR TITLE
Add missing #include.

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -30,6 +30,7 @@
 #include "MeshTypes.h"
 #include "PhysicsEngine/BodySetup.h"
 #include "PixelFormat.h"
+#include "Runtime/Launch/Resources/Version.h"
 #include "StaticMeshOperations.h"
 #include "StaticMeshResources.h"
 #include "UObject/ConstructorHelpers.h"


### PR DESCRIPTION
Fixes #674 

It's not needed in all (most?) scenarios, but should be here regardless.