### PR TITLE
Manage FStruct with TUniquePtr instead of raw pointer

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -8,7 +8,6 @@
 #include "Cesium3DTilesSelection/CreditSystem.h"
 #include "Cesium3DTilesSelection/GltfContent.h"
 #include "Cesium3DTilesSelection/IPrepareRendererResources.h"
-#include "Cesium3DTilesSelection/Tileset.h"
 #include "Cesium3DTilesSelection/TilesetLoadFailureDetails.h"
 #include "Cesium3DTilesSelection/TilesetOptions.h"
 #include "Cesium3DTilesetLoadFailureDetails.h"
@@ -863,7 +862,7 @@ void ACesium3DTileset::LoadTileset() {
   switch (this->TilesetSource) {
   case ETilesetSource::FromUrl:
     UE_LOG(LogCesium, Log, TEXT("Loading tileset from URL %s"), *this->Url);
-    this->_pTileset = new Cesium3DTilesSelection::Tileset(
+    this->_pTileset = MakeUnique<Cesium3DTilesSelection::Tileset>(
         externals,
         TCHAR_TO_UTF8(*this->Url),
         options);
@@ -879,14 +878,14 @@ void ACesium3DTileset::LoadTileset() {
             ? GetDefault<UCesiumRuntimeSettings>()->DefaultIonAccessToken
             : this->IonAccessToken;
     if (!IonAssetEndpointUrl.IsEmpty()) {
-      this->_pTileset = new Cesium3DTilesSelection::Tileset(
+      this->_pTileset = MakeUnique<Cesium3DTilesSelection::Tileset>(
           externals,
           static_cast<uint32_t>(this->IonAssetID),
           TCHAR_TO_UTF8(*token),
           options,
           TCHAR_TO_UTF8(*IonAssetEndpointUrl));
     } else {
-      this->_pTileset = new Cesium3DTilesSelection::Tileset(
+      this->_pTileset = MakeUnique<Cesium3DTilesSelection::Tileset>(
           externals,
           static_cast<uint32_t>(this->IonAssetID),
           TCHAR_TO_UTF8(*token),
@@ -948,8 +947,7 @@ void ACesium3DTileset::DestroyTileset() {
     return;
   }
 
-  delete this->_pTileset;
-  this->_pTileset = nullptr;
+  this->_pTileset.Reset();
 
   if (this->Url.Len() > 0) {
     UE_LOG(

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -662,7 +662,8 @@ static void loadPrimitive(
     needsTangents = true;
   }
 
-  TUniquePtr<FStaticMeshRenderData> RenderData = MakeUnique<FStaticMeshRenderData>();
+  TUniquePtr<FStaticMeshRenderData> RenderData =
+      MakeUnique<FStaticMeshRenderData>();
   RenderData->AllocateLODResources(1);
 
   FStaticMeshLODResources& LODResources = RenderData->LODResources[0];

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1525,8 +1525,7 @@ static void loadPrimitiveGameThreadPart(
   pStaticMesh->SetRenderData(std::move(loadResult.RenderData));
 #else
   // UE 5
-  pStaticMesh->SetRenderData(
-      TUniquePtr<FStaticMeshRenderData>(loadResult.RenderData));
+  pStaticMesh->SetRenderData(std::move(loadResult.RenderData));
 #endif
 
   const CesiumGltf::Model& model = *loadResult.pModel;

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1018,11 +1018,13 @@ static void loadPrimitive(
   if (StaticMeshBuildVertices.Num() != 0 && indices.Num() != 0) {
 #if PHYSICS_INTERFACE_PHYSX
     CESIUM_TRACE("PhysX cook");
+    PxTriangleMesh* createdCollisionMesh = nullptr;
     BuildPhysXTriangleMeshes(
-        primitiveResult.pCollisionMesh,
+        createdCollisionMesh,
         options.pMeshOptions->pNodeOptions->pModelOptions->pPhysXCooking,
         StaticMeshBuildVertices,
         indices);
+    primitiveResult.pCollisionMesh.Reset(createdCollisionMesh);
 #else
     CESIUM_TRACE("Chaos cook");
     primitiveResult.pCollisionMesh =
@@ -1654,7 +1656,7 @@ static void loadPrimitiveGameThreadPart(
 
   if (loadResult.pCollisionMesh) {
 #if PHYSICS_INTERFACE_PHYSX
-    pBodySetup->TriMeshes.Add(loadResult.pCollisionMesh);
+    pBodySetup->TriMeshes.Add(loadResult.pCollisionMesh.Release());
 #else
     pBodySetup->ChaosTriMeshes.Add(loadResult.pCollisionMesh);
 #endif

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.h
@@ -64,13 +64,13 @@ public:
     virtual ~HalfConstructed() = default;
   };
 
-  static std::unique_ptr<HalfConstructed> CreateOffGameThread(
+  static TUniquePtr<HalfConstructed> CreateOffGameThread(
       const glm::dmat4x4& Transform,
       const CreateModelOptions& Options);
 
   static UCesiumGltfComponent* CreateOnGameThread(
       AActor* ParentActor,
-      std::unique_ptr<HalfConstructed> HalfConstructed,
+      TUniquePtr<HalfConstructed> HalfConstructed,
       const glm::dmat4x4& CesiumToUnrealTransform,
       UMaterialInterface* BaseMaterial,
       UMaterialInterface* BaseWaterMaterial,

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -13,12 +13,12 @@
 
 using namespace CesiumGltf;
 
-static FTexturePlatformData*
+static TUniquePtr<FTexturePlatformData>
 createTexturePlatformData(int32 sizeX, int32 sizeY, EPixelFormat format) {
   if (sizeX > 0 && sizeY > 0 &&
       (sizeX % GPixelFormats[format].BlockSizeX) == 0 &&
       (sizeY % GPixelFormats[format].BlockSizeY) == 0) {
-    FTexturePlatformData* pTexturePlatformData = new FTexturePlatformData();
+    TUniquePtr<FTexturePlatformData> pTexturePlatformData = MakeUnique<FTexturePlatformData>();
     pTexturePlatformData->SizeX = sizeX;
     pTexturePlatformData->SizeY = sizeY;
     pTexturePlatformData->PixelFormat = format;
@@ -29,7 +29,7 @@ createTexturePlatformData(int32 sizeX, int32 sizeY, EPixelFormat format) {
   }
 }
 
-/*static*/ CesiumTextureUtility::LoadedTextureResult*
+/*static*/ TUniquePtr<CesiumTextureUtility::LoadedTextureResult>
 CesiumTextureUtility::loadTextureAnyThreadPart(
     const CesiumGltf::ImageCesium& image,
     const TextureAddress& addressX,
@@ -93,7 +93,7 @@ CesiumTextureUtility::loadTextureAnyThreadPart(
     };
   }
 
-  LoadedTextureResult* pResult = new LoadedTextureResult{};
+  TUniquePtr<LoadedTextureResult> pResult = MakeUnique<LoadedTextureResult>();
   pResult->pTextureData =
       createTexturePlatformData(image.width, image.height, pixelFormat);
   if (!pResult->pTextureData) {
@@ -157,7 +157,7 @@ CesiumTextureUtility::loadTextureAnyThreadPart(
       CESIUM_TRACE("Copying image.");
 
       // Create level 0 mip (full res image)
-      FTexture2DMipMap* pLevel0 = new FTexture2DMipMap();
+      FTexture2DMipMap *pLevel0 = new FTexture2DMipMap();
       pResult->pTextureData->Mips.Add(pLevel0);
       pLevel0->SizeX = width;
       pLevel0->SizeY = height;
@@ -229,7 +229,7 @@ CesiumTextureUtility::loadTextureAnyThreadPart(
   return pResult;
 }
 
-/*static*/ CesiumTextureUtility::LoadedTextureResult*
+/*static*/ TUniquePtr<CesiumTextureUtility::LoadedTextureResult>
 CesiumTextureUtility::loadTextureAnyThreadPart(
     const CesiumGltf::Model& model,
     const CesiumGltf::Texture& texture) {
@@ -333,30 +333,26 @@ CesiumTextureUtility::loadTextureAnyThreadPart(
   return loadTextureAnyThreadPart(image, addressX, addressY, filter);
 }
 
-/*static*/ bool CesiumTextureUtility::loadTextureGameThreadPart(
+/*static*/ UTexture2D* CesiumTextureUtility::loadTextureGameThreadPart(
     LoadedTextureResult* pHalfLoadedTexture) {
-  if (!pHalfLoadedTexture) {
-    return false;
+  if (!pHalfLoadedTexture || !pHalfLoadedTexture->pTextureData) {
+    return nullptr;
   }
 
-  UTexture2D*& pTexture = pHalfLoadedTexture->pTexture;
-
-  if (!pTexture) {
-    pTexture = NewObject<UTexture2D>(
-        GetTransientPackage(),
-        NAME_None,
-        RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
+  UTexture2D* pTexture = NewObject<UTexture2D>(
+      GetTransientPackage(),
+      NAME_None,
+      RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
 
 #if ENGINE_MAJOR_VERSION >= 5
-    pTexture->SetPlatformData(pHalfLoadedTexture->pTextureData);
+  pTexture->SetPlatformData(pHalfLoadedTexture->pTextureData);
 #else
-    pTexture->PlatformData = pHalfLoadedTexture->pTextureData;
+  pTexture->PlatformData = pHalfLoadedTexture->pTextureData.Release();
 #endif
-    pTexture->AddressX = pHalfLoadedTexture->addressX;
-    pTexture->AddressY = pHalfLoadedTexture->addressY;
-    pTexture->Filter = pHalfLoadedTexture->filter;
-    pTexture->UpdateResource();
-  }
+  pTexture->AddressX = pHalfLoadedTexture->addressX;
+  pTexture->AddressY = pHalfLoadedTexture->addressY;
+  pTexture->Filter = pHalfLoadedTexture->filter;
+  pTexture->UpdateResource();
 
-  return true;
+  return pTexture;
 }

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -18,7 +18,8 @@ createTexturePlatformData(int32 sizeX, int32 sizeY, EPixelFormat format) {
   if (sizeX > 0 && sizeY > 0 &&
       (sizeX % GPixelFormats[format].BlockSizeX) == 0 &&
       (sizeY % GPixelFormats[format].BlockSizeY) == 0) {
-    TUniquePtr<FTexturePlatformData> pTexturePlatformData = MakeUnique<FTexturePlatformData>();
+    TUniquePtr<FTexturePlatformData> pTexturePlatformData =
+        MakeUnique<FTexturePlatformData>();
     pTexturePlatformData->SizeX = sizeX;
     pTexturePlatformData->SizeY = sizeY;
     pTexturePlatformData->PixelFormat = format;
@@ -157,7 +158,7 @@ CesiumTextureUtility::loadTextureAnyThreadPart(
       CESIUM_TRACE("Copying image.");
 
       // Create level 0 mip (full res image)
-      FTexture2DMipMap *pLevel0 = new FTexture2DMipMap();
+      FTexture2DMipMap* pLevel0 = new FTexture2DMipMap();
       pResult->pTextureData->Mips.Add(pLevel0);
       pLevel0->SizeX = width;
       pLevel0->SizeY = height;

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -335,24 +335,27 @@ CesiumTextureUtility::loadTextureAnyThreadPart(
 
 /*static*/ UTexture2D* CesiumTextureUtility::loadTextureGameThreadPart(
     LoadedTextureResult* pHalfLoadedTexture) {
-  if (!pHalfLoadedTexture || !pHalfLoadedTexture->pTextureData) {
+  if (!pHalfLoadedTexture) {
     return nullptr;
   }
 
-  UTexture2D* pTexture = NewObject<UTexture2D>(
-      GetTransientPackage(),
-      NAME_None,
-      RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
+  UTexture2D*& pTexture = pHalfLoadedTexture->pTexture;
+  if (!pTexture && pHalfLoadedTexture->pTextureData) {
+    pTexture = NewObject<UTexture2D>(
+        GetTransientPackage(),
+        NAME_None,
+        RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
 
 #if ENGINE_MAJOR_VERSION >= 5
-  pTexture->SetPlatformData(pHalfLoadedTexture->pTextureData);
+    pTexture->SetPlatformData(pHalfLoadedTexture->pTextureData);
 #else
-  pTexture->PlatformData = pHalfLoadedTexture->pTextureData.Release();
+    pTexture->PlatformData = pHalfLoadedTexture->pTextureData.Release();
 #endif
-  pTexture->AddressX = pHalfLoadedTexture->addressX;
-  pTexture->AddressY = pHalfLoadedTexture->addressY;
-  pTexture->Filter = pHalfLoadedTexture->filter;
-  pTexture->UpdateResource();
+    pTexture->AddressX = pHalfLoadedTexture->addressX;
+    pTexture->AddressY = pHalfLoadedTexture->addressY;
+    pTexture->Filter = pHalfLoadedTexture->filter;
+    pTexture->UpdateResource();
+  }
 
   return pTexture;
 }

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -348,7 +348,7 @@ CesiumTextureUtility::loadTextureAnyThreadPart(
         RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
 
 #if ENGINE_MAJOR_VERSION >= 5
-    pTexture->SetPlatformData(pHalfLoadedTexture->pTextureData);
+    pTexture->SetPlatformData(pHalfLoadedTexture->pTextureData.Release());
 #else
     pTexture->PlatformData = pHalfLoadedTexture->pTextureData.Release();
 #endif

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.h
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.h
@@ -8,7 +8,6 @@
 #include "Templates/UniquePtr.h"
 #include <optional>
 
-
 class CesiumTextureUtility {
 public:
   struct LoadedTextureResult {

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.h
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.h
@@ -5,29 +5,30 @@
 #include "CesiumGltf/Model.h"
 #include "Engine/Texture.h"
 #include "Engine/Texture2D.h"
+#include "Templates/UniquePtr.h"
 #include <optional>
+
 
 class CesiumTextureUtility {
 public:
   struct LoadedTextureResult {
-    FTexturePlatformData* pTextureData;
+    TUniquePtr<FTexturePlatformData> pTextureData;
     TextureAddress addressX;
     TextureAddress addressY;
     TextureFilter filter;
-    UTexture2D* pTexture;
   };
 
   // TODO: documentation
-  static LoadedTextureResult* loadTextureAnyThreadPart(
+  static TUniquePtr<LoadedTextureResult> loadTextureAnyThreadPart(
       const CesiumGltf::ImageCesium& image,
       const TextureAddress& addressX,
       const TextureAddress& addressY,
       const TextureFilter& filter);
 
-  static LoadedTextureResult* loadTextureAnyThreadPart(
+  static TUniquePtr<LoadedTextureResult> loadTextureAnyThreadPart(
       const CesiumGltf::Model& model,
       const CesiumGltf::Texture& texture);
 
-  static bool
+  static UTexture2D*
   loadTextureGameThreadPart(LoadedTextureResult* pHalfLoadedTexture);
 };

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.h
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.h
@@ -16,6 +16,7 @@ public:
     TextureAddress addressX;
     TextureAddress addressY;
     TextureFilter filter;
+    UTexture2D* pTexture{nullptr};
   };
 
   // TODO: documentation

--- a/Source/CesiumRuntime/Private/LoadModelResult.h
+++ b/Source/CesiumRuntime/Private/LoadModelResult.h
@@ -4,7 +4,7 @@
 
 struct LoadPrimitiveResult {
   FCesiumMetadataPrimitive Metadata{};
-  FStaticMeshRenderData* RenderData = nullptr;
+  TUniquePtr<FStaticMeshRenderData> RenderData = nullptr;
   const CesiumGltf::Model* pModel = nullptr;
   const CesiumGltf::MeshPrimitive* pMeshPrimitive = nullptr;
   const CesiumGltf::Material* pMaterial = nullptr;
@@ -17,12 +17,12 @@ struct LoadPrimitiveResult {
 #endif
   std::string name{};
 
-  CesiumTextureUtility::LoadedTextureResult* baseColorTexture = nullptr;
-  CesiumTextureUtility::LoadedTextureResult* metallicRoughnessTexture = nullptr;
-  CesiumTextureUtility::LoadedTextureResult* normalTexture = nullptr;
-  CesiumTextureUtility::LoadedTextureResult* emissiveTexture = nullptr;
-  CesiumTextureUtility::LoadedTextureResult* occlusionTexture = nullptr;
-  CesiumTextureUtility::LoadedTextureResult* waterMaskTexture = nullptr;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> baseColorTexture = nullptr;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> metallicRoughnessTexture = nullptr;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> normalTexture = nullptr;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> emissiveTexture = nullptr;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> occlusionTexture = nullptr;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> waterMaskTexture = nullptr;
   std::unordered_map<std::string, uint32_t> textureCoordinateParameters;
 
   bool onlyLand = true;

--- a/Source/CesiumRuntime/Private/LoadModelResult.h
+++ b/Source/CesiumRuntime/Private/LoadModelResult.h
@@ -2,6 +2,18 @@
 
 #pragma once
 
+#if PHYSICS_INTERFACE_PHYSX
+#include <PxTriangleMesh.h>
+
+struct PxTriangleMeshDeleter {
+  void operator()(PxTriangleMesh* pCollisionMesh) {
+    if (pCollisionMesh) {
+      pCollisionMesh->release();
+    }
+  }
+};
+#endif
+
 struct LoadPrimitiveResult {
   FCesiumMetadataPrimitive Metadata{};
   TUniquePtr<FStaticMeshRenderData> RenderData = nullptr;
@@ -10,24 +22,20 @@ struct LoadPrimitiveResult {
   const CesiumGltf::Material* pMaterial = nullptr;
   glm::dmat4x4 transform{1.0};
 #if PHYSICS_INTERFACE_PHYSX
-  PxTriangleMesh* pCollisionMesh = nullptr;
+  TUniquePtr<PxTriangleMesh, PxTriangleMeshDeleter> pCollisionMesh;
 #else
   TSharedPtr<Chaos::FTriangleMeshImplicitObject, ESPMode::ThreadSafe>
       pCollisionMesh = nullptr;
 #endif
   std::string name{};
 
-  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> baseColorTexture =
-      nullptr;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> baseColorTexture;
   TUniquePtr<CesiumTextureUtility::LoadedTextureResult>
-      metallicRoughnessTexture = nullptr;
-  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> normalTexture = nullptr;
-  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> emissiveTexture =
-      nullptr;
-  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> occlusionTexture =
-      nullptr;
-  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> waterMaskTexture =
-      nullptr;
+      metallicRoughnessTexture;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> normalTexture;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> emissiveTexture;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> occlusionTexture;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> waterMaskTexture;
   std::unordered_map<std::string, uint32_t> textureCoordinateParameters;
 
   bool onlyLand = true;

--- a/Source/CesiumRuntime/Private/LoadModelResult.h
+++ b/Source/CesiumRuntime/Private/LoadModelResult.h
@@ -17,12 +17,17 @@ struct LoadPrimitiveResult {
 #endif
   std::string name{};
 
-  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> baseColorTexture = nullptr;
-  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> metallicRoughnessTexture = nullptr;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> baseColorTexture =
+      nullptr;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult>
+      metallicRoughnessTexture = nullptr;
   TUniquePtr<CesiumTextureUtility::LoadedTextureResult> normalTexture = nullptr;
-  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> emissiveTexture = nullptr;
-  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> occlusionTexture = nullptr;
-  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> waterMaskTexture = nullptr;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> emissiveTexture =
+      nullptr;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> occlusionTexture =
+      nullptr;
+  TUniquePtr<CesiumTextureUtility::LoadedTextureResult> waterMaskTexture =
+      nullptr;
   std::unordered_map<std::string, uint32_t> textureCoordinateParameters;
 
   bool onlyLand = true;

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "Cesium3DTilesSelection/Tileset.h"
 #include "Cesium3DTilesSelection/ViewState.h"
 #include "Cesium3DTilesSelection/ViewUpdateResult.h"
 #include "Cesium3DTilesetLoadFailureDetails.h"
@@ -689,9 +690,11 @@ public:
    */
   const glm::dmat4& GetCesiumTilesetToUnrealRelativeWorldTransform() const;
 
-  Cesium3DTilesSelection::Tileset* GetTileset() { return this->_pTileset; }
+  Cesium3DTilesSelection::Tileset* GetTileset() {
+    return this->_pTileset.Get();
+  }
   const Cesium3DTilesSelection::Tileset* GetTileset() const {
-    return this->_pTileset;
+    return this->_pTileset.Get();
   }
 
   // AActor overrides (some or most of them should be protected)
@@ -804,7 +807,7 @@ private:
 #endif
 
 private:
-  Cesium3DTilesSelection::Tileset* _pTileset;
+  TUniquePtr<Cesium3DTilesSelection::Tileset> _pTileset;
 
   // For debug output
   uint32_t _lastTilesRendered;


### PR DESCRIPTION
This prevents the leak where loaded result from worker thread is getting deleted in the main thread, but doesn't delete any sub resources. The bug can be reproduced by tuning the cache down to 0 and enabling ancestor and sibling preloading options. To make sure it's not the garbage collection being idle, you can use the command `gc.CollectGarbageEveryFrame 1`. You can see the memory increase after about 15 or 20 minutes of moving around. It happens more frequently with larger tileset.

To track the memory, you can run the sample with `-LLM` in the visual studio command line options. Then, in the editor, use command `stat LLM` in the console to see the memory