### PR TITLE
Don't crash when destroying a material that isn't the right type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause a crash after applying a non-UMaterialInstanceDynamic material to a tileset.
+
 ### v1.13.1 - 2022-05-05
 
 ##### Breaking Changes :mega:

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -2114,7 +2114,7 @@ void forEachPrimitiveComponent(UCesiumGltfComponent* pGltf, Func&& f) {
 #if ENGINE_MAJOR_VERSION >= 5
       if (!IsValid(pMaterial)) {
 #else
-      if (pMaterial->IsPendingKillOrUnreachable()) {
+      if (!IsValid(pMaterial) || pMaterial->IsPendingKillOrUnreachable()) {
 #endif
         // Don't try to update the material while it's in the process of being
         // destroyed. This can lead to the render thread freaking out when


### PR DESCRIPTION
Fixes #717 

When you drag/drop a material on a tileset in the viewport, Unreal applies that material to all of the actor's static meshes. This is not very useful because Cesium for Unreal creates new static meshes all the time, and it won't use that new material when it does so. So basically the material change is just temporary.

However, if you then set the material property on the Tileset itself, our code will try to destroy the old Material. And it does so in such a way that if the old material that was applied to a static mesh isn't derived from `UMaterialInstanceDynamic` (as ours are), it will end up dereferencing a nullptr and crash.

So this PR simply guards against the crash. I looked briefly into what it would take to make dragging/dropping a material properly apply the material to the tileset, but it doesn't look to be straightforward. The editor behavior looks fairly hard-coded here.