### PR TITLE
Check IsPendingKillOrUnreachable before modifying materials.

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -128,13 +128,6 @@ uint32_t updateTextureCoordinates(
   size_t textureCoordinateIndex = textureCoordinateMap.size();
   textureCoordinateMap[uvAccessorID] = textureCoordinateIndex;
 
-  struct A {
-    double x[5];
-  };
-
-  const A* a;
-  using Foo = decltype(a->x[0]);
-
   CesiumGltf::AccessorView<TMeshVector2> uvAccessor(model, uvAccessorID);
   if (uvAccessor.status() != CesiumGltf::AccessorViewStatus::Valid) {
     return 0;
@@ -1793,7 +1786,11 @@ void forEachPrimitiveComponent(UCesiumGltfComponent* pGltf, Func&& f) {
       UMaterialInstanceDynamic* pMaterial =
           Cast<UMaterialInstanceDynamic>(pPrimitive->GetMaterial(0));
 
+#if ENGINE_MAJOR_VERSION >= 5
       if (!IsValid(pMaterial)) {
+#else
+      if (pMaterial->IsPendingKillOrUnreachable()) {
+#endif
         // Don't try to update the material while it's in the process of being
         // destroyed. This can lead to the render thread freaking out when
         // it's asked to update a parameter for a material that has been

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1810,7 +1810,7 @@ void forEachPrimitiveComponent(UCesiumGltfComponent* pGltf, Func&& f) {
       f(pPrimitive, pMaterial, pCesiumData);
     }
   }
-}
+} // namespace
 
 } // namespace
 


### PR DESCRIPTION
Prior to #129, we sometimes had a crashing at shutdown or when switching levels causes by attempting to modify material parameters while the material was being destroyed. I fixed it by checking `Material->IsPendingKillOrUnreachable()` before attempting to modify parameters. But UE5 doesn't have this method, so in #735 I replaced with with a simple `IsValid`. That's not the same thing, and caused the crash bug to come back. So this PR switches back to `IsPendingKillOrUnreachable` in UE4, avoiding the regression. There are likely still problems in UE5.