### PR TITLE
Handle viewport aspect ratio not matching viewport dimensions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause incorrect LOD and culling when viewing a camera in-editor and the camera's aspect ratio does not match the viewport window's aspect ratio.
+
 ### v1.8.1 - 2021-12-02
 
 In this release, the cesium-native binaries are built using Xcode 11.3 on macOS instead of Xcode 12. Other platforms are unchanged from v1.8.0.

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -699,6 +699,11 @@ private:
     FVector location;
     FRotator rotation;
     double fieldOfViewDegrees;
+
+    // If not std::nullopt, the aspect ratio may be different from the one
+    // implied by the viewportSize and black bars are added as needed in order
+    // to achieve this aspect ratio within a larger viewport.
+    std::optional<double> aspectRatio = std::nullopt;
   };
 
   static Cesium3DTilesSelection::ViewState CreateViewStateFromViewParameters(


### PR DESCRIPTION
This fixes part of #680.

If an Editor viewport is viewing a particular camera, and that camera specifies an aspect ratio that doesn't match the dimensions of the viewport window, Unreal draws black bars at the sides or at the top and bottom, i.e. letterboxing. No real surprise there, of course.

![image](https://user-images.githubusercontent.com/924374/146370486-02132f55-5d9b-4780-9c1d-b697d0c364f0.png)

The perhaps more surprising thing is that `FEditorViewportClient::GetViewportDimensions` returns the size of the complete window, not the size of the portion in which rendering occurs. That is, the black bars are included in the size.

Having not realized or appreciated this, we were using the window dimensions for LOD computations, and computing the vertical FOV from the aspect ratio implied by the window dimensions. This caused LOD and culling problems, as seen in #680.

So with this PR, we use the actual aspect ratio, and compute the dimensions of the rendered area.

This PR also has a change to get the viewport size from the player controller in-game, rather than the world's game viewport. I don't know of a situation where this will make a difference, but it should be more correct.

Unfortunately this doesn't fix #680. Even with this change, when we're using the Movie Render Queue specifically, the player controller's `GetViewportSize` always returns 1920x1080 even when a different size has been specified. I spent hours trying to figure out how to get the _actual_ size, but haven't figured it out yet. I wrote a UDN ticket to ask Epic:
https://udn.unrealengine.com/s/question/0D54z00007LQvtdCAD/how-to-get-the-viewport-size-when-using-the-movie-render-queue

So this PR should be a good change worth merging, but some additional work will likely be necessary when we hear back from Epic.
