### PR TITLE
Allow short camera flights.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - Cesium for Unreal now does a much better job of releasing memory when the Unreal Engine garbage collector is not active, such as in the Editor.
 - Fixed a bug that could cause an incorrect field-of-view angle to be used for tile selection in the Editor.
+- Fixed a bug that caused `GlobeAwareDefaultPawn` (and its derived classes, notably `DynamicPawn`) to completely ignore short flights.
 
 ### v1.7.0 - 2021-11-01
 

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -112,7 +112,8 @@ void AGlobeAwareDefaultPawn::FlyToLocationECEF(
   this->_keypoints.clear();
   this->_currentFlyTime = 0.0;
 
-  if (steps == 0) {
+  if (flyTotalAngle == 0.0 &&
+      this->_flyToSourceRotation == this->_flyToDestinationRotation) {
     return;
   }
 


### PR DESCRIPTION
`GlobeAwareDefaultPawn` completely ignores requests to do camera flights that have "zero steps" as defined by  its `FlyToGranularityDegrees` property. With this PR, it will do arbitrarily short flights, including rotation-only flights.

Fixes #678 