### PR TITLE
Removed extra space from engine version in .uplugin

### DIFF
--- a/CesiumForUnreal.uplugin
+++ b/CesiumForUnreal.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "https://cesium.com/learn/unreal/",
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/87b0d05800a545d49bf858ef3458c4f7",
 	"SupportURL": "https://community.cesium.com",
-	"EngineVersion":  "4.26.0",
+	"EngineVersion": "4.26.0",
 	"CanContainContent": true,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,


### PR DESCRIPTION
There are two spaces in between `EngineVersion` and `4.26.0` in the uplugin file. As a result, the travis pipeline for 4.27 https://github.com/CesiumGS/cesium-unreal/blob/main/.travis.yml#L65 should break at the point where it does an in-place edit from `4.26.0` to `4.27.0`. Perhaps builds are still getting created despite this, but when running that command locally, the `sed` command doesn't succeed.