### PR TITLE
Blueprint API for Registering Custom Cameras

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### v1.9.0 - 2022-01-03
 
+##### Additions :tada:
+
+- The new `FCesiumCamera` and `ACesiumCameraManager` can be used to register and update custom camera views into Cesium tilesets.
+
 ##### Fixes :wrench:
 
 - Fixed a bug that could cause incorrect LOD and culling when viewing a camera in-editor and the camera's aspect ratio does not match the viewport window's aspect ratio.

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -84,6 +84,7 @@ ACesium3DTileset::ACesium3DTileset()
       _tilesToNoLongerRenderNextFrame{} {
 
   PrimaryActorTick.bCanEverTick = true;
+  PrimaryActorTick.TickGroup = ETickingGroup::TG_PostUpdateWork;
 
   this->SetActorEnableCollision(true);
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -12,6 +12,8 @@
 #include "Cesium3DTilesetRoot.h"
 #include "CesiumAsync/CachingAssetAccessor.h"
 #include "CesiumAsync/SqliteCache.h"
+#include "CesiumCamera.h"
+#include "CesiumCameraManager.h"
 #include "CesiumCustomVersion.h"
 #include "CesiumGeospatial/Cartographic.h"
 #include "CesiumGeospatial/Ellipsoid.h"
@@ -863,29 +865,38 @@ void ACesium3DTileset::DestroyTileset() {
   }
 }
 
-std::vector<ACesium3DTileset::UnrealCameraParameters>
-ACesium3DTileset::GetCameras() const {
-  std::vector<UnrealCameraParameters> cameras = this->GetPlayerCameras();
+std::vector<FCesiumCamera> ACesium3DTileset::GetCameras() const {
+  std::vector<FCesiumCamera> cameras = this->GetPlayerCameras();
 
-  std::vector<UnrealCameraParameters> sceneCaptures = this->GetSceneCaptures();
+  std::vector<FCesiumCamera> sceneCaptures = this->GetSceneCaptures();
   cameras.insert(
       cameras.end(),
       std::make_move_iterator(sceneCaptures.begin()),
       std::make_move_iterator(sceneCaptures.end()));
 
 #if WITH_EDITOR
-  std::vector<UnrealCameraParameters> editorCameras = this->GetEditorCameras();
+  std::vector<FCesiumCamera> editorCameras = this->GetEditorCameras();
   cameras.insert(
       cameras.end(),
       std::make_move_iterator(editorCameras.begin()),
       std::make_move_iterator(editorCameras.end()));
 #endif
 
+  ACesiumCameraManager* pCameraManager =
+      ACesiumCameraManager::GetDefaultCameraManager(this->GetWorld());
+  if (pCameraManager) {
+    const TMap<int32, FCesiumCamera>& extraCameras =
+        pCameraManager->GetCameras();
+    cameras.reserve(cameras.size() + extraCameras.Num());
+    for (auto cameraIt : extraCameras) {
+      cameras.push_back(cameraIt.Value);
+    }
+  }
+
   return cameras;
 }
 
-std::vector<ACesium3DTileset::UnrealCameraParameters>
-ACesium3DTileset::GetPlayerCameras() const {
+std::vector<FCesiumCamera> ACesium3DTileset::GetPlayerCameras() const {
   UWorld* pWorld = this->GetWorld();
   if (!pWorld) {
     return {};
@@ -907,7 +918,7 @@ ACesium3DTileset::GetPlayerCameras() const {
     useStereoRendering = true;
   }
 
-  std::vector<ACesium3DTileset::UnrealCameraParameters> cameras;
+  std::vector<FCesiumCamera> cameras;
   cameras.reserve(pWorld->GetNumPlayerControllers());
 
   for (auto playerControllerIt = pWorld->GetPlayerControllerIterator();
@@ -927,7 +938,7 @@ ACesium3DTileset::GetPlayerCameras() const {
       continue;
     }
 
-    double fov = pPlayerCameraManager->GetFOVAngle();
+    float fov = pPlayerCameraManager->GetFOVAngle();
 
     FVector location;
     FRotator rotation;
@@ -984,11 +995,11 @@ ACesium3DTileset::GetPlayerCameras() const {
         float hfov =
             glm::degrees(2.0f * glm::atan(1.0f / one_over_tan_half_hfov));
 
-        cameras.push_back(UnrealCameraParameters{
+        cameras.emplace_back(
             stereoLeftSize,
             leftEyeLocation,
             leftEyeRotation,
-            hfov});
+            hfov);
       }
 
       if (stereoRightSize.X >= 1.0 && stereoRightSize.Y >= 1.0) {
@@ -1008,26 +1019,21 @@ ACesium3DTileset::GetPlayerCameras() const {
         float hfov =
             glm::degrees(2.0f * glm::atan(1.0f / one_over_tan_half_hfov));
 
-        cameras.push_back(UnrealCameraParameters{
+        cameras.emplace_back(
             stereoRightSize,
             rightEyeLocation,
             rightEyeRotation,
-            hfov});
+            hfov);
       }
     } else {
-      cameras.push_back(UnrealCameraParameters{
-          FVector2D(sizeX, sizeY),
-          location,
-          rotation,
-          fov});
+      cameras.emplace_back(FVector2D(sizeX, sizeY), location, rotation, fov);
     }
   }
 
   return cameras;
 }
 
-std::vector<ACesium3DTileset::UnrealCameraParameters>
-ACesium3DTileset::GetSceneCaptures() const {
+std::vector<FCesiumCamera> ACesium3DTileset::GetSceneCaptures() const {
   // TODO: really USceneCaptureComponent2D can be attached to any actor, is it
   // worth searching every actor? Might it be better to provide an interface
   // where users can volunteer cameras to be used with the tile selection as
@@ -1037,7 +1043,7 @@ ACesium3DTileset::GetSceneCaptures() const {
       ASceneCapture2D::StaticClass();
   UGameplayStatics::GetAllActorsOfClass(this, SceneCapture2D, sceneCaptures);
 
-  std::vector<ACesium3DTileset::UnrealCameraParameters> cameras;
+  std::vector<FCesiumCamera> cameras;
   cameras.reserve(sceneCaptures.Num());
 
   for (AActor* pActor : sceneCaptures) {
@@ -1072,75 +1078,18 @@ ACesium3DTileset::GetSceneCaptures() const {
     FRotator captureRotation = pSceneCaptureComponent->GetComponentRotation();
     float captureFov = pSceneCaptureComponent->FOVAngle;
 
-    cameras.push_back(UnrealCameraParameters{
+    cameras.emplace_back(
         renderTargetSize,
         captureLocation,
         captureRotation,
-        captureFov});
+        captureFov);
   }
 
   return cameras;
 }
 
-/*static*/ Cesium3DTilesSelection::ViewState
-ACesium3DTileset::CreateViewStateFromViewParameters(
-    const UnrealCameraParameters& camera,
-    const glm::dmat4& unrealWorldToTileset) {
-
-  double horizontalFieldOfView =
-      FMath::DegreesToRadians(camera.fieldOfViewDegrees);
-
-  double aspectRatio;
-  glm::dvec2 size(camera.viewportSize.X, camera.viewportSize.Y);
-
-  if (camera.aspectRatio) {
-    // Use aspect ratio and recompute effective viewport size after black bars
-    // are added.
-    aspectRatio = *camera.aspectRatio;
-    double computedX = aspectRatio * camera.viewportSize.Y;
-    double computedY = camera.viewportSize.Y / aspectRatio;
-
-    double barWidth = camera.viewportSize.X - computedX;
-    double barHeight = camera.viewportSize.Y - computedY;
-
-    if (barWidth > 0.0 && barWidth > barHeight) {
-      // Black bars on the sides
-      size.x = computedX;
-    } else if (barHeight > 0.0 && barHeight > barWidth) {
-      // Black bars on the top and bottom
-      size.y = computedY;
-    }
-  } else {
-    aspectRatio = camera.viewportSize.X / camera.viewportSize.Y;
-  }
-
-  double verticalFieldOfView =
-      atan(tan(horizontalFieldOfView * 0.5) / aspectRatio) * 2.0;
-
-  FVector direction = camera.rotation.RotateVector(FVector(1.0f, 0.0f, 0.0f));
-  FVector up = camera.rotation.RotateVector(FVector(0.0f, 0.0f, 1.0f));
-
-  glm::dvec3 tilesetCameraLocation = glm::dvec3(
-      unrealWorldToTileset *
-      glm::dvec4(camera.location.X, camera.location.Y, camera.location.Z, 1.0));
-  glm::dvec3 tilesetCameraFront = glm::normalize(glm::dvec3(
-      unrealWorldToTileset *
-      glm::dvec4(direction.X, direction.Y, direction.Z, 0.0)));
-  glm::dvec3 tilesetCameraUp = glm::normalize(
-      glm::dvec3(unrealWorldToTileset * glm::dvec4(up.X, up.Y, up.Z, 0.0)));
-
-  return Cesium3DTilesSelection::ViewState::create(
-      tilesetCameraLocation,
-      tilesetCameraFront,
-      tilesetCameraUp,
-      size,
-      horizontalFieldOfView,
-      verticalFieldOfView);
-}
-
 #if WITH_EDITOR
-std::vector<ACesium3DTileset::UnrealCameraParameters>
-ACesium3DTileset::GetEditorCameras() const {
+std::vector<FCesiumCamera> ACesium3DTileset::GetEditorCameras() const {
   if (!GEditor) {
     return {};
   }
@@ -1159,7 +1108,7 @@ ACesium3DTileset::GetEditorCameras() const {
   const TArray<FEditorViewportClient*>& viewportClients =
       GEditor->GetAllViewportClients();
 
-  std::vector<ACesium3DTileset::UnrealCameraParameters> cameras;
+  std::vector<FCesiumCamera> cameras;
   cameras.reserve(viewportClients.Num());
 
   for (FEditorViewportClient* pEditorViewportClient : viewportClients) {
@@ -1169,21 +1118,20 @@ ACesium3DTileset::GetEditorCameras() const {
 
     const FVector& location = pEditorViewportClient->GetViewLocation();
     const FRotator& rotation = pEditorViewportClient->GetViewRotation();
-    double fov = pEditorViewportClient->ViewFOV;
+    float fov = pEditorViewportClient->ViewFOV;
     FIntPoint offset;
     FIntPoint size;
     pEditorViewportClient->GetViewportDimensions(offset, size);
-
-    std::optional<double> aspectRatio =
-        pEditorViewportClient->IsAspectRatioConstrained()
-            ? std::make_optional(pEditorViewportClient->AspectRatio)
-            : std::nullopt;
 
     if (size.X < 1 || size.Y < 1) {
       continue;
     }
 
-    cameras.push_back({size, location, rotation, fov, aspectRatio});
+    float aspectRatio = pEditorViewportClient->IsAspectRatioConstrained()
+                            ? pEditorViewportClient->AspectRatio
+                            : (size.X / size.Y);
+
+    cameras.emplace_back(size, location, rotation, fov, aspectRatio);
   }
 
   return cameras;
@@ -1461,7 +1409,7 @@ void ACesium3DTileset::Tick(float DeltaTime) {
 
   updateTilesetOptionsFromProperties();
 
-  std::vector<UnrealCameraParameters> cameras = this->GetCameras();
+  std::vector<FCesiumCamera> cameras = this->GetCameras();
   if (cameras.empty()) {
     return;
   }
@@ -1470,9 +1418,8 @@ void ACesium3DTileset::Tick(float DeltaTime) {
       this->GetCesiumTilesetToUnrealRelativeWorldTransform());
 
   std::vector<Cesium3DTilesSelection::ViewState> frustums;
-  for (const UnrealCameraParameters& camera : cameras) {
-    frustums.push_back(
-        CreateViewStateFromViewParameters(camera, unrealWorldToTileset));
+  for (const FCesiumCamera& camera : cameras) {
+    frustums.push_back(camera.createViewState(unrealWorldToTileset));
   }
 
   const Cesium3DTilesSelection::ViewUpdateResult& result =

--- a/Source/CesiumRuntime/Private/CesiumCamera.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCamera.cpp
@@ -8,7 +8,7 @@ FCesiumCamera::FCesiumCamera()
       Location(0.0f, 0.0f, 0.0f),
       Rotation(0.0f, 0.0f, 0.0f),
       FieldOfViewDegrees(0.0f),
-      AspectRatio(1.0f) {}
+      OverrideAspectRatio(0.0f) {}
 
 FCesiumCamera::FCesiumCamera(
     const FVector2D& ViewportSize_,
@@ -19,70 +19,16 @@ FCesiumCamera::FCesiumCamera(
       Location(Location_),
       Rotation(Rotation_),
       FieldOfViewDegrees(FieldOfViewDegrees_),
-      AspectRatio(ViewportSize.X / ViewportSize.Y) {}
+      OverrideAspectRatio(0.0f) {}
 
 FCesiumCamera::FCesiumCamera(
     const FVector2D& ViewportSize_,
     const FVector& Location_,
     const FRotator& Rotation_,
     float FieldOfViewDegrees_,
-    float AspectRatio_)
+    float OverrideAspectRatio_)
     : ViewportSize(ViewportSize_),
       Location(Location_),
       Rotation(Rotation_),
       FieldOfViewDegrees(FieldOfViewDegrees_),
-      AspectRatio(AspectRatio_) {}
-
-Cesium3DTilesSelection::ViewState
-FCesiumCamera::createViewState(const glm::dmat4& unrealWorldToTileset) const {
-
-  double horizontalFieldOfView =
-      FMath::DegreesToRadians(this->FieldOfViewDegrees);
-
-  double actualAspectRatio;
-  glm::dvec2 size(this->ViewportSize.X, this->ViewportSize.Y);
-
-  if (this->AspectRatio != 0.0f) {
-    // Use aspect ratio and recompute effective viewport size after black bars
-    // are added.
-    actualAspectRatio = this->AspectRatio;
-    double computedX = actualAspectRatio * this->ViewportSize.Y;
-    double computedY = this->ViewportSize.Y / actualAspectRatio;
-
-    double barWidth = this->ViewportSize.X - computedX;
-    double barHeight = this->ViewportSize.Y - computedY;
-
-    if (barWidth > 0.0 && barWidth > barHeight) {
-      // Black bars on the sides
-      size.x = computedX;
-    } else if (barHeight > 0.0 && barHeight > barWidth) {
-      // Black bars on the top and bottom
-      size.y = computedY;
-    }
-  } else {
-    actualAspectRatio = this->ViewportSize.X / this->ViewportSize.Y;
-  }
-
-  double verticalFieldOfView =
-      atan(tan(horizontalFieldOfView * 0.5) / actualAspectRatio) * 2.0;
-
-  FVector direction = this->Rotation.RotateVector(FVector(1.0f, 0.0f, 0.0f));
-  FVector up = this->Rotation.RotateVector(FVector(0.0f, 0.0f, 1.0f));
-
-  glm::dvec3 tilesetCameraLocation = glm::dvec3(
-      unrealWorldToTileset *
-      glm::dvec4(this->Location.X, this->Location.Y, this->Location.Z, 1.0));
-  glm::dvec3 tilesetCameraFront = glm::normalize(glm::dvec3(
-      unrealWorldToTileset *
-      glm::dvec4(direction.X, direction.Y, direction.Z, 0.0)));
-  glm::dvec3 tilesetCameraUp = glm::normalize(
-      glm::dvec3(unrealWorldToTileset * glm::dvec4(up.X, up.Y, up.Z, 0.0)));
-
-  return Cesium3DTilesSelection::ViewState::create(
-      tilesetCameraLocation,
-      tilesetCameraFront,
-      tilesetCameraUp,
-      size,
-      horizontalFieldOfView,
-      verticalFieldOfView);
-}
+      OverrideAspectRatio(OverrideAspectRatio_) {}

--- a/Source/CesiumRuntime/Private/CesiumCamera.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCamera.cpp
@@ -1,0 +1,88 @@
+
+#include "CesiumCamera.h"
+#include "CesiumRuntime.h"
+#include "Math/UnrealMathUtility.h"
+
+FCesiumCamera::FCesiumCamera()
+    : ViewportSize(1.0f, 1.0f),
+      Location(0.0f, 0.0f, 0.0f),
+      Rotation(0.0f, 0.0f, 0.0f),
+      FieldOfViewDegrees(0.0f),
+      AspectRatio(1.0f) {}
+
+FCesiumCamera::FCesiumCamera(
+    const FVector2D& ViewportSize_,
+    const FVector& Location_,
+    const FRotator& Rotation_,
+    float FieldOfViewDegrees_)
+    : ViewportSize(ViewportSize_),
+      Location(Location_),
+      Rotation(Rotation_),
+      FieldOfViewDegrees(FieldOfViewDegrees_),
+      AspectRatio(ViewportSize.X / ViewportSize.Y) {}
+
+FCesiumCamera::FCesiumCamera(
+    const FVector2D& ViewportSize_,
+    const FVector& Location_,
+    const FRotator& Rotation_,
+    float FieldOfViewDegrees_,
+    float AspectRatio_)
+    : ViewportSize(ViewportSize_),
+      Location(Location_),
+      Rotation(Rotation_),
+      FieldOfViewDegrees(FieldOfViewDegrees_),
+      AspectRatio(AspectRatio_) {}
+
+Cesium3DTilesSelection::ViewState
+FCesiumCamera::createViewState(const glm::dmat4& unrealWorldToTileset) const {
+
+  double horizontalFieldOfView =
+      FMath::DegreesToRadians(this->FieldOfViewDegrees);
+
+  double actualAspectRatio;
+  glm::dvec2 size(this->ViewportSize.X, this->ViewportSize.Y);
+
+  if (this->AspectRatio != 0.0f) {
+    // Use aspect ratio and recompute effective viewport size after black bars
+    // are added.
+    actualAspectRatio = this->AspectRatio;
+    double computedX = actualAspectRatio * this->ViewportSize.Y;
+    double computedY = this->ViewportSize.Y / actualAspectRatio;
+
+    double barWidth = this->ViewportSize.X - computedX;
+    double barHeight = this->ViewportSize.Y - computedY;
+
+    if (barWidth > 0.0 && barWidth > barHeight) {
+      // Black bars on the sides
+      size.x = computedX;
+    } else if (barHeight > 0.0 && barHeight > barWidth) {
+      // Black bars on the top and bottom
+      size.y = computedY;
+    }
+  } else {
+    actualAspectRatio = this->ViewportSize.X / this->ViewportSize.Y;
+  }
+
+  double verticalFieldOfView =
+      atan(tan(horizontalFieldOfView * 0.5) / actualAspectRatio) * 2.0;
+
+  FVector direction = this->Rotation.RotateVector(FVector(1.0f, 0.0f, 0.0f));
+  FVector up = this->Rotation.RotateVector(FVector(0.0f, 0.0f, 1.0f));
+
+  glm::dvec3 tilesetCameraLocation = glm::dvec3(
+      unrealWorldToTileset *
+      glm::dvec4(this->Location.X, this->Location.Y, this->Location.Z, 1.0));
+  glm::dvec3 tilesetCameraFront = glm::normalize(glm::dvec3(
+      unrealWorldToTileset *
+      glm::dvec4(direction.X, direction.Y, direction.Z, 0.0)));
+  glm::dvec3 tilesetCameraUp = glm::normalize(
+      glm::dvec3(unrealWorldToTileset * glm::dvec4(up.X, up.Y, up.Z, 0.0)));
+
+  return Cesium3DTilesSelection::ViewState::create(
+      tilesetCameraLocation,
+      tilesetCameraFront,
+      tilesetCameraUp,
+      size,
+      horizontalFieldOfView,
+      verticalFieldOfView);
+}

--- a/Source/CesiumRuntime/Private/CesiumCameraManager.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCameraManager.cpp
@@ -1,0 +1,98 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#include "CesiumCameraManager.h"
+#include "CesiumRuntime.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include <string>
+#include <vector>
+
+FName ACesiumCameraManager::DEFAULT_CAMERAMANAGER_TAG =
+    FName("DEFAULT_CAMERAMANAGER");
+
+/*static*/ ACesiumCameraManager* ACesiumCameraManager::GetDefaultCameraManager(
+    const UObject* WorldContextObject) {
+  UWorld* world = WorldContextObject->GetWorld();
+  // This method can be called by actors even when opening the content browser.
+  if (!IsValid(world)) {
+    return nullptr;
+  }
+  UE_LOG(
+      LogCesium,
+      Verbose,
+      TEXT("World name for GetDefaultCameraManager: %s"),
+      *world->GetFullName());
+
+  // Note: The actor iterator will be created with the
+  // "EActorIteratorFlags::SkipPendingKill" flag,
+  // meaning that we don't have to handle objects
+  // that have been deleted. (This is the default,
+  // but made explicit here)
+  ACesiumCameraManager* pCameraManager = nullptr;
+  EActorIteratorFlags flags = EActorIteratorFlags::OnlyActiveLevels |
+                              EActorIteratorFlags::SkipPendingKill;
+  for (TActorIterator<AActor> actorIterator(
+           world,
+           ACesiumCameraManager::StaticClass(),
+           flags);
+       actorIterator;
+       ++actorIterator) {
+    AActor* actor = *actorIterator;
+    if (actor->ActorHasTag(DEFAULT_CAMERAMANAGER_TAG)) {
+      pCameraManager = Cast<ACesiumCameraManager>(actor);
+      break;
+    }
+  }
+
+  if (!pCameraManager) {
+    UE_LOG(
+        LogCesium,
+        Verbose,
+        TEXT("Creating default ACesiumCameraManager for actor %s"),
+        *WorldContextObject->GetName());
+    // Spawn georeference in the persistent level
+    FActorSpawnParameters spawnParameters;
+    spawnParameters.SpawnCollisionHandlingOverride =
+        ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+    pCameraManager = world->SpawnActor<ACesiumCameraManager>(spawnParameters);
+    // Null check so the editor doesn't crash when it makes arbitrary calls to
+    // this function without a valid world context object.
+    if (pCameraManager) {
+      pCameraManager->Tags.Add(DEFAULT_CAMERAMANAGER_TAG);
+    }
+  } else {
+    UE_LOG(
+        LogCesium,
+        Verbose,
+        TEXT("Using existing ACesiumCameraManager %s for actor %s"),
+        *pCameraManager->GetName(),
+        *WorldContextObject->GetName());
+  }
+  return pCameraManager;
+}
+
+bool ACesiumCameraManager::ShouldTickIfViewportsOnly() const { return true; }
+
+void ACesiumCameraManager::Tick(float DeltaTime) { Super::Tick(DeltaTime); }
+
+int32 ACesiumCameraManager::AddCamera(UPARAM(ref) const FCesiumCamera& camera) {
+  int32 cameraId = this->_currentCameraId++;
+  this->_cameras.Emplace(cameraId, camera);
+  return cameraId;
+}
+
+bool ACesiumCameraManager::UpdateCamera(
+    int32 cameraId,
+    UPARAM(ref) const FCesiumCamera& camera) {
+  FCesiumCamera* pCurrentCamera = this->_cameras.Find(cameraId);
+  if (pCurrentCamera) {
+    *pCurrentCamera = camera;
+    return true;
+  }
+
+  return false;
+}
+
+const TMap<int32, FCesiumCamera>& ACesiumCameraManager::GetCameras() const {
+  return this->_cameras;
+}

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -20,6 +20,7 @@
 
 class UMaterialInterface;
 class ACesiumCartographicSelection;
+struct FCesiumCamera;
 
 namespace Cesium3DTilesSelection {
 class Tileset;
@@ -694,25 +695,13 @@ private:
   void LoadTileset();
   void DestroyTileset();
 
-  struct UnrealCameraParameters {
-    FVector2D viewportSize;
-    FVector location;
-    FRotator rotation;
-    double fieldOfViewDegrees;
-
-    // If not std::nullopt, the aspect ratio may be different from the one
-    // implied by the viewportSize and black bars are added as needed in order
-    // to achieve this aspect ratio within a larger viewport.
-    std::optional<double> aspectRatio = std::nullopt;
-  };
-
   static Cesium3DTilesSelection::ViewState CreateViewStateFromViewParameters(
-      const UnrealCameraParameters& camera,
+      const FCesiumCamera& camera,
       const glm::dmat4& unrealWorldToTileset);
 
-  std::vector<UnrealCameraParameters> GetCameras() const;
-  std::vector<UnrealCameraParameters> GetPlayerCameras() const;
-  std::vector<UnrealCameraParameters> GetSceneCaptures() const;
+  std::vector<FCesiumCamera> GetCameras() const;
+  std::vector<FCesiumCamera> GetPlayerCameras() const;
+  std::vector<FCesiumCamera> GetSceneCaptures() const;
 
 public:
   /**
@@ -759,7 +748,7 @@ private:
   void AddFocusViewportDelegate();
 
 #if WITH_EDITOR
-  std::vector<UnrealCameraParameters> GetEditorCameras() const;
+  std::vector<FCesiumCamera> GetEditorCameras() const;
 
   /**
    * Will focus all viewports on this tileset.

--- a/Source/CesiumRuntime/Public/CesiumCamera.h
+++ b/Source/CesiumRuntime/Public/CesiumCamera.h
@@ -1,0 +1,53 @@
+
+#pragma once
+
+#include "Math/Rotator.h"
+#include "Math/Vector.h"
+#include "Math/Vector2D.h"
+#include "UObject/ObjectMacros.h"
+
+#include "Cesium3DTilesSelection/ViewState.h"
+
+#include "CesiumCamera.generated.h"
+
+USTRUCT(BlueprintType)
+struct CESIUMRUNTIME_API FCesiumCamera {
+  GENERATED_USTRUCT_BODY()
+
+public:
+  UPROPERTY(BlueprintReadWrite)
+  FVector2D ViewportSize;
+
+  UPROPERTY(BlueprintReadWrite)
+  FVector Location;
+
+  UPROPERTY(BlueprintReadWrite)
+  FRotator Rotation;
+
+  UPROPERTY(BlueprintReadWrite)
+  float FieldOfViewDegrees;
+
+  // The aspect ratio may be different from the one implied by the ViewportSize
+  // and black bars are added as needed in order to achieve this aspect ratio
+  // within a larger viewport.
+  UPROPERTY(BlueprintReadWrite)
+  float AspectRatio = 0.0f;
+
+  FCesiumCamera();
+
+  FCesiumCamera(
+      const FVector2D& ViewportSize,
+      const FVector& Location,
+      const FRotator& Rotation,
+      float FieldOfViewDegrees);
+
+  FCesiumCamera(
+      const FVector2D& ViewportSize,
+      const FVector& Location,
+      const FRotator& Rotation,
+      float FieldOfViewDegrees,
+      float AspectRatio);
+
+  Cesium3DTilesSelection::ViewState
+  createViewState(const glm::dmat4& unrealWorldToTileset) const;
+};

--- a/Source/CesiumRuntime/Public/CesiumCamera.h
+++ b/Source/CesiumRuntime/Public/CesiumCamera.h
@@ -10,44 +10,83 @@
 
 #include "CesiumCamera.generated.h"
 
+/**
+ * @brief A camera description that {@link Cesium3DTileset}s can use to decide
+ * what tiles need to be loaded to sufficiently cover the camera view.
+ */
 USTRUCT(BlueprintType)
 struct CESIUMRUNTIME_API FCesiumCamera {
   GENERATED_USTRUCT_BODY()
 
 public:
+  /**
+   * @brief The pixel dimensions of the viewport.
+   */
   UPROPERTY(BlueprintReadWrite)
   FVector2D ViewportSize;
 
+  /**
+   * @brief The Unreal location of the camera.
+   */
   UPROPERTY(BlueprintReadWrite)
   FVector Location;
 
+  /**
+   * @brief The Unreal rotation of the camera.
+   */
   UPROPERTY(BlueprintReadWrite)
   FRotator Rotation;
 
+  /**
+   * @brief The horizontal field of view of the camera in degrees.
+   */
   UPROPERTY(BlueprintReadWrite)
   float FieldOfViewDegrees;
 
-  // The aspect ratio may be different from the one implied by the ViewportSize
-  // and black bars are added as needed in order to achieve this aspect ratio
-  // within a larger viewport.
+  /**
+   * @brief The overriden aspect ratio for this camera.
+   *
+   * When this is 0.0f, use the aspect ratio implied by ViewportSize.
+   *
+   * This may be different from the aspect ratio implied by the ViewportSize
+   * and black bars are added as needed in order to achieve this aspect ratio
+   * within a larger viewport.
+   */
   UPROPERTY(BlueprintReadWrite)
-  float AspectRatio = 0.0f;
+  float OverrideAspectRatio = 0.0f;
 
+  /**
+   * @brief Construct an uninitialized FCesiumCamera object.
+   */
   FCesiumCamera();
 
+  /**
+   * @brief Construct a new FCesiumCamera object.
+   *
+   * @param ViewportSize The viewport pixel size.
+   * @param Location The Unreal location.
+   * @param Rotation The Unreal rotation.
+   * @param FieldOfViewDegrees The horizontal field of view in degrees.
+   */
   FCesiumCamera(
       const FVector2D& ViewportSize,
       const FVector& Location,
       const FRotator& Rotation,
       float FieldOfViewDegrees);
 
+  /**
+   * @brief Construct a new FCesiumCamera object.
+   *
+   * @param ViewportSize The viewport pixel size.
+   * @param Location The Unreal location.
+   * @param Rotation The Unreal rotation.
+   * @param FieldOfViewDegrees The horizontal field of view in degrees.
+   * @param OverrideAspectRatio The overriden aspect ratio.
+   */
   FCesiumCamera(
       const FVector2D& ViewportSize,
       const FVector& Location,
       const FRotator& Rotation,
       float FieldOfViewDegrees,
-      float AspectRatio);
-
-  Cesium3DTilesSelection::ViewState
-  createViewState(const glm::dmat4& unrealWorldToTileset) const;
+      float OverrideAspectRatio);
 };

--- a/Source/CesiumRuntime/Public/CesiumCameraManager.h
+++ b/Source/CesiumRuntime/Public/CesiumCameraManager.h
@@ -8,11 +8,18 @@
 
 #include "CesiumCameraManager.generated.h"
 
+/**
+ * @brief Manages custom {@link FCesiumCamera}s for all
+ * {@link Cesium3DTileset}s in the world.
+ */
 UCLASS()
 class CESIUMRUNTIME_API ACesiumCameraManager : public AActor {
   GENERATED_BODY()
 
 public:
+  /**
+   * @brief Get the camera manager for this world.
+   */
   UFUNCTION(
       BlueprintCallable,
       Category = "CesiumCameraManager",
@@ -22,12 +29,31 @@ public:
 
   ACesiumCameraManager() {}
 
+  /**
+   * @brief Register a new camera with the camera manager.
+   *
+   * @param Camera The current state for the new camera.
+   * @return The generated ID for this camera. Use this ID to refer to the
+   * camera in the future when calling UpdateCamera.
+   */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
-  int32 AddCamera(UPARAM(ref) const FCesiumCamera& camera);
+  int32 AddCamera(UPARAM(ref) const FCesiumCamera& Camera);
 
+  /**
+   * @brief Update the state of the specified camera.
+   *
+   * @param CameraId The ID of the camera, as returned by AddCamera during
+   * registration.
+   * @param Camera The new, updated state of the camera.
+   * @return Whether the updating was successful. If false, the CameraId was
+   * invalid.
+   */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
-  bool UpdateCamera(int32 cameraId, UPARAM(ref) const FCesiumCamera& camera);
+  bool UpdateCamera(int32 CameraId, UPARAM(ref) const FCesiumCamera& Camera);
 
+  /**
+   * @brief Get a read-only map of the current camera IDs to cameras.
+   */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   const TMap<int32, FCesiumCamera>& GetCameras() const;
 

--- a/Source/CesiumRuntime/Public/CesiumCameraManager.h
+++ b/Source/CesiumRuntime/Public/CesiumCameraManager.h
@@ -1,0 +1,43 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "CesiumCamera.h"
+#include "Containers/Map.h"
+#include "GameFramework/Actor.h"
+
+#include "CesiumCameraManager.generated.h"
+
+UCLASS()
+class CESIUMRUNTIME_API ACesiumCameraManager : public AActor {
+  GENERATED_BODY()
+
+public:
+  UFUNCTION(
+      BlueprintCallable,
+      Category = "CesiumCameraManager",
+      meta = (WorldContext = "WorldContextObject"))
+  static ACesiumCameraManager*
+  GetDefaultCameraManager(const UObject* WorldContextObject);
+
+  ACesiumCameraManager() {}
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  int32 AddCamera(UPARAM(ref) const FCesiumCamera& camera);
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  bool UpdateCamera(int32 cameraId, UPARAM(ref) const FCesiumCamera& camera);
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  const TMap<int32, FCesiumCamera>& GetCameras() const;
+
+  virtual bool ShouldTickIfViewportsOnly() const override;
+
+  virtual void Tick(float DeltaTime) override;
+
+private:
+  int32 _currentCameraId = 0;
+  TMap<int32, FCesiumCamera> _cameras;
+
+  static FName DEFAULT_CAMERAMANAGER_TAG;
+};


### PR DESCRIPTION
Custom camera views into Cesium tilesets that aren't automatically picked up can be manually registered now through Blueprint or C++. Extra views can be programmatically updated each frame, in the example below the custom view simply sweeps 360 degrees. This custom camera registration ability may also be useful for AI that needs to "probe" certain sections of tileset geometry to navigate.

##### The custom camera sweeps 360 degrees.
![ezgif-2-5007a8e56f](https://user-images.githubusercontent.com/6706316/150899182-1a2c3459-049a-4e4f-ac4a-00fce7f8d5e7.gif)

##### Registering a custom camera with the Cesium Camera Manager. A reference to the camera manager and the camera id are saved for later.
![camera-manager-0](https://user-images.githubusercontent.com/6706316/151236782-58ccdbb8-da99-4912-8ed7-b190b405765b.JPG)

##### Updating the custom camera, referencing it using the camera id saved earlier.
![camera-manager-1](https://user-images.githubusercontent.com/6706316/151237065-b7d85635-00d8-453f-bdb4-2295882d3962.JPG)

