### PR TITLE
Update tile url source logs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Swapped latitude and longitude parameters on georeferenced sublevels to match with the main georeference.
 - Adjusted the presentation of sublevels in the Cesium Georeference details panel.
 - We now explicitly free physics mesh UVs and face remap data, reducing memory usage in the Editor and reducing pressure on the garbage collector in-game.
+- We now Log the correct asset source when loading a new tileset from either URL or Ion. 
 
 ### v1.14.0 - 2022-06-01
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -214,26 +214,34 @@ void ACesium3DTileset::PostInitProperties() {
 
 void ACesium3DTileset::SetTilesetSource(ETilesetSource InSource) {
   if (InSource != this->TilesetSource) {
-    this->TilesetSource = InSource;
     this->DestroyTileset();
+    this->TilesetSource = InSource;
   }
 }
 
 void ACesium3DTileset::SetUrl(const FString& InUrl) {
+  UE_LOG(
+    LogCesium,
+    Log,
+    TEXT("In set URL"));
   if (InUrl != this->Url) {
-    this->Url = InUrl;
     if (this->TilesetSource == ETilesetSource::FromUrl) {
       this->DestroyTileset();
     }
+    UE_LOG(
+      LogCesium,
+      Log,
+      TEXT("After destroy tile"));
+    this->Url = InUrl;
   }
 }
 
 void ACesium3DTileset::SetIonAssetID(int64 InAssetID) {
   if (InAssetID >= 0 && InAssetID != this->IonAssetID) {
-    this->IonAssetID = InAssetID;
     if (this->TilesetSource == ETilesetSource::FromCesiumIon) {
       this->DestroyTileset();
     }
+    this->IonAssetID = InAssetID;
   }
 }
 
@@ -930,35 +938,41 @@ void ACesium3DTileset::LoadTileset() {
     }
   }
 
-  if (this->Url.Len() > 0) {
+  switch (this->TilesetSource) {
+  case ETilesetSource::FromUrl:
     UE_LOG(
-        LogCesium,
-        Log,
-        TEXT("Loading tileset from URL %s done"),
-        *this->Url);
-  } else {
+      LogCesium,
+      Log,
+      TEXT("Loading tileset from URL %s done"),
+      *this->Url);
+    break;
+  case ETilesetSource::FromCesiumIon:
     UE_LOG(
-        LogCesium,
-        Log,
-        TEXT("Loading tileset for asset ID %d done"),
-        this->IonAssetID);
+      LogCesium,
+      Log,
+      TEXT("Loading tileset for asset ID %d done"),
+      this->IonAssetID);
+    break;
   }
 }
 
 void ACesium3DTileset::DestroyTileset() {
 
-  if (this->Url.Len() > 0) {
+  switch (this->TilesetSource) {
+  case ETilesetSource::FromUrl:
     UE_LOG(
-        LogCesium,
-        Verbose,
-        TEXT("Destroying tileset from URL %s"),
-        *this->Url);
-  } else {
+      LogCesium,
+      Log, //Verbose,
+      TEXT("Destroying tileset from URL %s"),
+      *this->Url);
+    break;
+  case ETilesetSource::FromCesiumIon:
     UE_LOG(
-        LogCesium,
-        Verbose,
-        TEXT("Destroying tileset for asset ID %d"),
-        this->IonAssetID);
+      LogCesium,
+      Log, //Verbose,
+      TEXT("Destroying tileset for asset ID %d"),
+      this->IonAssetID);
+    break;
   }
 
   // The way CesiumRasterOverlay::add is currently implemented, destroying the
@@ -979,18 +993,21 @@ void ACesium3DTileset::DestroyTileset() {
 
   this->_pTileset.Reset();
 
-  if (this->Url.Len() > 0) {
+  switch (this->TilesetSource) {
+  case ETilesetSource::FromUrl:
     UE_LOG(
-        LogCesium,
-        Verbose,
-        TEXT("Destroying tileset from URL %s done"),
-        *this->Url);
-  } else {
+      LogCesium,
+      Log,// Verbose,
+      TEXT("Destroying tileset from URL %s done"),
+      *this->Url);
+    break;
+  case ETilesetSource::FromCesiumIon:
     UE_LOG(
-        LogCesium,
-        Verbose,
-        TEXT("Destroying tileset for asset ID %d done"),
-        this->IonAssetID);
+      LogCesium,
+      Log, //Verbose,
+      TEXT("Destroying tileset for asset ID %d done"),
+      this->IonAssetID);
+    break;
   }
 }
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -220,18 +220,10 @@ void ACesium3DTileset::SetTilesetSource(ETilesetSource InSource) {
 }
 
 void ACesium3DTileset::SetUrl(const FString& InUrl) {
-  UE_LOG(
-    LogCesium,
-    Log,
-    TEXT("In set URL"));
   if (InUrl != this->Url) {
     if (this->TilesetSource == ETilesetSource::FromUrl) {
       this->DestroyTileset();
     }
-    UE_LOG(
-      LogCesium,
-      Log,
-      TEXT("After destroy tile"));
     this->Url = InUrl;
   }
 }
@@ -247,20 +239,20 @@ void ACesium3DTileset::SetIonAssetID(int64 InAssetID) {
 
 void ACesium3DTileset::SetIonAccessToken(const FString& InAccessToken) {
   if (this->IonAccessToken != InAccessToken) {
-    this->IonAccessToken = InAccessToken;
     if (this->TilesetSource == ETilesetSource::FromCesiumIon) {
       this->DestroyTileset();
     }
+    this->IonAccessToken = InAccessToken;
   }
 }
 
 void ACesium3DTileset::SetIonAssetEndpointUrl(
     const FString& InIonAssetEndpointUrl) {
   if (this->IonAssetEndpointUrl != InIonAssetEndpointUrl) {
-    this->IonAssetEndpointUrl = InIonAssetEndpointUrl;
     if (this->TilesetSource == ETilesetSource::FromCesiumIon) {
       this->DestroyTileset();
     }
+    this->IonAssetEndpointUrl = InIonAssetEndpointUrl;
   }
 }
 
@@ -962,14 +954,14 @@ void ACesium3DTileset::DestroyTileset() {
   case ETilesetSource::FromUrl:
     UE_LOG(
       LogCesium,
-      Log, //Verbose,
+      Verbose,
       TEXT("Destroying tileset from URL %s"),
       *this->Url);
     break;
   case ETilesetSource::FromCesiumIon:
     UE_LOG(
       LogCesium,
-      Log, //Verbose,
+      Verbose,
       TEXT("Destroying tileset for asset ID %d"),
       this->IonAssetID);
     break;
@@ -997,14 +989,14 @@ void ACesium3DTileset::DestroyTileset() {
   case ETilesetSource::FromUrl:
     UE_LOG(
       LogCesium,
-      Log,// Verbose,
+      Verbose,
       TEXT("Destroying tileset from URL %s done"),
       *this->Url);
     break;
   case ETilesetSource::FromCesiumIon:
     UE_LOG(
       LogCesium,
-      Log, //Verbose,
+      Verbose,
       TEXT("Destroying tileset for asset ID %d done"),
       this->IonAssetID);
     break;

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -933,17 +933,17 @@ void ACesium3DTileset::LoadTileset() {
   switch (this->TilesetSource) {
   case ETilesetSource::FromUrl:
     UE_LOG(
-      LogCesium,
-      Log,
-      TEXT("Loading tileset from URL %s done"),
-      *this->Url);
+        LogCesium,
+        Log,
+        TEXT("Loading tileset from URL %s done"),
+        *this->Url);
     break;
   case ETilesetSource::FromCesiumIon:
     UE_LOG(
-      LogCesium,
-      Log,
-      TEXT("Loading tileset for asset ID %d done"),
-      this->IonAssetID);
+        LogCesium,
+        Log,
+        TEXT("Loading tileset for asset ID %d done"),
+        this->IonAssetID);
     break;
   }
 }
@@ -953,17 +953,17 @@ void ACesium3DTileset::DestroyTileset() {
   switch (this->TilesetSource) {
   case ETilesetSource::FromUrl:
     UE_LOG(
-      LogCesium,
-      Verbose,
-      TEXT("Destroying tileset from URL %s"),
-      *this->Url);
+        LogCesium,
+        Verbose,
+        TEXT("Destroying tileset from URL %s"),
+        *this->Url);
     break;
   case ETilesetSource::FromCesiumIon:
     UE_LOG(
-      LogCesium,
-      Verbose,
-      TEXT("Destroying tileset for asset ID %d"),
-      this->IonAssetID);
+        LogCesium,
+        Verbose,
+        TEXT("Destroying tileset for asset ID %d"),
+        this->IonAssetID);
     break;
   }
 
@@ -988,17 +988,17 @@ void ACesium3DTileset::DestroyTileset() {
   switch (this->TilesetSource) {
   case ETilesetSource::FromUrl:
     UE_LOG(
-      LogCesium,
-      Verbose,
-      TEXT("Destroying tileset from URL %s done"),
-      *this->Url);
+        LogCesium,
+        Verbose,
+        TEXT("Destroying tileset from URL %s done"),
+        *this->Url);
     break;
   case ETilesetSource::FromCesiumIon:
     UE_LOG(
-      LogCesium,
-      Verbose,
-      TEXT("Destroying tileset for asset ID %d done"),
-      this->IonAssetID);
+        LogCesium,
+        Verbose,
+        TEXT("Destroying tileset for asset ID %d done"),
+        this->IonAssetID);
     break;
   }
 }


### PR DESCRIPTION
- The original github issue #830 was a red herring, the problem wasn't that the wrong tileset was loaded, but it was a mistake on the log that printed out the wrong information about the source and tilset input url or ID. 