### PR TITLE
Credits Crash

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
@@ -153,7 +153,7 @@ void ACesiumCreditSystem::BeginPlay() {
     _creditsWidget =
         CreateWidget<UScreenCreditsWidget>(GetWorld(), CreditsWidgetClass);
   }
-  if (_creditsWidget) {
+  if (IsValid(_creditsWidget)) {
     _creditsWidget->AddToViewport();
   }
 }
@@ -163,7 +163,7 @@ bool ACesiumCreditSystem::ShouldTickIfViewportsOnly() const { return true; }
 void ACesiumCreditSystem::Tick(float DeltaTime) {
   Super::Tick(DeltaTime);
 
-  if (!_pCreditSystem || !_creditsWidget) {
+  if (!_pCreditSystem || !IsValid(_creditsWidget)) {
     return;
   }
 

--- a/Source/CesiumRuntime/Public/CesiumCreditSystem.h
+++ b/Source/CesiumRuntime/Public/CesiumCreditSystem.h
@@ -53,6 +53,8 @@ public:
 
 private:
   static UClass* CesiumCreditSystemBP;
+
+  UPROPERTY()
   class UScreenCreditsWidget* _creditsWidget;
 
   /**


### PR DESCRIPTION
Fixes #921 

_creditsWidget was null and caused the program to crash. Although I haven't been able to reproduce it, it was most likely deleted by the garbage collector because it wasn't a UPROPERTY. 

Also replaced nullptr checks for IsValid.