### PR TITLE
Collect occlusion results on the render thread 

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.cpp
@@ -101,11 +101,11 @@ void UCesiumBoundingVolumeComponent::UpdateOcclusion(
     return;
   }
 
-  TileOcclusionState occlusionState = 
+  TileOcclusionState occlusionState =
       cesiumViewExtension.getPrimitiveOcclusionState(
           this->ComponentId,
-          _occlusionState == TileOcclusionState::Occluded); 
-  
+          _occlusionState == TileOcclusionState::Occluded);
+
   // If the occlusion result is unavailable, continue using the previous result.
   if (occlusionState != TileOcclusionState::OcclusionUnavailable) {
     _occlusionState = occlusionState;

--- a/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.cpp
@@ -4,8 +4,6 @@
 #include "CalcBounds.h"
 #include "CesiumGeoreference.h"
 #include "CesiumLifetime.h"
-#include "Runtime/Renderer/Private/ScenePrivate.h"
-#include "SceneTypes.h"
 #include "UObject/UObjectGlobals.h"
 #include "VecMath.h"
 #include <optional>
@@ -97,62 +95,21 @@ FPrimitiveSceneProxy* UCesiumBoundingVolumeComponent::CreateSceneProxy() {
   return new FCesiumBoundingVolumeSceneProxy(this);
 }
 
-UCesiumBoundingVolumeComponent::UCesiumBoundingVolumeComponent()
-    : _tileBounds(CesiumGeometry::OrientedBoundingBox(
-          glm::dvec3(0.0),
-          glm::dmat3(1.0))),
-      _tileTransform(1.0),
-      _cesiumToUnreal(1.0) {}
-
-void UCesiumBoundingVolumeComponent::UpdateOcclusionFromView(
-    const FSceneView* View) {
-  if (_ignoreRemainingViews) {
+void UCesiumBoundingVolumeComponent::UpdateOcclusion(
+    const CesiumViewExtension& cesiumViewExtension) {
+  if (!_isMapped) {
     return;
   }
 
-  const FSceneViewState* pViewState = View->State->GetConcreteViewState();
-  if (pViewState && pViewState->PrimitiveOcclusionHistorySet.Num()) {
-    const FPrimitiveOcclusionHistory* pHistory =
-        pViewState->PrimitiveOcclusionHistorySet.Find(
-            FPrimitiveOcclusionHistoryKey(this->ComponentId, 0));
-    if (pHistory) {
-      if (!pHistory->OcclusionStateWasDefiniteLastFrame) {
-        _isDefiniteThisFrame = false;
-        _ignoreRemainingViews = true;
-        return;
-      }
-
-      _isDefiniteThisFrame = true;
-
-      if (_isOccluded) {
-        if (pHistory->LastPixelsPercentage > 0.01f) {
-          _isOccludedThisFrame = false;
-          _ignoreRemainingViews = true;
-          return;
-        }
-      } else {
-        if (!pHistory->WasOccludedLastFrame) {
-          // pHistory->LastPixelsPercentage > 0.0f) {
-          _isOccludedThisFrame = false;
-          _ignoreRemainingViews = true;
-          return;
-        }
-      }
-
-      _isOccludedThisFrame = true;
-    }
+  TileOcclusionState occlusionState = 
+      cesiumViewExtension.getPrimitiveOcclusionState(
+          this->ComponentId,
+          _occlusionState == TileOcclusionState::Occluded); 
+  
+  // If the occlusion result is unavailable, continue using the previous result.
+  if (occlusionState != TileOcclusionState::OcclusionUnavailable) {
+    _occlusionState = occlusionState;
   }
-}
-
-void UCesiumBoundingVolumeComponent::FinalizeOcclusionResultForFrame() {
-  if (_isDefiniteThisFrame) {
-    _isOccluded = _isOccludedThisFrame;
-    _isOcclusionAvailable = true;
-  }
-
-  _isOccludedThisFrame = false;
-  _isDefiniteThisFrame = true;
-  _ignoreRemainingViews = false;
 }
 
 void UCesiumBoundingVolumeComponent::_updateTransform() {
@@ -174,17 +131,6 @@ void UCesiumBoundingVolumeComponent::UpdateTransformFromCesium(
   this->_updateTransform();
 }
 
-Cesium3DTilesSelection::TileOcclusionState
-UCesiumBoundingVolumeComponent::getOcclusionState() const {
-  if (!this->_isOcclusionAvailable) {
-    return Cesium3DTilesSelection::TileOcclusionState::OcclusionUnavailable;
-  } else if (this->_isOccluded) {
-    return Cesium3DTilesSelection::TileOcclusionState::Occluded;
-  } else {
-    return Cesium3DTilesSelection::TileOcclusionState::NotOccluded;
-  }
-}
-
 void UCesiumBoundingVolumeComponent::reset(const Tile* pTile) {
   if (pTile) {
     this->_tileTransform = pTile->getTransform();
@@ -193,8 +139,7 @@ void UCesiumBoundingVolumeComponent::reset(const Tile* pTile) {
     this->_updateTransform();
     this->SetVisibility(true);
   } else {
-    this->_isOccluded = false;
-    this->_isOcclusionAvailable = false;
+    this->_occlusionState = TileOcclusionState::OcclusionUnavailable;
     this->_isMapped = false;
     this->SetVisibility(false);
   }

--- a/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "CesiumViewExtension.h"
 #include "Components/PrimitiveComponent.h"
 #include "Components/SceneComponent.h"
 #include "CoreMinimal.h"
@@ -82,26 +83,16 @@ class UCesiumBoundingVolumeComponent
 
 public:
   // Sets default values for this component's properties
-  UCesiumBoundingVolumeComponent();
+  UCesiumBoundingVolumeComponent() {};
   virtual ~UCesiumBoundingVolumeComponent() = default;
 
   FPrimitiveSceneProxy* CreateSceneProxy() override;
 
   /**
-   * Add an active view for this frame. Occlusion results for this bounding
-   * volume will be pulled from the view and aggregated with the results from
-   * other views. Call FinalizeOcclusionResultsForFrame after adding all the
-   * relevant views.
-   *
-   * @param View An active view to retrieve occlusion results from.
+   * Update the occlusion state for this bounding volume from the 
+   * CesiumViewExtension.
    */
-  void UpdateOcclusionFromView(const FSceneView* View);
-
-  /**
-   * Finalizes a collective occlusion result for this bounding volume from all
-   * the views sent to UpdateOcclusionFromView.
-   */
-  void FinalizeOcclusionResultForFrame();
+  void UpdateOcclusion(const CesiumViewExtension& cesiumViewExtension);
 
   /**
    * Updates this component's transform from a new double-precision
@@ -117,11 +108,11 @@ public:
 
   bool ShouldRecreateProxyOnUpdateTransform() const override { return true; }
 
-  bool IsMappedToTile() const { return this->_isMapped; }
-
   // virtual void BeginDestroy() override;
 
-  Cesium3DTilesSelection::TileOcclusionState getOcclusionState() const override;
+  Cesium3DTilesSelection::TileOcclusionState getOcclusionState() const override {
+    return _occlusionState;
+  }
 
 protected:
   void reset(const Cesium3DTilesSelection::Tile* pTile) override;
@@ -129,18 +120,14 @@ protected:
 private:
   void _updateTransform();
 
-  bool _isOccludedThisFrame = false;
-  bool _isDefiniteThisFrame = true;
-  bool _ignoreRemainingViews = false;
-
-  bool _isOccluded = false;
-  bool _isOcclusionAvailable = false;
+  Cesium3DTilesSelection::TileOcclusionState _occlusionState =
+      Cesium3DTilesSelection::TileOcclusionState::OcclusionUnavailable;
 
   // Whether this proxy is currently mapped to a tile.
   bool _isMapped = false;
 
   Cesium3DTilesSelection::BoundingVolume _tileBounds =
       CesiumGeometry::OrientedBoundingBox(glm::dvec3(0.0), glm::dmat3(1.0));
-  glm::dmat4 _tileTransform;
-  glm::dmat4 _cesiumToUnreal;
+  glm::dmat4 _tileTransform = glm::dmat4(1.0);
+  glm::dmat4 _cesiumToUnreal = glm::dmat4(1.0);
 };

--- a/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.h
@@ -83,13 +83,13 @@ class UCesiumBoundingVolumeComponent
 
 public:
   // Sets default values for this component's properties
-  UCesiumBoundingVolumeComponent() {};
+  UCesiumBoundingVolumeComponent(){};
   virtual ~UCesiumBoundingVolumeComponent() = default;
 
   FPrimitiveSceneProxy* CreateSceneProxy() override;
 
   /**
-   * Update the occlusion state for this bounding volume from the 
+   * Update the occlusion state for this bounding volume from the
    * CesiumViewExtension.
    */
   void UpdateOcclusion(const CesiumViewExtension& cesiumViewExtension);
@@ -110,7 +110,8 @@ public:
 
   // virtual void BeginDestroy() override;
 
-  Cesium3DTilesSelection::TileOcclusionState getOcclusionState() const override {
+  Cesium3DTilesSelection::TileOcclusionState
+  getOcclusionState() const override {
     return _occlusionState;
   }
 

--- a/Source/CesiumRuntime/Private/CesiumViewExtension.h
+++ b/Source/CesiumRuntime/Private/CesiumViewExtension.h
@@ -1,34 +1,50 @@
 
 #pragma once
 
+#include "Containers/Queue.h"
+#include "Containers/Set.h"
+#include "Runtime/Renderer/Private/ScenePrivate.h"
 #include "SceneTypes.h"
 #include "SceneView.h"
 #include "SceneViewExtension.h"
-#include "Runtime/Renderer/Private/ScenePrivate.h"
-#include "Containers/Queue.h"
-#include "Containers/Set.h"
-#include "SceneTypes.h"
 #include <Cesium3DTilesSelection/TileOcclusionRendererProxy.h>
-#include <unordered_set>
 #include <cstdint>
+#include <unordered_set>
 
 class ACesium3DTileset;
 
 class CesiumViewExtension : public FSceneViewExtensionBase {
 private:
+  // Occlusion results for a single view.
   struct SceneViewOcclusionResults {
     const FSceneView* pView = nullptr;
-    TSet<FPrimitiveOcclusionHistory,FPrimitiveOcclusionHistoryKeyFuncs> PrimitiveOcclusionHistorySet{};
+    TSet<FPrimitiveOcclusionHistory, FPrimitiveOcclusionHistoryKeyFuncs>
+        PrimitiveOcclusionHistorySet{};
   };
 
+  // A collection of occlusion results by view.
   struct AggregatedOcclusionUpdate {
     std::vector<SceneViewOcclusionResults> occlusionResultsByView{};
   };
 
+  // The current collection of occlusion results for this frame.
   AggregatedOcclusionUpdate _currentAggregation_renderThread{};
   AggregatedOcclusionUpdate _currentOcclusionResults{};
 
+  // A queue to pass occlusion results from the render thread to the game
+  // thread.
   TQueue<AggregatedOcclusionUpdate, EQueueMode::Spsc> _occlusionResultsQueue;
+
+  // A queue to recycle the previously-allocated occlusion history sets. The
+  // game thread recycles the sets by moving them into the queue and sending
+  // them back to the render thread.
+  TQueue<
+      TSet<FPrimitiveOcclusionHistory, FPrimitiveOcclusionHistoryKeyFuncs>,
+      EQueueMode::Spsc>
+      _recycledOcclusionHistorySets;
+
+  // The last known frame number. This is used to determine when an occlusion
+  // results aggregation is complete.
   int64_t _frameNumber_renderThread = -1;
 
 public:
@@ -36,7 +52,8 @@ public:
   ~CesiumViewExtension();
 
   Cesium3DTilesSelection::TileOcclusionState getPrimitiveOcclusionState(
-      const FPrimitiveComponentId& id, bool previouslyOccluded) const;
+      const FPrimitiveComponentId& id,
+      bool previouslyOccluded) const;
 
   void SetupViewFamily(FSceneViewFamily& InViewFamily) override;
   void SetupView(FSceneViewFamily& InViewFamily, FSceneView& InView) override;

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -816,8 +816,6 @@ public:
   virtual void PostLoad() override;
   virtual void Serialize(FArchive& Ar) override;
 
-  void UpdateFromView(FSceneViewFamily& ViewFamily);
-
   // UObject overrides
 #if WITH_EDITOR
   virtual void


### PR DESCRIPTION
We are pretty sure that the current way that occlusion results are retrieved from the renderer is technically thread-unsafe (https://github.com/CesiumGS/cesium-unreal/issues/904). This attempts to fix that by retrieving occlusion results on the render thread.

Thanks to Kevin for suggesting this type of approach in [this comment](https://github.com/CesiumGS/cesium-unreal/pull/917#issuecomment-1191240481), this feels a lot safer and easier to reason about!