### PR TITLE
Update developer setup instructions to look for INSTALL at the root.

### DIFF
--- a/Documentation/developer-setup-windows.md
+++ b/Documentation/developer-setup-windows.md
@@ -76,7 +76,7 @@ Basically just open the `C:\Dev\cesium-unreal-samples\Plugins\cesium-unreal\exte
 - Press "Configure" (and confirm the creation of the directory and the default generator for the project)
 - Press "Generate"
 
-This will generate the project file called `cesium-unreal-extern.sln` in the directory `C:\Dev\cesium-unreal-samples\Plugins\cesium-unreal\extern\build`. You can open this solution file in the Visual Studio IDE and compile as normal. To install cesium-native to the project - which is required for use with Cesium for Unreal - open the `CMakePredefinedTargets` folder in the Solution Explorer, right-click on `INSTALL`, and choose Build. Use the Solution Configuration dropdown to change between the Debug and Release configurations.
+This will generate the project file called `cesium-unreal-extern.sln` in the directory `C:\Dev\cesium-unreal-samples\Plugins\cesium-unreal\extern\build`. You can open this solution file in the Visual Studio IDE and compile as normal. To install cesium-native to the project - which is required for use with Cesium for Unreal - right-click on `INSTALL` in Solution Explorer, and choose Build. `INSTALL` may be found inside a folder called `CMakePredefinedTargets`. Use the Solution Configuration dropdown to change between the Debug and Release configurations.
 
 
 ## CMake command-line
@@ -92,7 +92,7 @@ To use Visual Studio 2017 instead, open "x64 Native Tools Command Prompt for VS 
 
       cmake -B build -S . -G "Visual Studio 15 2017 Win64"
 
-With either compiler, the commands above will generate the project file called `cesium-unreal-extern.sln` in the directory `C:\Dev\cesium-unreal-samples\Plugins\cesium-unreal\extern\build`. You can open this solution file in the Visual Studio IDE and compile as normal. To install cesium-native to the project - which is required for use with Cesium for Unreal - open the `CMakePredefinedTargets` folder in the Solution Explorer, right-click on `INSTALL`, and choose Build. Use the Solution Configuration dropdown to change between the Debug and Release configurations.
+With either compiler, the commands above will generate the project file called `cesium-unreal-extern.sln` in the directory `C:\Dev\cesium-unreal-samples\Plugins\cesium-unreal\extern\build`. You can open this solution file in the Visual Studio IDE and compile as normal. To install cesium-native to the project - which is required for use with Cesium for Unreal - right-click on `INSTALL` in Solution Explorer, and choose Build. `INSTALL` may be found inside a folder called `CMakePredefinedTargets`. Use the Solution Configuration dropdown to change between the Debug and Release configurations.
 
 You can also build the Release version entirely from the command-line:
 


### PR DESCRIPTION
As reported on the community forum:
https://community.cesium.com/t/development-setup/16792

Our setup instructions say to look in the Visual Studio Solution Explorer for a folder called `CMakePredefinedTargets`. But that doesn't seem to exist anymore, probably as a result of a newer version of either Visual Studio 2019 or CMake. Instead, the INSTALL target is just sitting at the top level. So I updated the instructions accordingly.