### PR TITLE
Add macOS / UE5 build to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,8 +117,8 @@ jobs:
           fetch-depth: 0 # so that `git describe` works.
       - name: Set environment variables
         run: |
-          export $CESIUM_UNREAL_VERSION=$(git describe)
-          export $BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-500-macos-${CESIUM_UNREAL_VERSION}"
+          export CESIUM_UNREAL_VERSION=$(git describe)
+          export BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-500-macos-${CESIUM_UNREAL_VERSION}"
           # Make these available to subsequent steps
           echo "CESIUM_UNREAL_VERSION=${CESIUM_UNREAL_VERSION}" >> $GITHUB_ENV
           echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=${BUILD_CESIUM_UNREAL_PACKAGE_NAME}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           mkdir -p extern/build
           cd extern/build
-          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
           cmake --build . -j14 --target install
           cd ../..
           rm -rf extern

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
           mkdir -p extern/build
           cd extern/build
           cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
-          cmake --build . -j14 --target install
+          cmake --build . -j4 --target install
           cd ../..
           rm -rf extern
       - name: Build plugin
@@ -158,7 +158,7 @@ jobs:
       - name: Download macOS build
         uses: actions/download-artifact@v3
         with:
-          name: CesiumForUnreal-500-macOS-${{ env.CESIUM_UNREAL_VERSION}}.zip
+          name: CesiumForUnreal-500-macos-${{ env.CESIUM_UNREAL_VERSION}}.zip
           path: combine
       - name: Download Android build
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,9 +98,51 @@ jobs:
         with:
           name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}.zip
           path: packages
+  MacOS:
+    runs-on: macos-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: us-east-1
+    steps:
+      - name: Get Unreal Engine
+        run: |
+          aws s3 cp s3://cesium-unreal-engine/5.0.1/macOS/UE501.zip .
+          unzip -q UE501.zip -d $HOME
+          rm UE501.zip
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0 # so that `git describe` works.
+      - name: Set environment variables
+        run: |
+          export $CESIUM_UNREAL_VERSION=$(git describe)
+          export $BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-500-macos-${CESIUM_UNREAL_VERSION}"
+          # Make these available to subsequent steps
+          echo "CESIUM_UNREAL_VERSION=${CESIUM_UNREAL_VERSION}" >> $GITHUB_ENV
+          echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=${BUILD_CESIUM_UNREAL_PACKAGE_NAME}" >> $GITHUB_ENV
+      - name: Build cesium-native
+        run: |
+          mkdir -p extern/build
+          cd extern/build
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake --build . -j14 --target install
+          cd ../..
+          rm -rf extern
+      - name: Build plugin
+        run: |
+          export UNREAL_ENGINE_DIR=$HOME/UE_5.0
+          cd $UNREAL_ENGINE_DIR/Engine/Build/BatchFiles
+          ./RunUAT.sh BuildPlugin -Plugin="$GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Mac
+      - name: Publish plugin package artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}.zip
+          path: packages
   Combine:
     runs-on: ubuntu-latest
-    needs: [Windows, Android, Linux]
+    needs: [Windows, Android, Linux, MacOS]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -113,6 +155,11 @@ jobs:
           # Make these available to subsequent steps
           echo "CESIUM_UNREAL_VERSION=$CESIUM_UNREAL_VERSION" >> $GITHUB_ENV
           echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=$BUILD_CESIUM_UNREAL_PACKAGE_NAME" >> $GITHUB_ENV
+      - name: Download macOS build
+        uses: actions/download-artifact@v3
+        with:
+          name: CesiumForUnreal-500-macOS-${{ env.CESIUM_UNREAL_VERSION}}.zip
+          path: combine
       - name: Download Android build
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
The standard `macos-latest` runner had enough disk space to make this work. 😅 