### PR TITLE
Add callback for when dynamic pawn finishes flying

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 - `UCesiumGltfPrimitiveComponent` now has static mobility, allowing it to finally take advantage of several rendering optimizations only available for static objects.
 - Added `UCesiumBoundingVolumePoolComponent` and `UCesiumBoundingVolumeComponent` to track the occlusion state of prospective tiles before they are loaded. This allows tile loads to be avoided if they will be occluded anyways.
 - Added options in `ACesium3DTileset` to control occlusion culling and turn it off if necessary. 
+- Added a new delegate `OnTilesetLoaded` that is exposed to the blueprint, which is invoked when the current tileset has finished loading.
+- Added a getter `GetLoadProgress` exposed to blueprint, which returns the current loaded percentage of the tileset. 
 - Added BP accessible callback `OnFlightComplete` for when Dynamic Pawn completes flight. 
 - Added BP accessible callback `OnFlightInterrupt` for when Dynamic Pawn's flying is interrupted. 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - `UCesiumGltfPrimitiveComponent` now has static mobility, allowing it to finally take advantage of several rendering optimizations only available for static objects.
 - Added `UCesiumBoundingVolumePoolComponent` and `UCesiumBoundingVolumeComponent` to track the occlusion state of prospective tiles before they are loaded. This allows tile loads to be avoided if they will be occluded anyways.
 - Added options in `ACesium3DTileset` to control occlusion culling and turn it off if necessary. 
+- Added BP accessible callback `onFlightComplete` for when Dynamic Pawn completes flight. 
 
 ##### Fixes :wrench:
 - Fixed credit images not appearing in UE5.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@
 - `UCesiumGltfPrimitiveComponent` now has static mobility, allowing it to finally take advantage of several rendering optimizations only available for static objects.
 - Added `UCesiumBoundingVolumePoolComponent` and `UCesiumBoundingVolumeComponent` to track the occlusion state of prospective tiles before they are loaded. This allows tile loads to be avoided if they will be occluded anyways.
 - Added options in `ACesium3DTileset` to control occlusion culling and turn it off if necessary. 
-- Added BP accessible callback `onFlightComplete` for when Dynamic Pawn completes flight. 
+- Added BP accessible callback `OnFlightComplete` for when Dynamic Pawn completes flight. 
+- Added BP accessible callback `OnFlightInterrupt` for when Dynamic Pawn's flying is interrupted. 
 
 ##### Fixes :wrench:
 - Fixed credit images not appearing in UE5.

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -272,6 +272,11 @@ void AGlobeAwareDefaultPawn::_handleFlightStep(float DeltaSeconds) {
     Controller->SetControlRotation(this->_flyToDestinationRotation.Rotator());
     this->_bFlyingToLocation = false;
     this->_currentFlyTime = 0.0;
+
+    // Trigger callback accessible from BP
+    UE_LOG(LogCesium, Verbose, TEXT("Broadcasting OnFlightComplete"));
+    onFlightComplete.Broadcast();
+
     return;
   }
 

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -275,7 +275,7 @@ void AGlobeAwareDefaultPawn::_handleFlightStep(float DeltaSeconds) {
 
     // Trigger callback accessible from BP
     UE_LOG(LogCesium, Verbose, TEXT("Broadcasting OnFlightComplete"));
-    onFlightComplete.Broadcast();
+    OnFlightComplete.Broadcast();
 
     return;
   }
@@ -391,4 +391,8 @@ void AGlobeAwareDefaultPawn::_interruptFlight() {
   FRotator currentRotator = Controller->GetControlRotation();
   currentRotator.Roll = 0.0;
   Controller->SetControlRotation(currentRotator);
+
+  // Trigger callback accessible from BP
+  UE_LOG(LogCesium, Verbose, TEXT("Broadcasting OnFlightInterrupt"));
+  OnFlightInterrupt.Broadcast();
 }

--- a/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
+++ b/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
@@ -14,6 +14,12 @@ class UCesiumGlobeAnchorComponent;
 class UCurveFloat;
 
 /**
+ * The delegate for when the pawn finishes flying
+ * which is triggered from _handleFlightStep
+ */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FCompletedFlight);
+
+/**
  * This pawn can be used to easily move around the globe while maintaining a
  * sensible orientation. As the pawn moves across the horizon, it automatically
  * changes its own up direction such that the world always looks right-side up.
@@ -97,6 +103,13 @@ public:
    */
   UPROPERTY(EditAnywhere, Category = "Cesium", meta = (ClampMin = 0.0))
   double FlyToGranularityDegrees = 0.01;
+
+  /**
+   * A delegate that will be called whenver the pawn finishes flying
+   *
+   */
+  UPROPERTY(BlueprintAssignable, Category = "Cesium");
+  FCompletedFlight onFlightComplete;
 
   /**
    * Begin a smooth camera flight to the given Earth-Centered, Earth-Fixed

--- a/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
+++ b/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
@@ -20,6 +20,12 @@ class UCurveFloat;
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FCompletedFlight);
 
 /**
+ * The delegate for when the pawn's flying is interrupted
+ * which is triggered from _interruptFlight
+ */
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FInterruptedFlight);
+
+/**
  * This pawn can be used to easily move around the globe while maintaining a
  * sensible orientation. As the pawn moves across the horizon, it automatically
  * changes its own up direction such that the world always looks right-side up.
@@ -105,11 +111,18 @@ public:
   double FlyToGranularityDegrees = 0.01;
 
   /**
-   * A delegate that will be called whenver the pawn finishes flying
+   * A delegate that will be called whenever the pawn finishes flying
    *
    */
   UPROPERTY(BlueprintAssignable, Category = "Cesium");
-  FCompletedFlight onFlightComplete;
+  FCompletedFlight OnFlightComplete;
+
+  /**
+   * A delegate that will be called when a pawn's flying is interrupted
+   *
+   */
+  UPROPERTY(BlueprintAssignable, Category = "Cesium");
+  FInterruptedFlight OnFlightInterrupt;
 
   /**
    * Begin a smooth camera flight to the given Earth-Centered, Earth-Fixed


### PR DESCRIPTION
- Solves #827 
- Adds a BP accessible delegate `onFlightComplete` in the `AGlobeAwareDefaultPawn` class. 
- Tested with the `flyTo` example following the tutorial: https://cesium.com/learn/unreal/unreal-flyto/. 
- @nithinp7 