### PR TITLE
Fix credit images not showing in UE5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 - Added `UCesiumBoundingVolumePoolComponent` and `UCesiumBoundingVolumeComponent` to track the occlusion state of prospective tiles before they are loaded. This allows tile loads to be avoided if they will be occluded anyways.
 - Added options in `ACesium3DTileset` to control occlusion culling and turn it off if necessary. 
 
+##### Fixes :wrench:
+- Fixed credit images not appearing in UE5.
+- Added `UPROPERTY` to the Credit Widget to prevent it from being deleted by the garbage collector. 
+
 ### v1.15.0 - 2022-07-01
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Private/ScreenCreditsWidget.cpp
+++ b/Source/CesiumRuntime/Private/ScreenCreditsWidget.cpp
@@ -49,22 +49,19 @@ public:
       ButtonStyle.SetNormal(*Brush);
       ButtonStyle.SetHovered(*Brush);
       ButtonStyle.SetPressed(*Brush);
-      HyperlinkStyle.SetUnderlineStyle(ButtonStyle);
 
-      TSharedPtr<FSlateHyperlinkRun::FWidgetViewModel> model =
-          MakeShareable(new FSlateHyperlinkRun::FWidgetViewModel);
+      ChildSlot
+          [SNew(SButton).ButtonStyle(&ButtonStyle).OnClicked_Lambda([Url]() {
+            FPlatformProcess::LaunchURL(*Url, NULL, NULL);
+            return FReply::Handled();
+          })];
 
-      ChildSlot[SNew(SRichTextHyperlink, model.ToSharedRef())
-                    .Style(&HyperlinkStyle)
-                    .OnNavigate_Lambda([Url]() {
-                      FPlatformProcess::LaunchURL(*Url, NULL, NULL);
-                    })];
+      this->SetCursor(EMouseCursor::Hand);
     }
   }
 
 private:
   FButtonStyle ButtonStyle;
-  FHyperlinkStyle HyperlinkStyle;
 };
 
 class SInlineHyperlinkText : public SCompoundWidget {


### PR DESCRIPTION
SRichTextHyperlink didn't work the same way in UE5 and prevented images from showing. Instead changed to an SButton.