### PR TITLE
Add concierge config to check first time contributors.

### DIFF
--- a/.concierge/config.json
+++ b/.concierge/config.json
@@ -1,3 +1,4 @@
 {
+    "contributorsFromGitHub": "true",
     "maxDaysSinceUpdate": 30
 }

--- a/.concierge/templates/pullRequestOpened.hbs
+++ b/.concierge/templates/pullRequestOpened.hbs
@@ -1,4 +1,10 @@
+{{#if askAboutContributors}}
+Thank you so much for the pull request @{{ userName }}! I noticed this is your first pull request and I wanted to say welcome to the Cesium community!
+
+The [Pull Request Guidelines](https://github.com/CesiumGS/cesium/blob/main/CONTRIBUTING.md#pull-request-guidelines) is a handy reference for making sure your PR gets accepted quickly, so make sure to skim that.
+{{else}}
 Thanks for the pull request @{{ userName }}!
+{{/if}}
 
 {{#if claEnabled}}
 {{#if errorCla}}


### PR DESCRIPTION
Cesium Concierge now supports checking GitHub's contributor list for new and existing contributors. This PR adds this check and adds a welcome message for 1st time contributors.