### PR TITLE
Remove dependency on EditorScriptingUtilities plugin in the metadata-textures branch

### DIFF
--- a/CesiumForUnreal.uplugin
+++ b/CesiumForUnreal.uplugin
@@ -42,10 +42,6 @@
 		{
 			"Name": "Water",
 			"Enabled": true
-		},
-    {
-      "Name": "EditorScriptingUtilities",
-      "Enabled": true
-    }
+		}
 	]
 }

--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -184,7 +184,6 @@ public class CesiumRuntime : ModuleRules
                     "SlateCore",
                     "WorldBrowser",
                     "ContentBrowser",
-                    "EditorScriptingUtilities",
                     "MaterialEditor"
                 }
             );

--- a/Source/CesiumRuntime/Private/CesiumEncodedMetadataComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumEncodedMetadataComponent.cpp
@@ -390,10 +390,8 @@ static void RemapUserConnections(
     }
   }
 }
-#endif // WITH_EDITOR
 
 void UCesiumEncodedMetadataComponent::GenerateMaterial() {
-#if WITH_EDITOR
   ACesium3DTileset* pTileset = Cast<ACesium3DTileset>(this->GetOwner());
 
   if (!pTileset) {
@@ -882,5 +880,6 @@ void UCesiumEncodedMetadataComponent::GenerateMaterial() {
     AssetsToHighlight.Add(this->TargetMaterialLayer);
     pContentBrowserModule->Get().SyncBrowserToAssets(AssetsToHighlight);
   }
-#endif
 }
+
+#endif // WITH_EDITOR

--- a/Source/CesiumRuntime/Public/CesiumEncodedMetadataComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumEncodedMetadataComponent.h
@@ -241,7 +241,7 @@ public:
   UFUNCTION(CallInEditor, Category = "EncodeMetadata")
   void AutoFill();
 
-#if WITH_EDITORONLY_DATA
+#if WITH_EDITOR
   /**
    * @brief This button can be used to create a boiler-plate material layer that
    * exposes the requested metadata properties in the current description. The
@@ -251,7 +251,9 @@ public:
    */
   UFUNCTION(CallInEditor, Category = "EncodeMetadata")
   void GenerateMaterial();
+#endif
 
+#if WITH_EDITORONLY_DATA
   /**
    * @brief This is the target UMaterialFunctionMaterialLayer that the
    * boiler-plate material generation will use. When pressing

--- a/Source/CesiumRuntime/Public/CesiumEncodedMetadataComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumEncodedMetadataComponent.h
@@ -241,7 +241,7 @@ public:
   UFUNCTION(CallInEditor, Category = "EncodeMetadata")
   void AutoFill();
 
-#if WITH_EDITOR
+#if WITH_EDITORONLY_DATA
   /**
    * @brief This button can be used to create a boiler-plate material layer that
    * exposes the requested metadata properties in the current description. The

--- a/Source/CesiumRuntime/Public/CesiumExclusionZone.h
+++ b/Source/CesiumRuntime/Public/CesiumExclusionZone.h
@@ -6,16 +6,18 @@
 
 #include "CesiumExclusionZone.generated.h"
 
+struct UE_DEPRECATED(
+    4.26,
+    "Exclusion Zones have been deprecated. Please use Cartographic Polygon actor instead.")
+    FCesiumExclusionZone;
+
 /**
  * A region that should be excluded from a tileset.
  *
  * This is **experimental**, and may change in future releases.
  */
 USTRUCT()
-struct UE_DEPRECATED(
-    4.26,
-    "Exclusion Zones have been deprecated. Please use Cartographic Polygon actor instead.")
-    FCesiumExclusionZone {
+struct CESIUMRUNTIME_API FCesiumExclusionZone {
   GENERATED_BODY()
 
   /**

--- a/Source/CesiumRuntime/Public/CesiumMetadataFeatureTable.h
+++ b/Source/CesiumRuntime/Public/CesiumMetadataFeatureTable.h
@@ -16,16 +16,18 @@ struct Accessor;
 struct FeatureTable;
 } // namespace CesiumGltf
 
+struct UE_DEPRECATED(
+    4.26,
+    "FCesiumMetadataFeatureTable is deprecated, use FCesiumFeatureTable instead.")
+    FCesiumMetadataFeatureTable;
+
 /**
  * A Blueprint-accessible wrapper for a glTF feature table. A feature table is a
  * collection of properties for each feature ID in the mesh. It also knows how
  * to look up the feature ID associated with a given mesh vertex.
  */
 USTRUCT(BlueprintType)
-struct UE_DEPRECATED(
-    4.26,
-    "FCesiumMetadataFeatureTable is deprecated, use FCesiumFeatureTable instead.")
-    CESIUMRUNTIME_API FCesiumMetadataFeatureTable {
+struct CESIUMRUNTIME_API FCesiumMetadataFeatureTable {
   GENERATED_USTRUCT_BODY()
 
   using FeatureIDAccessorType = std::variant<


### PR DESCRIPTION
This is a PR into #698. The reason Travis CI fails in that branch is because our dodgy cut down distribution of Unreal Engine doesn't include a bunch of plugins, including EditorScriptingUtilities. But it's relatively easy to remove the dependency in this case, so that's what I've done.

I also removed the code that saves the generated material. I think it's fine to let the Editor consider it unsaved, and to let the user save in the normal way if they would like to do so. But maybe there's a more subtle reason it was necessary to save it explicitly? Everything seemed to work ok, but it's possible I missed something.
