### PR TITLE
No troubleshooting panel in game worlds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- The Cesium ion Token Troubleshooting panel will no longer appear in game worlds, including Play-In-Editor.
+
 ### v1.10.1 - 2022-02-01
 
 ##### Fixes :wrench:

--- a/Source/CesiumEditor/Private/CesiumEditor.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditor.cpp
@@ -365,6 +365,12 @@ TSharedRef<SDockTab> FCesiumEditorModule::SpawnCesiumIonAssetBrowserTab(
 
 void FCesiumEditorModule::OnTilesetLoadFailure(
     const FCesium3DTilesetLoadFailureDetails& details) {
+  // Don't pop a troubleshooting panel over a game world (including
+  // Play-In-Editor).
+  if (details.Tileset && details.Tileset->GetWorld()->IsGameWorld()) {
+    return;
+  }
+
   FLevelEditorModule* pLevelEditorModule =
       FModuleManager::GetModulePtr<FLevelEditorModule>(
           FName(TEXT("LevelEditor")));
@@ -384,6 +390,12 @@ void FCesiumEditorModule::OnTilesetLoadFailure(
 
 void FCesiumEditorModule::OnRasterOverlayLoadFailure(
     const FCesiumRasterOverlayLoadFailureDetails& details) {
+  // Don't pop a troubleshooting panel over a game world (including
+  // Play-In-Editor).
+  if (details.Overlay && details.Overlay->GetWorld()->IsGameWorld()) {
+    return;
+  }
+
   FLevelEditorModule* pLevelEditorModule =
       FModuleManager::GetModulePtr<FLevelEditorModule>(
           FName(TEXT("LevelEditor")));

--- a/Source/CesiumRuntime/Private/CesiumIonRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumIonRasterOverlay.cpp
@@ -12,6 +12,11 @@ void UCesiumIonRasterOverlay::TroubleshootToken() {
 std::unique_ptr<Cesium3DTilesSelection::RasterOverlay>
 UCesiumIonRasterOverlay::CreateOverlay(
     const Cesium3DTilesSelection::RasterOverlayOptions& options) {
+  if (this->IonAssetID <= 0) {
+    // Don't create an overlay for an invalid asset ID.
+    return nullptr;
+  }
+
   FString token =
       this->IonAccessToken.IsEmpty()
           ? GetDefault<UCesiumRuntimeSettings>()->DefaultIonAccessToken

--- a/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
@@ -86,11 +86,14 @@ void UCesiumRasterOverlay::AddToTileset() {
 
   std::unique_ptr<Cesium3DTilesSelection::RasterOverlay> pOverlay =
       this->CreateOverlay(options);
-  this->_pOverlay = pOverlay.get();
 
-  pTileset->getOverlays().add(std::move(pOverlay));
+  if (pOverlay) {
+    this->_pOverlay = pOverlay.get();
 
-  this->OnAdd(pTileset, this->_pOverlay);
+    pTileset->getOverlays().add(std::move(pOverlay));
+
+    this->OnAdd(pTileset, this->_pOverlay);
+  }
 }
 
 void UCesiumRasterOverlay::RemoveFromTileset() {


### PR DESCRIPTION
Fixes #755 

There's more we could do here, but this fixes the most important part by far. With this PR, the Token Troubleshooting panel will no longer appear when in Play-In-Editor (or any other game world). And we'll no longer try to connect to ion and pop up a troubleshooting panel for an asset ID of 0.