### PR TITLE
Use proper labels for self-hosted runners.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Cesium for Unreal
 on: [push]
 jobs:
   Windows:
-    runs-on: self-hosted
+    runs-on: ["self-hosted","windows","x64","unreal"]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
           name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}.zip
           path: packages
   Android:
-    runs-on: self-hosted
+    runs-on: ["self-hosted","windows","x64","unreal"]
     steps:
       - name: Install additional dependencies
         run: |
@@ -63,7 +63,7 @@ jobs:
           name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}.zip
           path: packages
   Linux:
-    runs-on: self-hosted
+    runs-on: ["self-hosted","windows","x64","unreal"]
     steps:
       - name: Install additional dependencies
         run: |


### PR DESCRIPTION
I've enabled the [runner_enable_workflow_job_labels_check](https://github.com/philips-labs/terraform-aws-github-runner#input_runner_enable_workflow_job_labels_check) option in our self-hosted Actions runner config so that it won't spin up new EC2 instances for builds that don't need the self-hosted runner (i.e. macOS, iOS, Combine). But with that option enabled, the set of labels has to match exactly. So this PR adds the necessary labels.