### PR TITLE
Remove supportrasteroverlay

### DIFF
--- a/Source/CesiumEditor/Private/CesiumEditor.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditor.cpp
@@ -443,7 +443,7 @@ ACesium3DTileset* FCesiumEditorModule::FindFirstTilesetSupportingOverlays() {
 
   for (TActorIterator<ACesium3DTileset> it(pCurrentWorld); it; ++it) {
     const Cesium3DTilesSelection::Tileset* pTileset = it->GetTileset();
-    if (pTileset && pTileset->supportsRasterOverlays()) {
+    if (pTileset) {
       return *it;
     }
   }


### PR DESCRIPTION
- This PR removes calling `supportsRasterOverlay` which is removed in `cesium-native` in this PR: https://github.com/CesiumGS/cesium-native/pull/532 