### PR TITLE
Collect occlusion results on the render thread

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.h
@@ -88,14 +88,14 @@ public:
   FPrimitiveSceneProxy* CreateSceneProxy() override;
 
   /**
-   * Add an active view for this frame. Occlusion results for this bounding
-   * volume will be pulled from the view and aggregated with the results from
-   * other views. Call FinalizeOcclusionResultsForFrame after adding all the
-   * relevant views.
+   * Aggregates an active view for this frame. Occlusion results for this 
+   * bounding volume will be pulled from the view and aggregated with the 
+   * results from other views. Call FinalizeOcclusionResultsForFrame after 
+   * aggregating all the relevant views.
    *
    * @param View An active view to retrieve occlusion results from.
    */
-  void UpdateOcclusionFromView(const FSceneView* View);
+  void AggregateOcclusionFromView_RenderThread(const FSceneView* View);
 
   /**
    * Finalizes a collective occlusion result for this bounding volume from all
@@ -129,9 +129,11 @@ protected:
 private:
   void _updateTransform();
 
-  bool _isOccludedThisFrame = false;
-  bool _isDefiniteThisFrame = true;
-  bool _ignoreRemainingViews = false;
+  // The only game-thread-safe place to access these is
+  // FinalizeOcclusionResultForFrame
+  bool _isOccludedThisFrame_RenderThread = false;
+  bool _isDefiniteThisFrame_RenderThread = true;
+  bool _ignoreRemainingViews_RenderThread = false;
 
   bool _isOccluded = false;
   bool _isOcclusionAvailable = false;

--- a/Source/CesiumRuntime/Private/CesiumRuntime.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRuntime.cpp
@@ -6,6 +6,7 @@
 #include "SpdlogUnrealLoggerSink.h"
 #include <Modules/ModuleManager.h>
 #include <spdlog/spdlog.h>
+#include "GenericPlatform/GenericPlatformProcess.h"
 
 #if CESIUM_TRACING_ENABLED
 #include <chrono>

--- a/Source/CesiumRuntime/Private/CesiumViewExtension.cpp
+++ b/Source/CesiumRuntime/Private/CesiumViewExtension.cpp
@@ -9,10 +9,24 @@ CesiumViewExtension::CesiumViewExtension(const FAutoRegister& autoRegister)
 CesiumViewExtension::~CesiumViewExtension() {}
 
 void CesiumViewExtension::RegisterTileset(ACesium3DTileset* pTileset) {
+  // TODO: add new tilesets to a temp list and add them the next time
+  // the fence is complete in BeginRenderViewFamily
+  // The current approach may cause a hitch when adding new tilesets.
+  if (_aggregatingViewFamilies) {
+    _finishAggregation();
+  }
+  
+  _aggregationFence.Wait();
   this->_registeredTilesets.insert(pTileset);
 }
 
+// TODO: find a way not to block game thread on UnregisterTileset
 void CesiumViewExtension::UnregisterTileset(ACesium3DTileset* pTileset) {
+  if (_aggregatingViewFamilies) {
+    _finishAggregation();
+  }
+
+  _aggregationFence.Wait();
   this->_registeredTilesets.erase(pTileset);
 }
 
@@ -24,8 +38,24 @@ void CesiumViewExtension::SetupView(
 
 void CesiumViewExtension::BeginRenderViewFamily(
     FSceneViewFamily& InViewFamily) {
-  for (ACesium3DTileset* pTileset : this->_registeredTilesets) {
-    pTileset->UpdateFromView(InViewFamily);
+  if (_frameNumber != (uint64_t)GFrameNumber) {
+    // This is the first BeginRenderViewFamily call this frame. Effectively we 
+    // use this as a "Tick".
+    if (_aggregatingViewFamilies) {
+      // Completed aggregating views from last frame, kick off a render fence
+      // to wait for the render thread aggregation to finish 
+      _finishAggregation();
+    } else if (_aggregationFence.IsFenceComplete()) {
+      if (_frameNumber > -1) {
+        for (ACesium3DTileset* pTileset : this->_registeredTilesets) {
+          pTileset->CompleteViewsAggregation();
+        }
+      }
+
+      _startAggregation();      
+    }
+    
+    _frameNumber = GFrameNumber;
   }
 }
 
@@ -39,4 +69,27 @@ void CesiumViewExtension::PreRenderView_RenderThread(
 
 void CesiumViewExtension::PostRenderViewFamily_RenderThread(
     FRHICommandListImmediate& RHICmdList,
-    FSceneViewFamily& InViewFamily) {}
+    FSceneViewFamily& InViewFamily) {
+  if (_aggregatingViewFamilies_RenderThread) {
+    for (ACesium3DTileset* pTileset : this->_registeredTilesets) {
+      pTileset->AggregateViews_RenderThread(InViewFamily);
+    }
+  }
+}
+
+void CesiumViewExtension::_startAggregation() {
+  _aggregatingViewFamilies = true;
+  ENQUEUE_RENDER_COMMAND(CesiumViewExtension_StartAggregation)(
+  [this](FRHICommandListImmediate& RHICmdList) {
+    this->_aggregatingViewFamilies_RenderThread = true;
+  });
+}
+
+void CesiumViewExtension::_finishAggregation() {
+  _aggregatingViewFamilies = false;
+  ENQUEUE_RENDER_COMMAND(CesiumViewExtension_FinishAggregation)
+  ([this](FRHICommandListImmediate& RHICmdList) {
+    this->_aggregatingViewFamilies_RenderThread = false;
+  });
+  _aggregationFence.BeginFence();
+}

--- a/Source/CesiumRuntime/Private/CesiumViewExtension.h
+++ b/Source/CesiumRuntime/Private/CesiumViewExtension.h
@@ -4,6 +4,7 @@
 #include "SceneTypes.h"
 #include "SceneView.h"
 #include "SceneViewExtension.h"
+#include "RenderCommandFence.h"
 #include <unordered_set>
 
 class ACesium3DTileset;
@@ -11,6 +12,10 @@ class ACesium3DTileset;
 class CesiumViewExtension : public FSceneViewExtensionBase {
 private:
   std::unordered_set<ACesium3DTileset*> _registeredTilesets;
+  FRenderCommandFence _aggregationFence;
+  bool _aggregatingViewFamilies = false;
+  bool _aggregatingViewFamilies_RenderThread = false;
+  int64_t _frameNumber = -1;
 
 public:
   CesiumViewExtension(const FAutoRegister& autoRegister);
@@ -31,4 +36,8 @@ public:
   void PostRenderViewFamily_RenderThread(
       FRHICommandListImmediate& RHICmdList,
       FSceneViewFamily& InViewFamily) override;
+
+private:
+  void _startAggregation();
+  void _finishAggregation();
 };

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -816,7 +816,8 @@ public:
   virtual void PostLoad() override;
   virtual void Serialize(FArchive& Ar) override;
 
-  void UpdateFromView(FSceneViewFamily& ViewFamily);
+  void AggregateViews_RenderThread(FSceneViewFamily& ViewFamily);
+  void CompleteViewsAggregation();
 
   // UObject overrides
 #if WITH_EDITOR


### PR DESCRIPTION
We are pretty sure that the current way that occlusion results are retrieved from the renderer is technically thread-unsafe (#904). This attempts to fix that by retrieving occlusion results on the render thread.

My main worry with this approach is the lack of throughput in occlusion results from the render thread to the game thread. The latency on the other hand is unavoidable since the game thread may be 1-2 frames ahead of the render thread. However, fwiw the original implementation for retrieving occlusion results (before the thread unsafe usage of the CesiumViewExtension) had the same throughput limitation and it still worked quite well. We might be able to implement some sort of 2-3 frame pipelining to increase the throughput, but it may require some more thought.