### PR TITLE
Go back to xcode 11.3 (instead of 12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,12 +154,7 @@ jobs:
     env: PATH=/c/Python39:/c/Python39/Scripts:$PATH
   - name: MacOS 4.26
     os: osx
-    osx_image: xcode12
-    addons:
-      homebrew:
-        packages:
-        - p7zip
-        update: true
+    osx_image: xcode11.3
     install:
     - python -m pip install --upgrade pip
     - pip3 install --upgrade pip
@@ -181,7 +176,7 @@ jobs:
     - cd $HOME/UE_4.26/Users/Shared/Epic\ Games/UE_4.26/Engine/Build/BatchFiles
     - ./RunUAT.sh BuildPlugin -Plugin="$CLONEDIR/CesiumForUnreal.uplugin" -Package="$CLONEDIR/../packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Mac
     - cd "$CLONEDIR/../packages"
-    - 7z a ${BUILD_CESIUM_UNREAL_PACKAGE_NAME}.zip CesiumForUnreal/
+    - zip -r -X ${BUILD_CESIUM_UNREAL_PACKAGE_NAME}.zip CesiumForUnreal
     - aws s3 cp ${BUILD_CESIUM_UNREAL_PACKAGE_NAME}.zip s3://builds-cesium-unreal/
     - export PACKAGE_LINK=$(aws --region us-east-1 s3 presign s3://builds-cesium-unreal/${BUILD_CESIUM_UNREAL_PACKAGE_NAME}.zip --expires-in 315360000)
     - http POST "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/statuses/${TRAVIS_COMMIT}" "Authorization:token ${GITHUB_TOKEN}" state=success context=UE4.26-macOS "target_url=${PACKAGE_LINK}" --ignore-stdin
@@ -258,7 +253,8 @@ jobs:
     - export PACKAGE_LINK=$(aws --region us-east-1 s3 presign s3://builds-cesium-unreal/${BUILD_CESIUM_UNREAL_PACKAGE_NAME}.zip --expires-in 315360000)
     - http POST "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/statuses/${TRAVIS_COMMIT}" "Authorization:token ${GITHUB_TOKEN}" state=success context=UE4.27-Linux "target_url=${PACKAGE_LINK}" --ignore-stdin
     env: PATH=/c/Python39:/c/Python39/Scripts:$PATH
-  - stage: Combine Packages 4.26
+  - stage: Combine Packages
+    name: Combine for UE 4.26
     os: linux
     dist: focal
     git:
@@ -285,7 +281,7 @@ jobs:
     - aws s3 cp CesiumForUnreal-426-${CESIUM_UNREAL_VERSION}.zip s3://builds-cesium-unreal/
     - export PACKAGE_LINK=$(aws --region us-east-1 s3 presign s3://builds-cesium-unreal/CesiumForUnreal-426-${CESIUM_UNREAL_VERSION}.zip --expires-in 315360000)
     - http POST "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/statuses/${TRAVIS_COMMIT}" "Authorization:token ${GITHUB_TOKEN}" state=success context=UE4.26-AllPlatforms "target_url=${PACKAGE_LINK}" --ignore-stdin
-  - stage: Combine Packages 4.27
+  - name: Combine for UE 4.27
     os: linux
     dist: focal
     git:


### PR DESCRIPTION
Epic reported problems building our latest release on macOS:

```
Undefined symbols for architecture x86_64:

"___darwin_check_fd_set_overflow", referenced from:

httplib::detail::SocketStream::is_readable() const in libCesiumIonClient.a(Connection.cpp.o)
httplib::detail::SocketStream::is_writable() const in libCesiumIonClient.a(Connection.cpp.o)
httplib::detail::keep_alive(int, long) in libCesiumIonClient.a(Connection.cpp.o)
httplib::Server::listen_internal() in libCesiumIonClient.a(Connection.cpp.o)

ld: symbol(s) not found for architecture x86_64

clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This is almost certainly caused by our move to xcode 12 in #682. This PR goes back to xcode 11.3 and then solves the original problem by removing the use of Homebrew entirely. We were only using it to install 7zip, and the built-in zip command is just fine for our needs.