### PR TITLE
Disable physics mesh option in ue5 with Chaos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Swapped latitude and longitude parameters on georeferenced sublevels to match with the main georeference.
 - Adjusted the presentation of sublevels in the Cesium Georeference details panel.
 - We now explicitly free physics mesh UVs and face remap data, reducing memory usage in the Editor and reducing pressure on the garbage collector in-game.
+- Disabling physics meshes of a tileset now works in Unreal Engine 5. 
 
 ### v1.14.0 - 2022-06-01
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -550,6 +550,7 @@ public:
     CreateGltfOptions::CreateModelOptions options;
     options.pModel = &model;
     options.alwaysIncludeTangents = this->_pActor->GetAlwaysIncludeTangents();
+    options.createPhysicsMeshes = this->_pActor->GetCreatePhysicsMeshes();
 
 #if PHYSICS_INTERFACE_PHYSX
     options.pPhysXCookingModule = this->_pPhysXCookingModule;

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1166,21 +1166,25 @@ static void loadPrimitive(
   primitiveResult.pCollisionMesh = nullptr;
 
   if (StaticMeshBuildVertices.Num() != 0 && indices.Num() != 0) {
+    if (options.pMeshOptions->pNodeOptions->pModelOptions
+            ->createPhysicsMeshes) {
 #if PHYSICS_INTERFACE_PHYSX
-    CESIUM_TRACE("PhysX cook");
-    PxTriangleMesh* createdCollisionMesh = nullptr;
-    BuildPhysXTriangleMeshes(
-        createdCollisionMesh,
-        primitiveResult.uvInfo,
-        options.pMeshOptions->pNodeOptions->pModelOptions->pPhysXCookingModule,
-        StaticMeshBuildVertices,
-        indices);
-    primitiveResult.pCollisionMesh.Reset(createdCollisionMesh);
+      CESIUM_TRACE("PhysX cook");
+      PxTriangleMesh* createdCollisionMesh = nullptr;
+      BuildPhysXTriangleMeshes(
+          createdCollisionMesh,
+          primitiveResult.uvInfo,
+          options.pMeshOptions->pNodeOptions->pModelOptions
+              ->pPhysXCookingModule,
+          StaticMeshBuildVertices,
+          indices);
+      primitiveResult.pCollisionMesh.Reset(createdCollisionMesh);
 #else
-    CESIUM_TRACE("Chaos cook");
-    primitiveResult.pCollisionMesh =
-        BuildChaosTriangleMeshes(StaticMeshBuildVertices, indices);
+      CESIUM_TRACE("Chaos cook");
+      primitiveResult.pCollisionMesh =
+          BuildChaosTriangleMeshes(StaticMeshBuildVertices, indices);
 #endif
+    }
   }
 
   // load primitive metadata

--- a/Source/CesiumRuntime/Private/CreateGltfOptions.h
+++ b/Source/CesiumRuntime/Private/CreateGltfOptions.h
@@ -18,6 +18,7 @@ struct CreateModelOptions {
   const CesiumGltf::Model* pModel = nullptr;
   const FMetadataDescription* pEncodedMetadataDescription = nullptr;
   bool alwaysIncludeTangents = false;
+  bool createPhysicsMeshes = true;
 #if PHYSICS_INTERFACE_PHYSX
   IPhysXCookingModule* pPhysXCookingModule = nullptr;
 #endif


### PR DESCRIPTION
- Solves #860 
- Adds a new field in `CreateGltfOptions` that indicates whether if we should create physics meshes for the Gltf
- Tested on UE5