### PR TITLE
Verify mips point to valid pixels.

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -111,6 +111,19 @@ CesiumTextureUtility::loadTextureAnyThreadPart(
     CESIUM_TRACE("Copying existing mips.");
 
     for (const CesiumGltf::ImageCesiumMipPosition& mip : image.mipPositions) {
+      if (mip.byteOffset >= image.pixelData.size() ||
+          mip.byteOffset + mip.byteSize > image.pixelData.size()) {
+        UE_LOG(
+            LogCesium,
+            Warning,
+            TEXT(
+                "Invalid mip in glTF; it has a byteOffset of %d and a byteSize of %d but only %d bytes of pixel data are available."),
+            mip.byteOffset,
+            mip.byteSize,
+            image.pixelData.size());
+        continue;
+      }
+
       FTexture2DMipMap* pLevel = new FTexture2DMipMap();
       pResult->pTextureData->Mips.Add(pLevel);
 


### PR DESCRIPTION
This is a small PR to make sure `ImageCesiumMipPosition`s point to valid pixels before trying to read from potentially invalid memory.