### PR TITLE
Delete emissive texture

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGltfPrimitiveComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfPrimitiveComponent.cpp
@@ -62,6 +62,7 @@ void destroyGltfParameterValues(
       assocation,
       index);
   destroyMaterialTexture(pMaterial, "normalTexture", assocation, index);
+  destroyMaterialTexture(pMaterial, "emissiveTexture", assocation, index);
   destroyMaterialTexture(pMaterial, "occlusionTexture", assocation, index);
 }
 


### PR DESCRIPTION
Some tilesets uses emissive texture for unlit, but we don't delete it properly