### PR TITLE
Make overlay Add/Remove/Refresh methods accessible from Blueprints.

### DIFF
--- a/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
@@ -42,6 +42,7 @@ public:
    * overlay is already added or if this component's Owner is not a Cesium 3D
    * Tileset, this method does nothing.
    */
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   void AddToTileset();
 
   /**
@@ -49,11 +50,13 @@ public:
    * overlay is not yet added or if this component's Owner is not a Cesium 3D
    * Tileset, this method does nothing.
    */
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   void RemoveFromTileset();
 
   /**
    * Refreshes this tileset by removing and re-adding it.
    */
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
   void Refresh();
 
   UFUNCTION(BlueprintCallable, Category = "Cesium")


### PR DESCRIPTION
Building on #696. This isn't strictly necessary because you can just `Deactivate` and then (re-) `Activate` the component to achieve the same effect. But it's more convenient.