### PR TITLE
Sublevel property cleanup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### v1.???
+
+##### Fixes :wrench:
+- Swapped latitude and longitude parameters on georeferenced sublevels to match with the main georeference.
+- Adjusted the presentation of sublevels in the Cesium Georeference details panel.
+
 ### v1.14.0 - 2022-06-01
 
 ##### Breaking Changes :mega:

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -61,7 +61,7 @@ public:
    */
   UPROPERTY(
       EditAnywhere,
-      Category = "CesiumSublevels",
+      Category = "Cesium|Cesium Sublevels",
       meta = (EditCondition = "KeepWorldOriginNearCamera"))
   bool OriginRebaseInsideSublevels = true;
 
@@ -69,7 +69,7 @@ public:
    * Whether to visualize the level loading radii in the editor. Helpful for
    * initially positioning the level and choosing a load radius.
    */
-  UPROPERTY(EditAnywhere, Category = "CesiumSublevels")
+  UPROPERTY(EditAnywhere, Category = "Cesium|Cesium Sublevels")
   bool ShowLoadRadii = true;
 
   /*
@@ -85,7 +85,7 @@ public:
    * @returns true if a new sub-level is active, or false if the Index was
    * outside the valid range and so no sub-level is active.
    */
-  UFUNCTION(BlueprintCallable, Category = "CesiumSublevels")
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Cesium Sublevels")
   bool SwitchToLevel(int32 Index);
 
   /*
@@ -100,8 +100,8 @@ public:
    */
   UPROPERTY(
       EditAnywhere,
-      Category = "CesiumSublevels",
-      Meta = (TitleProperty = "LevelName"))
+      Category = "Cesium|Cesium Sublevels",
+      Meta = (TitleProperty = "LevelName", DisplayName = "Georeferenced Sublevels"))
   TArray<FCesiumSubLevel> CesiumSubLevels;
 
   /**

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -101,7 +101,9 @@ public:
   UPROPERTY(
       EditAnywhere,
       Category = "Cesium|Cesium Sublevels",
-      Meta = (TitleProperty = "LevelName", DisplayName = "Georeferenced Sublevels"))
+      Meta =
+          (TitleProperty = "LevelName",
+           DisplayName = "Georeferenced Sublevels"))
   TArray<FCesiumSubLevel> CesiumSubLevels;
 
   /**

--- a/Source/CesiumRuntime/Public/CesiumSubLevel.h
+++ b/Source/CesiumRuntime/Public/CesiumSubLevel.h
@@ -39,16 +39,6 @@ struct FCesiumSubLevel {
   bool Enabled = true;
 
   /**
-   * The WGS84 longitude in degrees of where this level should sit on the
-   * globe, in the range [-180, 180]
-   */
-  UPROPERTY(
-      EditAnywhere,
-      Category = "Cesium",
-      meta = (ClampMin = -180.0, ClampMax = 180.0, EditCondition = "Enabled"))
-  double LevelLongitude = 0.0;
-
-  /**
    * The WGS84 latitude in degrees of where this level should sit on the globe,
    * in the range [-90, 90]
    */
@@ -57,6 +47,16 @@ struct FCesiumSubLevel {
       Category = "Cesium",
       meta = (ClampMin = -90.0, ClampMax = 90.0, EditCondition = "Enabled"))
   double LevelLatitude = 0.0;
+
+    /**
+   * The WGS84 longitude in degrees of where this level should sit on the
+   * globe, in the range [-180, 180]
+   */
+  UPROPERTY(
+      EditAnywhere,
+      Category = "Cesium",
+      meta = (ClampMin = -180.0, ClampMax = 180.0, EditCondition = "Enabled"))
+  double LevelLongitude = 0.0;
 
   /**
    * The height in meters above the WGS84 globe this level should sit.

--- a/Source/CesiumRuntime/Public/CesiumSubLevel.h
+++ b/Source/CesiumRuntime/Public/CesiumSubLevel.h
@@ -48,7 +48,7 @@ struct FCesiumSubLevel {
       meta = (ClampMin = -90.0, ClampMax = 90.0, EditCondition = "Enabled"))
   double LevelLatitude = 0.0;
 
-    /**
+  /**
    * The WGS84 longitude in degrees of where this level should sit on the
    * globe, in the range [-180, 180]
    */


### PR DESCRIPTION
Contains a few small fixes to the editor UI for georeferenced sublevels.

- Swapped the latitude and longitude parameter of sublevels in the array so that they match the latitude/longitude standard. (Tested this in editor and the change did not seem to introduce any issues.)
- Recategorized the sublevel-related parameters on the CesiumGeoreference so that the sublevels category is nested under the "Cesium" category and not as a separate category
- Changed the display name of the `CesiumSubLevels` array to read "Georeferenced Sublevels". This is for clarity and consistency of documentation. Since the property name itself is unchanged, this should not be a breaking change.

Old on left, new on right.
<p>
<img src="https://user-images.githubusercontent.com/39537389/172216137-6aa857c4-448f-4f2f-b0fa-ce67e305a5df.png" width="48%" /></a>&nbsp;
<img src="https://user-images.githubusercontent.com/39537389/172215129-0f7b869a-4706-4435-8a00-0a4ffbb1fcb6.png" width="48%" /></a>&nbsp;
<br/>

I wasn't sure if the sublevel parameters had been in their own category for a particular reason. If they were, just let me know and I'll discard those changes.
