### PR TITLE
Fixes crash when editing georeference while sublevel is selected

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v1.10.0 - ????
+
+##### Fixes :wrench
+
+- Fixed a crash when editing the georeference detail panel while a sublevel is active.
+
 ### v1.9.0 - 2022-01-03
 
 ##### Fixes :wrench:

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -1188,9 +1188,9 @@ void ACesiumGeoreference::_enableAndGeoreferenceCurrentSubLevel() {
     pLevel->LevelLongitude = this->OriginLongitude;
     pLevel->LevelLatitude = this->OriginLatitude;
     pLevel->LevelHeight = this->OriginHeight;
-  }
 
-  pLevel->Enabled = pLevel->CanBeEnabled;
+    pLevel->Enabled = pLevel->CanBeEnabled;
+  }
 }
 
 #endif


### PR DESCRIPTION
Fixes #726 