### PR TITLE
Refactor CesiumGltfComponent.cpp

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -548,6 +548,7 @@ public:
       const glm::dmat4& transform) override {
 
     CreateModelOptions options;
+    options.pModel = &model;
     options.alwaysIncludeTangents = this->_pActor->GetAlwaysIncludeTangents();
 
 #if PHYSICS_INTERFACE_PHYSX
@@ -555,7 +556,7 @@ public:
 #endif
 
     std::unique_ptr<UCesiumGltfComponent::HalfConstructed> pHalf =
-        UCesiumGltfComponent::CreateOffGameThread(model, transform, options);
+        UCesiumGltfComponent::CreateOffGameThread(transform, options);
     return pHalf.release();
   }
 

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -505,8 +505,9 @@ static void loadPrimitive(
 
   CESIUM_TRACE("loadPrimitive<T>");
 
-  const Model& model = *options.meshOptions.nodeOptions.modelOptions.pModel;
-  const Mesh& mesh = *options.meshOptions.pMesh;
+  const Model& model =
+      *options.pMeshOptions->pNodeOptions->pModelOptions->pModel;
+  const Mesh& mesh = *options.pMeshOptions->pMesh;
   const MeshPrimitive& primitive = *options.pPrimitive;
 
   if (primitive.mode != CesiumGltf::MeshPrimitive::Mode::TRIANGLES &&
@@ -609,7 +610,7 @@ static void loadPrimitive(
 
   bool needsTangents =
       hasNormalMap ||
-      options.meshOptions.nodeOptions.modelOptions.alwaysIncludeTangents;
+      options.pMeshOptions->pNodeOptions->pModelOptions->alwaysIncludeTangents;
 
   bool hasTangents = false;
   auto tangentAccessorIt = primitive.attributes.find("TANGENT");
@@ -975,7 +976,7 @@ static void loadPrimitive(
   primitiveResult.pCollisionMesh = nullptr;
 
 #if PHYSICS_INTERFACE_PHYSX
-  if (options.meshOptions.nodeOptions.modelOptions.pPhysXCooking) {
+  if (options.pMeshOptions->pNodeOptions->pModelOptions->pPhysXCooking) {
     CESIUM_TRACE("PhysX cook");
     // TODO: use PhysX interface directly so we don't need to copy the
     // vertices (it takes a stride parameter).
@@ -995,14 +996,15 @@ static void loadPrimitive(
       physicsIndices[i].v2 = indices[3 * i + 2];
     }
 
-    options.meshOptions.nodeOptions.modelOptions.pPhysXCooking->CreateTriMesh(
-        "PhysXGeneric",
-        EPhysXMeshCookFlags::Default,
-        vertices,
-        physicsIndices,
-        TArray<uint16>(),
-        true,
-        primitiveResult.pCollisionMesh);
+    options.pMeshOptions->pNodeOptions->pModelOptions->pPhysXCooking
+        ->CreateTriMesh(
+            "PhysXGeneric",
+            EPhysXMeshCookFlags::Default,
+            vertices,
+            physicsIndices,
+            TArray<uint16>(),
+            true,
+            primitiveResult.pCollisionMesh);
   }
 #else
   if (StaticMeshBuildVertices.Num() != 0 && indices.Num() != 0) {
@@ -1025,7 +1027,8 @@ static void loadIndexedPrimitive(
     const CesiumGltf::Accessor& positionAccessor,
     const CesiumGltf::AccessorView<FVector>& positionView) {
 
-  const Model& model = *options.meshOptions.nodeOptions.modelOptions.pModel;
+  const Model& model =
+      *options.pMeshOptions->pNodeOptions->pModelOptions->pModel;
   const MeshPrimitive& primitive = *options.pPrimitive;
 
   const CesiumGltf::Accessor& indexAccessorGltf =
@@ -1093,7 +1096,8 @@ static void loadPrimitive(
     const CreatePrimitiveOptions& options) {
   CESIUM_TRACE("loadPrimitive");
 
-  const Model& model = *options.meshOptions.nodeOptions.modelOptions.pModel;
+  const Model& model =
+      *options.pMeshOptions->pNodeOptions->pModelOptions->pModel;
   const MeshPrimitive& primitive = *options.pPrimitive;
 
   auto positionAccessorIt = primitive.attributes.find("POSITION");
@@ -1142,7 +1146,7 @@ static void loadMesh(
 
   CESIUM_TRACE("loadMesh");
 
-  const Model& model = *options.nodeOptions.modelOptions.pModel;
+  const Model& model = *options.pNodeOptions->pModelOptions->pModel;
   const Mesh& mesh = *options.pMesh;
 
   result = LoadMeshResult();
@@ -1181,7 +1185,7 @@ static void loadNode(
 
   CESIUM_TRACE("loadNode");
 
-  const Model& model = *options.modelOptions.pModel;
+  const Model& model = *options.pModelOptions->pModel;
   const Node& node = *options.pNode;
 
   LoadNodeResult& result = loadNodeResults.emplace_back();
@@ -1338,8 +1342,8 @@ static LoadModelResult loadModelAnyThreadPart(
   } else if (model.meshes.size() > 0) {
     // No nodes either, show all the meshes.
     for (const CesiumGltf::Mesh& mesh : model.meshes) {
-      CreateMeshOptions meshOptions;
-      meshOptions.nodeOptions = options;
+      CreateNodeOptions dummyNodeOptions = options;
+      CreateMeshOptions meshOptions = dummyNodeOptions;
       meshOptions.pMesh = &mesh;
       LoadNodeResult& dummyNodeResult = result.nodeResults.emplace_back();
       loadMesh(dummyNodeResult.meshResult, rootTransform, meshOptions);

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.h
@@ -15,6 +15,13 @@ class UMaterialInterface;
 class UTexture2D;
 class UStaticMeshComponent;
 struct CreateModelOptions;
+struct CreateNodeOptions;
+struct CreateMeshOptions;
+struct CreatePrimitiveOptions;
+struct LoadModelResult;
+struct LoadNodeResult;
+struct LoadMeshResult;
+struct LoadPrimitiveResult;
 
 #if PHYSICS_INTERFACE_PHYSX
 class IPhysXCooking;

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.h
@@ -58,7 +58,6 @@ public:
   };
 
   static std::unique_ptr<HalfConstructed> CreateOffGameThread(
-      const CesiumGltf::Model& Model,
       const glm::dmat4x4& Transform,
       const CreateModelOptions& Options);
 

--- a/Source/CesiumRuntime/Private/CesiumGltfPrimitiveComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfPrimitiveComponent.cpp
@@ -75,7 +75,7 @@ void destroyWaterParameterValues(
 } // namespace
 
 void UCesiumGltfPrimitiveComponent::BeginDestroy() {
-  // This should mirror the logic in loadModelGameThreadPart in
+  // This should mirror the logic in loadPrimitiveGameThreadPart in
   // CesiumGltfComponent.cpp
   UMaterialInstanceDynamic* pMaterial =
       Cast<UMaterialInstanceDynamic>(this->GetMaterial(0));

--- a/Source/CesiumRuntime/Private/CreateModelOptions.h
+++ b/Source/CesiumRuntime/Private/CreateModelOptions.h
@@ -13,29 +13,14 @@ struct CreateModelOptions {
 struct CreateNodeOptions {
   const CreateModelOptions* pModelOptions = nullptr;
   const CesiumGltf::Node* pNode = nullptr;
-
-  CreateNodeOptions() = default;
-
-  CreateNodeOptions(const CreateModelOptions& modelOptions_)
-      : pModelOptions(&modelOptions_) {}
 };
 
 struct CreateMeshOptions {
   const CreateNodeOptions* pNodeOptions = nullptr;
   const CesiumGltf::Mesh* pMesh = nullptr;
-
-  CreateMeshOptions() = default;
-
-  CreateMeshOptions(const CreateNodeOptions& nodeOptions_)
-      : pNodeOptions(&nodeOptions_) {}
 };
 
 struct CreatePrimitiveOptions {
   const CreateMeshOptions* pMeshOptions = nullptr;
   const CesiumGltf::MeshPrimitive* pPrimitive = nullptr;
-
-  CreatePrimitiveOptions() = default;
-
-  CreatePrimitiveOptions(const CreateMeshOptions& meshOptions_)
-      : pMeshOptions(&meshOptions_) {}
 };

--- a/Source/CesiumRuntime/Private/CreateModelOptions.h
+++ b/Source/CesiumRuntime/Private/CreateModelOptions.h
@@ -3,8 +3,33 @@
 #pragma once
 
 struct CreateModelOptions {
+  const CesiumGltf::Model* pModel = nullptr;
   bool alwaysIncludeTangents = false;
 #if PHYSICS_INTERFACE_PHYSX
   IPhysXCooking* pPhysXCooking = nullptr;
 #endif
+};
+
+struct CreateNodeOptions {
+  CreateModelOptions modelOptions{};
+  const CesiumGltf::Node* pNode = nullptr;
+
+  CreateNodeOptions(const CreateModelOptions& modelOptions_)
+      : modelOptions(modelOptions_) {}
+};
+
+struct CreateMeshOptions {
+  CreateNodeOptions nodeOptions{};
+  const CesiumGltf::Mesh* pMesh = nullptr;
+
+  CreateMeshOptions(const CreateNodeOptions& nodeOptions_)
+      : nodeOptions(nodeOptions_) {}
+};
+
+struct CreatePrimitiveOptions {
+  CreateMeshOptions meshOptions{};
+  const CesiumGltf::MeshPrimitive* pPrimitive = nullptr;
+
+  CreatePrimitiveOptions(const CreateMeshOptions& meshOptions_)
+      : meshOptions(meshOptions_) {}
 };

--- a/Source/CesiumRuntime/Private/CreateModelOptions.h
+++ b/Source/CesiumRuntime/Private/CreateModelOptions.h
@@ -14,6 +14,8 @@ struct CreateNodeOptions {
   CreateModelOptions modelOptions{};
   const CesiumGltf::Node* pNode = nullptr;
 
+  CreateNodeOptions() = default;
+
   CreateNodeOptions(const CreateModelOptions& modelOptions_)
       : modelOptions(modelOptions_) {}
 };
@@ -22,6 +24,8 @@ struct CreateMeshOptions {
   CreateNodeOptions nodeOptions{};
   const CesiumGltf::Mesh* pMesh = nullptr;
 
+  CreateMeshOptions() = default;
+
   CreateMeshOptions(const CreateNodeOptions& nodeOptions_)
       : nodeOptions(nodeOptions_) {}
 };
@@ -29,6 +33,8 @@ struct CreateMeshOptions {
 struct CreatePrimitiveOptions {
   CreateMeshOptions meshOptions{};
   const CesiumGltf::MeshPrimitive* pPrimitive = nullptr;
+
+  CreatePrimitiveOptions() = default;
 
   CreatePrimitiveOptions(const CreateMeshOptions& meshOptions_)
       : meshOptions(meshOptions_) {}

--- a/Source/CesiumRuntime/Private/CreateModelOptions.h
+++ b/Source/CesiumRuntime/Private/CreateModelOptions.h
@@ -11,31 +11,31 @@ struct CreateModelOptions {
 };
 
 struct CreateNodeOptions {
-  CreateModelOptions modelOptions{};
+  const CreateModelOptions* pModelOptions = nullptr;
   const CesiumGltf::Node* pNode = nullptr;
 
   CreateNodeOptions() = default;
 
   CreateNodeOptions(const CreateModelOptions& modelOptions_)
-      : modelOptions(modelOptions_) {}
+      : pModelOptions(&modelOptions_) {}
 };
 
 struct CreateMeshOptions {
-  CreateNodeOptions nodeOptions{};
+  const CreateNodeOptions* pNodeOptions = nullptr;
   const CesiumGltf::Mesh* pMesh = nullptr;
 
   CreateMeshOptions() = default;
 
   CreateMeshOptions(const CreateNodeOptions& nodeOptions_)
-      : nodeOptions(nodeOptions_) {}
+      : pNodeOptions(&nodeOptions_) {}
 };
 
 struct CreatePrimitiveOptions {
-  CreateMeshOptions meshOptions{};
+  const CreateMeshOptions* pMeshOptions = nullptr;
   const CesiumGltf::MeshPrimitive* pPrimitive = nullptr;
 
   CreatePrimitiveOptions() = default;
 
   CreatePrimitiveOptions(const CreateMeshOptions& meshOptions_)
-      : meshOptions(meshOptions_) {}
+      : pMeshOptions(&meshOptions_) {}
 };

--- a/Source/CesiumRuntime/Private/LoadModelResult.h
+++ b/Source/CesiumRuntime/Private/LoadModelResult.h
@@ -1,0 +1,48 @@
+// Copyright 2020-2021 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+struct LoadPrimitiveResult {
+  FCesiumMetadataPrimitive Metadata{};
+  FStaticMeshRenderData* RenderData = nullptr;
+  const CesiumGltf::Model* pModel = nullptr;
+  const CesiumGltf::MeshPrimitive* pMeshPrimitive = nullptr;
+  const CesiumGltf::Material* pMaterial = nullptr;
+  glm::dmat4x4 transform{1.0};
+#if PHYSICS_INTERFACE_PHYSX
+  PxTriangleMesh* pCollisionMesh = nullptr;
+#else
+  TSharedPtr<Chaos::FTriangleMeshImplicitObject, ESPMode::ThreadSafe>
+      pCollisionMesh = nullptr;
+#endif
+  std::string name{};
+
+  CesiumTextureUtility::LoadedTextureResult* baseColorTexture = nullptr;
+  CesiumTextureUtility::LoadedTextureResult* metallicRoughnessTexture = nullptr;
+  CesiumTextureUtility::LoadedTextureResult* normalTexture = nullptr;
+  CesiumTextureUtility::LoadedTextureResult* emissiveTexture = nullptr;
+  CesiumTextureUtility::LoadedTextureResult* occlusionTexture = nullptr;
+  CesiumTextureUtility::LoadedTextureResult* waterMaskTexture = nullptr;
+  std::unordered_map<std::string, uint32_t> textureCoordinateParameters;
+
+  bool onlyLand = true;
+  bool onlyWater = false;
+
+  double waterMaskTranslationX = 0.0;
+  double waterMaskTranslationY = 0.0;
+  double waterMaskScale = 1.0;
+
+  OverlayTextureCoordinateIDMap overlayTextureCoordinateIDToUVIndex{};
+};
+
+struct LoadMeshResult {
+  std::vector<LoadPrimitiveResult> primitiveResults{};
+};
+
+struct LoadNodeResult {
+  std::optional<LoadMeshResult> meshResult = std::nullopt;
+};
+
+struct LoadModelResult {
+  std::vector<LoadNodeResult> nodeResults{};
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-unreal",
-  "version": "1.6.2",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Attempts to slightly clean up the hierarchical glTF loading in `CesiumGltfComponent.cpp`. The main goal is to make gltf loading more easily extensible as we grow support for extensions. Hopefully this means future changes / additions to the gltf loading process can be more localized to only the functionality and hierarchy level that they effect.

Main Changes:
- `CreateModelOptions` replaced by several structs for model options, node options, mesh options, and primitive options. Each struct can be extended easily in the future to contain new options (usually from glTF extensions) at that level. For example, nodes usually have a single mesh, but with the MAXAR_mesh_variants extension, an arbitrary number of meshes may be associated with a node. Similarly, in EXT_mesh_gpu_instancing, the node-level extension can indicate that its mesh (and so all the primitives coming from the mesh as well) should be instanced. These are examples of what could eventually go inside some of these options struct, even though most of them are empty for now.
- `LoadModelResult` replaced by several structs (model result, node result, mesh result, and primitive result) to retain the hierarchy of the result of the loading. Similar to the above change, this will help new additions be localized to a specific level (node, mesh, primitive, etc) and the result of that loading will be discernible conveniently at that same level.
- Changed some function / struct names that were misleading about what they were doing. E.g. `LoadModelResult` has been changed to `LoadPrimitiveResult`, `loadModelGameThreadPart` has been changed to `loadPrimitiveGameThreadPart`.
- ... hopefully more!

CC: @kring @baothientran @joseph-kaile 
Do you folks have any suggestions / objections for refactoring this code and how I'm going about it here? I'm open to more suggestions for other things to clean up / refactor in this PR related to the gltf loading.