### PR TITLE
Don't crash if a tileset/overlay is destroyed while reporting error.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Swapped latitude and longitude parameters on georeferenced sublevels to match with the main georeference.
 - Adjusted the presentation of sublevels in the Cesium Georeference details panel.
 - We now explicitly free physics mesh UVs and face remap data, reducing memory usage in the Editor and reducing pressure on the garbage collector in-game.
+- Fixed a bug that could cause a crash when reporting tileset or raster overlay load errors, particularly while switching levels.
 
 ### v1.14.0 - 2022-06-01
 

--- a/Source/CesiumEditor/Private/CesiumEditor.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditor.cpp
@@ -365,9 +365,13 @@ TSharedRef<SDockTab> FCesiumEditorModule::SpawnCesiumIonAssetBrowserTab(
 
 void FCesiumEditorModule::OnTilesetLoadFailure(
     const FCesium3DTilesetLoadFailureDetails& details) {
+  if (!details.Tileset.IsValid()) {
+    return;
+  }
+
   // Don't pop a troubleshooting panel over a game world (including
   // Play-In-Editor).
-  if (details.Tileset && details.Tileset->GetWorld()->IsGameWorld()) {
+  if (details.Tileset->GetWorld()->IsGameWorld()) {
     return;
   }
 
@@ -382,17 +386,21 @@ void FCesiumEditorModule::OnTilesetLoadFailure(
   // Check for a 401 connecting to Cesium ion, which means the token is invalid
   // (or perhaps the asset ID is). Also check for a 404, because ion returns 404
   // when the token is valid but not authorized for the asset.
-  if (details.Tileset && details.Type == ECesium3DTilesetLoadType::CesiumIon &&
+  if (details.Type == ECesium3DTilesetLoadType::CesiumIon &&
       (details.HttpStatusCode == 401 || details.HttpStatusCode == 404)) {
-    CesiumIonTokenTroubleshooting::Open(details.Tileset, true);
+    CesiumIonTokenTroubleshooting::Open(details.Tileset.Get(), true);
   }
 }
 
 void FCesiumEditorModule::OnRasterOverlayLoadFailure(
     const FCesiumRasterOverlayLoadFailureDetails& details) {
+  if (!details.Overlay.IsValid()) {
+    return;
+  }
+
   // Don't pop a troubleshooting panel over a game world (including
   // Play-In-Editor).
-  if (details.Overlay && details.Overlay->GetWorld()->IsGameWorld()) {
+  if (details.Overlay->GetWorld()->IsGameWorld()) {
     return;
   }
 
@@ -407,10 +415,9 @@ void FCesiumEditorModule::OnRasterOverlayLoadFailure(
   // Check for a 401 connecting to Cesium ion, which means the token is invalid
   // (or perhaps the asset ID is). Also check for a 404, because ion returns 404
   // when the token is valid but not authorized for the asset.
-  if (details.Overlay &&
-      details.Type == ECesiumRasterOverlayLoadType::CesiumIon &&
+  if (details.Type == ECesiumRasterOverlayLoadType::CesiumIon &&
       (details.HttpStatusCode == 401 || details.HttpStatusCode == 404)) {
-    CesiumIonTokenTroubleshooting::Open(details.Overlay, true);
+    CesiumIonTokenTroubleshooting::Open(details.Overlay.Get(), true);
   }
 }
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -840,7 +840,7 @@ void ACesium3DTileset::LoadTileset() {
             uint8_t(Cesium3DTilesSelection::TilesetLoadType::TilesetJson));
         assert(this->_pTileset == details.pTileset);
 
-        FCesium3DTilesetLoadFailureDetails ueDetails;
+        FCesium3DTilesetLoadFailureDetails ueDetails{};
         ueDetails.Tileset = this;
         ueDetails.Type = ECesium3DTilesetLoadType(typeValue);
         ueDetails.HttpStatusCode =

--- a/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
@@ -69,7 +69,7 @@ void UCesiumRasterOverlay::AddToTileset() {
                 Cesium3DTilesSelection::RasterOverlayLoadType::TilesetJson));
         assert(this->_pTileset == details.pTileset);
 
-        FCesiumRasterOverlayLoadFailureDetails ueDetails;
+        FCesiumRasterOverlayLoadFailureDetails ueDetails{};
         ueDetails.Overlay = this;
         ueDetails.Type = ECesiumRasterOverlayLoadType(typeValue);
         ueDetails.HttpStatusCode =

--- a/Source/CesiumRuntime/Public/Cesium3DTilesetLoadFailureDetails.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTilesetLoadFailureDetails.h
@@ -33,7 +33,7 @@ struct CESIUMRUNTIME_API FCesium3DTilesetLoadFailureDetails {
    * The tileset that encountered the load failure.
    */
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Cesium")
-  ACesium3DTileset* Tileset = nullptr;
+  TWeakObjectPtr<ACesium3DTileset> Tileset = nullptr;
 
   /**
    * The type of request that failed to load.

--- a/Source/CesiumRuntime/Public/CesiumRasterOverlayLoadFailureDetails.h
+++ b/Source/CesiumRuntime/Public/CesiumRasterOverlayLoadFailureDetails.h
@@ -33,7 +33,7 @@ struct CESIUMRUNTIME_API FCesiumRasterOverlayLoadFailureDetails {
    * The overlay that encountered the load failure.
    */
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Cesium")
-  UCesiumRasterOverlay* Overlay = nullptr;
+  TWeakObjectPtr<UCesiumRasterOverlay> Overlay = nullptr;
 
   /**
    * The type of request that failed to load.


### PR DESCRIPTION
Fixes #879 

Like Bao said in that issue, I don't completely understand why UE5 (only) is unloading the _new_ level and destroying its tilesets when switching levels. But whatever the reason (or even if it's a bug), the fact remains that it's _possible_ for a Tileset or RasterOverlay to be destroyed between the time we schedule a main thread task to handle a load error and the time that main thread task is actually run. And it's not ok to crash when that happens. So now the load error structs use `TWeakObjectPtr` to guarantee we don't dereference a stale pointer while handling load errors.