### PR TITLE
Expose CesiumSunSky date and time properties to Sequencer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - Fixed a bug that causes a graphical glitch by using 16-bit indices when 32-bit is needed.
 - Fixed a bug where metadata from the feature table was not decoded from UTF-8.
 - Improved the shadows, making shadows fade in and out less noticable.
+- Exposed CesiumSunSky date and time parameters to Sequencer. Be sure to use an Event Track to call `UpdateSun` every frame when animating changes in date or time.
 
 ##### Fixes :wrench:
 

--- a/Source/CesiumRuntime/Public/CesiumSunSky.h
+++ b/Source/CesiumRuntime/Public/CesiumSunSky.h
@@ -96,6 +96,7 @@ protected:
   UPROPERTY(
       EditAnywhere,
       BlueprintReadWrite,
+      Interp,
       Category = "Cesium|Date and Time",
       meta = (UIMin = 4, UIMax = 22, ClampMin = 0, ClampMax = 23.9999))
   float SolarTime = 13.f;
@@ -109,6 +110,7 @@ protected:
   UPROPERTY(
       EditAnywhere,
       BlueprintReadWrite,
+      Interp,
       Category = "Cesium|Date and Time",
       meta = (ClampMin = 1, ClampMax = 31))
   int32 Day = 21;
@@ -122,6 +124,7 @@ protected:
   UPROPERTY(
       EditAnywhere,
       BlueprintReadWrite,
+      Interp,
       Category = "Cesium|Date and Time",
       meta = (ClampMin = 1, ClampMax = 12))
   int32 Month = 9;
@@ -135,6 +138,7 @@ protected:
   UPROPERTY(
       EditAnywhere,
       BlueprintReadWrite,
+      Interp,
       Category = "Cesium|Date and Time",
       meta = (UIMin = 1800, UIMax = 2200, ClampMin = 0, ClampMax = 4000))
   int32 Year = 2019;

--- a/Source/CesiumRuntime/Public/CesiumSunSky.h
+++ b/Source/CesiumRuntime/Public/CesiumSunSky.h
@@ -83,6 +83,7 @@ protected:
   UPROPERTY(
       EditAnywhere,
       BlueprintReadWrite,
+      Interp,
       Category = "Cesium|Date and Time",
       meta = (ClampMin = -12, ClampMax = 14))
   float TimeZone = -5.f;


### PR DESCRIPTION
See https://github.com/CesiumGS/cesium-unreal/issues/760 - Previously, you could not animate the date or time in Sequencer. This PR exposes CesiumSunSky's Solar Time, Day, Month, Year, and Time Zone parameters to Sequencer. 

![image](https://user-images.githubusercontent.com/39537389/155024870-2cf56a99-5eb2-4718-b1a5-f5737b640f69.png)


Note that currently, CesiumSunSky's `UpdateSun` function must be called every frame in order for the animation to reflect in the scene. The best way I could find around that was to add a [Repeater Event Track](https://docs.unrealengine.com/4.26/en-US/AnimatingObjects/Sequencer/Workflow/EventTrackOverview/) on CesiumSunSky in the sequencer, then binding that event to UpdateSun. Steps to do that below, since I'm not sure where else to document them:

1. Add CesiumSunSky to the Sequencer track
2. Click the "+ Track" button and select Event>Repeater from the menu
3. Double-click the new Event Track - it will create a new Sequence Director blueprint. Connect an Update Sun node to the event. 
![image](https://user-images.githubusercontent.com/39537389/155024614-e0698e44-e686-49ad-8295-d7870144f662.png)
4. Keyframe your animation
5. To make sure it's working, right click on the event track and select Properties>Call In Editor. 

Of course, there's a lot that could be improved here - it would be great if people didn't have to add the event track. But I imagine that would involve refactoring the SunSky so this is probably enough for now.
