### PR TITLE
Stop encoding metadata after deleting metadata component

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -803,6 +803,8 @@ void ACesium3DTileset::LoadTileset() {
     this->_encodedMetadataDescription = {
         pEncodedMetadataDescriptionComponent->FeatureTables,
         pEncodedMetadataDescriptionComponent->FeatureTextures};
+  } else {
+    this->_encodedMetadataDescription = {};
   }
 
   ACesiumCreditSystem* pCreditSystem = this->ResolveCreditSystem();


### PR DESCRIPTION
Fixes #836 