### PR TITLE
Explicitly free UBodySetup UVInfo and FaceMap data in CesiumLifetime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- We now explicitly free physics mesh UVs and face remap data, reducing memory usage in the Editor and reducing pressure on the garbage collector in-game.
+
 ### v1.14.0 - 2022-06-01
 
 ##### Breaking Changes :mega:

--- a/Source/CesiumRuntime/Private/CesiumLifetime.cpp
+++ b/Source/CesiumRuntime/Private/CesiumLifetime.cpp
@@ -105,6 +105,10 @@
 
   UBodySetup* pBodySetup = Cast<UBodySetup>(pObject);
   if (pBodySetup) {
+    pBodySetup->UVInfo.IndexBuffer.Empty();
+    pBodySetup->UVInfo.VertPositions.Empty();
+    pBodySetup->UVInfo.VertUVs.Empty();
+    pBodySetup->FaceRemap.Empty();
     pBodySetup->ClearPhysicsMeshes();
   }
 }


### PR DESCRIPTION
Starting in v1.13.0, panning around the Melbourne example level in the Editor causes memory usage to grow without bound. I eventually tracked it down the cause: starting in v1.13.0, we're asking PhysX to `bSupportUVFromHitResults` and `bSupportFaceRemap`. This causes it to produce a bunch of extra data that we put into a `UBodySetup`. But when we free the `UBodySetup` in `CesiumLifetime`, we were failing to free this extra data. One might expect a method called `ClearPhysicsMeshes` (which we were already calling) to free this data, too, but alas, it does not.

Without the explicit free:
1) Memory usage grows without bound in the Editor, because the Editor doesn't run the UE garbage collector.
2) In-game, the garbage collector will free this memory eventually, but probably not as soon as we'd like. It also makes the GC work harder than if we just freed it ourselves manually.

Thanks to @baothientran for noticing this!
