### PR TITLE
Add option to invert CesiumPolygonRasterOverlays

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Change Log
 
+### v1.14.0 - ????
+
+##### Breading Changes :mega:
+
+- Renamed `ExcludeTilesInside` to `ExcludeSelectedTiles` on the `CesiumPolygonRasterOverlay`. A core redirect was added to remap the property value in existing projects.
+
+##### Additions :tada:
+
+- Added the `InvertSelection` option on `CesiumPolygonRasterOverlay` to rasterize outside the selection instead of inside. When used in conjunction with the `ExcludeSelectedTiles` option, tiles completely outside the polygon selection will be culled, instead of the tiles inside.
+
 ### v1.13.2 - 2022-05-13
 
 ##### Fixes :wrench:

--- a/Config/Engine.ini
+++ b/Config/Engine.ini
@@ -28,3 +28,5 @@
 +PropertyRedirects=(OldName="CesiumSunSky.EnableMobileRendering",NewName="UseMobileRendering")
 
 +FunctionRedirects=(OldName="CesiumSunSky.AdjustAtmosphereRadius",NewName="UpdateAtmosphereRadius")
+
++PropertyRedirects=(OldName="CesiumPolygonRasterOverlay.ExcludeTilesInside",NewName="ExcludeSelectedTiles")

--- a/Source/CesiumRuntime/Private/CesiumPolygonRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPolygonRasterOverlay.cpp
@@ -33,6 +33,7 @@ UCesiumPolygonRasterOverlay::CreateOverlay(
   return std::make_unique<Cesium3DTilesSelection::RasterizedPolygonsOverlay>(
       TCHAR_TO_UTF8(*this->MaterialLayerKey),
       polygons,
+      this->InvertSelection,
       CesiumGeospatial::Ellipsoid::WGS84,
       CesiumGeospatial::GeographicProjection(),
       options);
@@ -43,7 +44,7 @@ void UCesiumPolygonRasterOverlay::OnAdd(
     RasterOverlay* pOverlay) {
   // If this overlay is used for culling, add it as an excluder too for
   // efficiency.
-  if (pTileset && this->ExcludeTilesInside) {
+  if (pTileset && this->ExcludeSelectedTiles) {
     RasterizedPolygonsOverlay* pPolygons =
         static_cast<RasterizedPolygonsOverlay*>(pOverlay);
     assert(this->_pExcluder == nullptr);

--- a/Source/CesiumRuntime/Public/CesiumPolygonRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumPolygonRasterOverlay.h
@@ -32,10 +32,10 @@ public:
   TArray<ACesiumCartographicPolygon*> Polygons;
 
   /**
-   * Whether to invert the selection specified by the polygons. 
-   * 
+   * Whether to invert the selection specified by the polygons.
+   *
    * If this is true, only the areas outside of all the polygons will be
-   * rasterized. 
+   * rasterized.
    */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
   bool InvertSelection = false;
@@ -46,10 +46,10 @@ public:
    * enabled when this overlay will be used for clipping. But when this overlay
    * is used for other effects, this option should be disabled to avoid missing
    * tiles.
-   * 
-   * Note that if InvertSelection is true, this will cull tiles that are 
+   *
+   * Note that if InvertSelection is true, this will cull tiles that are
    * outside of all the polygons. If it is false, this will cull tiles that are
-   * completely inside at least one polygon. 
+   * completely inside at least one polygon.
    */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
   bool ExcludeSelectedTiles = true;

--- a/Source/CesiumRuntime/Public/CesiumPolygonRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumPolygonRasterOverlay.h
@@ -32,14 +32,27 @@ public:
   TArray<ACesiumCartographicPolygon*> Polygons;
 
   /**
-   * Whether tiles that fall entirely inside this overlay's polygons should be
+   * Whether to invert the selection specified by the polygons. 
+   * 
+   * If this is true, only the areas outside of all the polygons will be
+   * rasterized. 
+   */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
+  bool InvertSelection = false;
+
+  /**
+   * Whether tiles that fall entirely within the rasterized selection should be
    * excluded from loading and rendering. For better performance, this should be
    * enabled when this overlay will be used for clipping. But when this overlay
    * is used for other effects, this option should be disabled to avoid missing
    * tiles.
+   * 
+   * Note that if InvertSelection is true, this will cull tiles that are 
+   * outside of all the polygons. If it is false, this will cull tiles that are
+   * completely inside at least one polygon. 
    */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
-  bool ExcludeTilesInside = true;
+  bool ExcludeSelectedTiles = true;
 
 protected:
   virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay> CreateOverlay(


### PR DESCRIPTION
Exposes the new option to invert polygon selections added in Cesium Native here, merge it first: https://github.com/CesiumGS/cesium-native/pull/504

##### A city block cutout from Melbourne, using the new feature.
![invert-selection](https://user-images.githubusercontent.com/6706316/169837617-0730d8a8-2614-4d9d-80fa-e5836fbd5de1.JPG)


##### The wire-frame view shows that tiles entirely outside of the polygon selection are culled.
![invert-selection2](https://user-images.githubusercontent.com/6706316/169837677-a0932245-8f27-4c8b-991c-fcccc58581f3.JPG)

