### PR TITLE
Added missing category specifiers in CesiumCamera

### DIFF
--- a/Source/CesiumRuntime/Public/CesiumCamera.h
+++ b/Source/CesiumRuntime/Public/CesiumCamera.h
@@ -52,7 +52,7 @@ public:
    * and black bars are added as needed in order to achieve this aspect ratio
    * within a larger viewport.
    */
-  UPROPERTY(BlueprintReadWrite)
+  UPROPERTY(BlueprintReadWrite, Category = "Cesium")
   float OverrideAspectRatio = 0.0f;
 
   /**

--- a/Source/CesiumRuntime/Public/CesiumCamera.h
+++ b/Source/CesiumRuntime/Public/CesiumCamera.h
@@ -22,25 +22,25 @@ public:
   /**
    * @brief The pixel dimensions of the viewport.
    */
-  UPROPERTY(BlueprintReadWrite)
+  UPROPERTY(BlueprintReadWrite, Category = "Cesium")
   FVector2D ViewportSize;
 
   /**
    * @brief The Unreal location of the camera.
    */
-  UPROPERTY(BlueprintReadWrite)
+  UPROPERTY(BlueprintReadWrite, Category = "Cesium")
   FVector Location;
 
   /**
    * @brief The Unreal rotation of the camera.
    */
-  UPROPERTY(BlueprintReadWrite)
+  UPROPERTY(BlueprintReadWrite, Category = "Cesium")
   FRotator Rotation;
 
   /**
    * @brief The horizontal field of view of the camera in degrees.
    */
-  UPROPERTY(BlueprintReadWrite)
+  UPROPERTY(BlueprintReadWrite, Category = "Cesium")
   float FieldOfViewDegrees;
 
   /**


### PR DESCRIPTION
This should fix the CI in main. This was only caught in the IOS and Mac 4.27 CI, which didn't exist in #459. So merging that PR into main must have broken CI.