### PR TITLE
Add callback on tileset finished loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Intermediate
 ThirdParty/build
 Source/ThirdParty
 node_modules
+extern/build-helper.sh

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "vector": "cpp"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "files.associations": {
-        "vector": "cpp"
+        "vector": "cpp",
+        "atomic": "cpp"
     }
 }

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -805,6 +805,13 @@ void ACesium3DTileset::UpdateFromView(FSceneViewFamily& ViewFamily) {
   }
 }
 
+void ACesium3DTileset::GetLoadingStatus() {
+  int32_t loadNum = this->_pTileset->getTilesetLoadingStatus();
+  if (loadNum) { 
+      UE_LOG(LogCesium, Log, TEXT("LOADING TILES %ld"), loadNum);
+  }
+}
+
 void ACesium3DTileset::LoadTileset() {
   static std::shared_ptr<CesiumAsync::IAssetAccessor> pAssetAccessor =
       std::make_shared<CesiumAsync::CachingAssetAccessor>(
@@ -1725,6 +1732,8 @@ void ACesium3DTileset::Tick(float DeltaTime) {
   hideTilesToNoLongerRender(this->_tilesToNoLongerRenderNextFrame);
   this->_tilesToNoLongerRenderNextFrame = result.tilesToNoLongerRenderThisFrame;
   showTilesToRender(result.tilesToRenderThisFrame);
+
+  this->GetLoadingStatus();
 }
 
 void ACesium3DTileset::EndPlay(const EEndPlayReason::Type EndPlayReason) {

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -807,11 +807,10 @@ void ACesium3DTileset::UpdateFromView(FSceneViewFamily& ViewFamily) {
 
 void ACesium3DTileset::GetLoadingPercentage() {
   uint32_t loadPercent = this->_pTileset->computeLoadProgress();
+  this->_loadProgress = loadPercent;
   if (loadPercent < 100) {
-    UE_LOG(LogCesium, Log, TEXT("%ld%% Tiles loaded."), loadPercent);
     this->_activeLoading = true;
   } else if (this->_activeLoading && loadPercent == 100) {
-    UE_LOG(LogCesium, Log, TEXT("All tiles are loaded. "));
     this->_activeLoading = false;
   }
 }
@@ -1593,7 +1592,7 @@ void ACesium3DTileset::updateLastViewUpdateResultState(
         LogCesium,
         Display,
         TEXT(
-            "%s: %d ms, Visited %d, Culled Visited %d, Rendered %d, Culled %d, Occluded %d, Waiting For Occlusion Results %d, Max Depth Visited: %d, Loading-Low %d, Loading-Medium %d, Loading-High %d"),
+            "%s: %d ms, Visited %d, Culled Visited %d, Rendered %d, Culled %d, Occluded %d, Waiting For Occlusion Results %d, Max Depth Visited: %d, Loading-Low %d, Loading-Medium %d, Loading-High %d, Loaded tiles %d%%"),
         *this->GetName(),
         (std::chrono::high_resolution_clock::now() - this->_startTime).count() /
             1000000,
@@ -1606,7 +1605,8 @@ void ACesium3DTileset::updateLastViewUpdateResultState(
         result.maxDepthVisited,
         result.tilesLoadingLowPriority,
         result.tilesLoadingMediumPriority,
-        result.tilesLoadingHighPriority);
+        result.tilesLoadingHighPriority,
+        this->_loadProgress);
   }
 }
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -805,16 +805,12 @@ void ACesium3DTileset::UpdateFromView(FSceneViewFamily& ViewFamily) {
   }
 }
 
-uint32_t ACesium3DTileset::GetLoadedPercentage() {
-  this->_loadProgress = this->_pTileset->computeLoadProgress();
-  return this->_loadProgress;
-}
-
 void ACesium3DTileset::UpdateLoadStatus() {
   this->_loadProgress = this->_pTileset->computeLoadProgress();
-  this->_activeLoading = this->_loadProgress < 100;
 
-  if (this->_activeLoading && this->_loadProgress == 100) {
+  if (this->_loadProgress < 100) {
+    this->_activeLoading = true;
+  } else if (this->_activeLoading && this->_loadProgress == 100) {
 
     // Tileset just finished loading, we broadcast the update
     UE_LOG(LogCesium, Verbose, TEXT("Broadcasting OnTileLoaded"));
@@ -1740,6 +1736,7 @@ void ACesium3DTileset::Tick(float DeltaTime) {
       this->_captureMovieMode ? this->_pTileset->updateViewOffline(frustums)
                               : this->_pTileset->updateView(frustums);
   updateLastViewUpdateResultState(result);
+  this->UpdateLoadStatus();
 
   removeVisibleTilesFromList(
       this->_tilesToNoLongerRenderNextFrame,

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -805,10 +805,10 @@ void ACesium3DTileset::UpdateFromView(FSceneViewFamily& ViewFamily) {
   }
 }
 
-void ACesium3DTileset::GetLoadingStatus() {
-  int32_t loadNum = this->_pTileset->getTilesetLoadingStatus();
-  if (loadNum) { 
-      UE_LOG(LogCesium, Log, TEXT("LOADING TILES %ld"), loadNum);
+void ACesium3DTileset::GetLoadingPercentage() {
+  size_t loadPercent = this->_pTileset->getTilesetLoadingStatus();
+  if (loadPercent) {
+    UE_LOG(LogCesium, Log, TEXT("LOADING TILES %ld"), loadPercent);
   }
 }
 
@@ -1733,7 +1733,7 @@ void ACesium3DTileset::Tick(float DeltaTime) {
   this->_tilesToNoLongerRenderNextFrame = result.tilesToNoLongerRenderThisFrame;
   showTilesToRender(result.tilesToRenderThisFrame);
 
-  this->GetLoadingStatus();
+  this->GetLoadingPercentage();
 }
 
 void ACesium3DTileset::EndPlay(const EEndPlayReason::Type EndPlayReason) {

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -806,9 +806,13 @@ void ACesium3DTileset::UpdateFromView(FSceneViewFamily& ViewFamily) {
 }
 
 void ACesium3DTileset::GetLoadingPercentage() {
-  size_t loadPercent = this->_pTileset->getTilesetLoadingStatus();
-  if (loadPercent) {
-    UE_LOG(LogCesium, Log, TEXT("LOADING TILES %ld"), loadPercent);
+  uint32_t loadPercent = this->_pTileset->computeLoadProgress();
+  if (loadPercent < 100) {
+    UE_LOG(LogCesium, Log, TEXT("%ld%% Tiles loaded."), loadPercent);
+    this->_activeLoading = true;
+  } else if (this->_activeLoading && loadPercent == 100) {
+    UE_LOG(LogCesium, Log, TEXT("All tiles are loaded. "));
+    this->_activeLoading = false;
   }
 }
 

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -929,6 +929,7 @@ private:
   uint32_t _lastTilesLoadingLowPriority;
   uint32_t _lastTilesLoadingMediumPriority;
   uint32_t _lastTilesLoadingHighPriority;
+  uint32_t _loadProgress;
   bool _activeLoading;
 
   uint32_t _lastTilesVisited;

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -929,6 +929,7 @@ private:
   uint32_t _lastTilesLoadingLowPriority;
   uint32_t _lastTilesLoadingMediumPriority;
   uint32_t _lastTilesLoadingHighPriority;
+  bool _activeLoading;
 
   uint32_t _lastTilesVisited;
   uint32_t _lastCulledTilesVisited;

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -817,6 +817,7 @@ public:
   virtual void Serialize(FArchive& Ar) override;
 
   void UpdateFromView(FSceneViewFamily& ViewFamily);
+  void GetLoadingStatus();
 
   // UObject overrides
 #if WITH_EDITOR

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -518,11 +518,6 @@ public:
   UPROPERTY(BlueprintAssignable, Category = "Cesium");
   FCompletedLoadTrigger OnTilesetLoaded;
 
-  /**
-   * Updates the current loading progress in percentage of the tileset.
-   */
-  void UpdateLoadStatus();
-
 private:
   /**
    * The type of source from which to load this tileset.
@@ -834,7 +829,7 @@ public:
   virtual void Serialize(FArchive& Ar) override;
 
   void UpdateFromView(FSceneViewFamily& ViewFamily);
-  uint32_t GetLoadedPercentage();
+  void UpdateLoadStatus();
 
   // UObject overrides
 #if WITH_EDITOR

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -817,7 +817,7 @@ public:
   virtual void Serialize(FArchive& Ar) override;
 
   void UpdateFromView(FSceneViewFamily& ViewFamily);
-  void GetLoadingStatus();
+  void GetLoadingPercentage();
 
   // UObject overrides
 #if WITH_EDITOR

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -42,6 +42,12 @@ DECLARE_MULTICAST_DELEGATE_OneParam(
     FCesium3DTilesetLoadFailure,
     const FCesium3DTilesetLoadFailureDetails&);
 
+/**
+ * The delegate for the Acesium3DTileset::OnTilesetLoaded,
+ * which is triggered from UpdateLoadStatus
+ */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FCompletedLoadTrigger);
+
 CESIUMRUNTIME_API extern FCesium3DTilesetLoadFailure
     OnCesium3DTilesetLoadFailure;
 
@@ -506,6 +512,17 @@ public:
       meta = (ShowOnlyInnerProperties, SkipUCSModifiedProperties))
   FBodyInstance BodyInstance;
 
+  /**
+   * A delegate that will be called whenever the tileset is fully loaded.
+   */
+  UPROPERTY(BlueprintAssignable, Category = "Cesium");
+  FCompletedLoadTrigger OnTilesetLoaded;
+
+  /**
+   * Updates the current loading progress in percentage of the tileset.
+   */
+  void UpdateLoadStatus();
+
 private:
   /**
    * The type of source from which to load this tileset.
@@ -817,7 +834,7 @@ public:
   virtual void Serialize(FArchive& Ar) override;
 
   void UpdateFromView(FSceneViewFamily& ViewFamily);
-  void GetLoadingPercentage();
+  uint32_t GetLoadedPercentage();
 
   // UObject overrides
 #if WITH_EDITOR

--- a/extern/build-helper.sh
+++ b/extern/build-helper.sh
@@ -1,0 +1,1 @@
+cmake -B build -S . -G "Visual Studio 16 2019" && cmake --build build --config Debug --target install && cmake --build build --config Release --target install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-unreal",
-  "version": "1.10.1",
+  "version": "1.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
   "homepage": "https://github.com/CesiumGS/cesium-unreal#readme",
   "devDependencies": {
     "clang-format": "^1.5.0"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
- Depends on this PR from Cesium Native: https://github.com/CesiumGS/cesium-native/pull/525 
- Solves #774  
- This PR contains adding a new delegate `OnTilesetLoaded` that is exposed to the blueprint, which is invoked when the current tileset has finished loading 
- Currently we determine a tileset to be loaded when there are no tiles to be loaded in the queues, no tiles currently in load, and no occlusion results that we are waiting on. 