### PR TITLE
Fix incorrect computation of bounding boxes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug introduced in v1.13.0 that could lead to incorrect axis-aligned bounding boxes.
+
 ### v1.13.1 - 2022-05-05
 
 ##### Breaking Changes :mega:

--- a/Source/CesiumRuntime/Private/CesiumGltfPrimitiveComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfPrimitiveComponent.cpp
@@ -183,14 +183,10 @@ struct CalcBoundsOperation {
         glm::max(glm::length(halfAxes[0]), glm::length(halfAxes[1]));
     sphereRadius = glm::max(sphereRadius, glm::length(halfAxes[2]));
 
-    FVector xs(halfAxes[0].x, halfAxes[1].x, halfAxes[2].x);
-    FVector ys(halfAxes[0].y, halfAxes[1].y, halfAxes[2].y);
-    FVector zs(halfAxes[0].z, halfAxes[1].z, halfAxes[2].z);
-
     FBoxSphereBounds result;
     result.Origin = VecMath::createVector(center);
     result.SphereRadius = sphereRadius;
-    result.BoxExtent = FVector(xs.GetAbsMax(), ys.GetAbsMax(), zs.GetAbsMax());
+    result.BoxExtent = FVector(sphereRadius, sphereRadius, sphereRadius);
     return result;
   }
 
@@ -207,14 +203,17 @@ struct CalcBoundsOperation {
     double sphereRadius = glm::max(glm::length(corner1), glm::length(corner2));
     sphereRadius = glm::max(sphereRadius, glm::length(corner3));
 
-    FVector xs(halfAxes[0].x, halfAxes[1].x, halfAxes[2].x);
-    FVector ys(halfAxes[0].y, halfAxes[1].y, halfAxes[2].y);
-    FVector zs(halfAxes[0].z, halfAxes[1].z, halfAxes[2].z);
+    double maxX = glm::abs(halfAxes[0].x) + glm::abs(halfAxes[1].x) +
+                  glm::abs(halfAxes[2].x);
+    double maxY = glm::abs(halfAxes[0].y) + glm::abs(halfAxes[1].y) +
+                  glm::abs(halfAxes[2].y);
+    double maxZ = glm::abs(halfAxes[0].z) + glm::abs(halfAxes[1].z) +
+                  glm::abs(halfAxes[2].z);
 
     FBoxSphereBounds result;
     result.Origin = VecMath::createVector(center);
     result.SphereRadius = sphereRadius;
-    result.BoxExtent = FVector(xs.GetAbsMax(), ys.GetAbsMax(), zs.GetAbsMax());
+    result.BoxExtent = FVector(maxX, maxY, maxZ);
     return result;
   }
 


### PR DESCRIPTION
Fixes #839

I "improved" the bounding box computation in #823. It looked surprisingly right considering how actually wrong it was. 😆
Generally it worked ok near the georeference origin, but got very bad for tiles that are not well aligned to the Unreal axes.

I think it's correct now, but it would definitely be wise for someone to double-check my math when reviewing this!