### PR TITLE
Revert change to Android cache DB location

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v1.10.1 - 2022-02-01
+
+##### Fixes :wrench:
+
+- Fixed a crash at startup on Android devices introduced in v1.10.0.
+
 ### v1.10.0 - 2022-02-01
 
 ##### Breaking Changes :mega:

--- a/CesiumForUnreal.uplugin
+++ b/CesiumForUnreal.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 20,
-	"VersionName": "1.10.0",
+	"Version": 21,
+	"VersionName": "1.10.1",
 	"FriendlyName": "Cesium for Unreal",
 	"Description": "Unlock the 3D geospatial ecosystem in Unreal Engine with real-world 3D content and a high accuracy full-scale WGS84 globe.",
 	"Category": "Geospatial",

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -723,7 +723,9 @@ private:
 };
 
 static std::string getCacheDatabaseName() {
-#if PLATFORM_ANDROID || PLATFORM_IOS
+#if PLATFORM_ANDROID
+  FString BaseDirectory = FPaths::ProjectPersistentDownloadDir();
+#elif PLATFORM_IOS
   FString BaseDirectory =
       FPaths::Combine(*FPaths::ProjectSavedDir(), TEXT("Cesium"));
   if (!IFileManager::Get().DirectoryExists(*BaseDirectory)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-unreal",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Cesium for Unreal",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
#713 made a seemingly sensible change to where the request cache is stored on Android devices. But after that change, apps that use Cesium for Unreal crash on startup on Android. On my phone, the cache filename ends up being `../../../CesiumForUnrealSamples/Saved/Cesium/cesium-request-cache.sqlite`. That sure looks like a relative path to me, despite the fact that it's the result of calling `ConvertToAbsolutePathForExternalAppForWrite` 🤷. My guess is that it's relative to the wrong place or somesuch, so Android won't let us open a file for writing there.

This PR switches back to the previous location on Android. It continues to use the new one on iOS.