### PR TITLE
Fix 1-3 frame false-occlusion bug

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.cpp
@@ -104,7 +104,8 @@ void UCesiumBoundingVolumeComponent::UpdateOcclusion(
   TileOcclusionState occlusionState =
       cesiumViewExtension.getPrimitiveOcclusionState(
           this->ComponentId,
-          _occlusionState == TileOcclusionState::Occluded);
+          _occlusionState == TileOcclusionState::Occluded,
+          _mappedFrameTime);
 
   // If the occlusion result is unavailable, continue using the previous result.
   if (occlusionState != TileOcclusionState::OcclusionUnavailable) {
@@ -136,6 +137,7 @@ void UCesiumBoundingVolumeComponent::reset(const Tile* pTile) {
     this->_tileTransform = pTile->getTransform();
     this->_tileBounds = pTile->getBoundingVolume();
     this->_isMapped = true;
+    this->_mappedFrameTime = GetWorld()->GetRealTimeSeconds();
     this->_updateTransform();
     this->SetVisibility(true);
   } else {

--- a/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumBoundingVolumeComponent.h
@@ -127,6 +127,9 @@ private:
   // Whether this proxy is currently mapped to a tile.
   bool _isMapped = false;
 
+  // The time when this bounding volume was mapped to the tile.
+  float _mappedFrameTime = 0.0f;
+
   Cesium3DTilesSelection::BoundingVolume _tileBounds =
       CesiumGeometry::OrientedBoundingBox(glm::dvec3(0.0), glm::dmat3(1.0));
   glm::dmat4 _tileTransform = glm::dmat4(1.0);

--- a/Source/CesiumRuntime/Private/CesiumViewExtension.cpp
+++ b/Source/CesiumRuntime/Private/CesiumViewExtension.cpp
@@ -46,12 +46,12 @@ TileOcclusionState CesiumViewExtension::getPrimitiveOcclusionState(
     }
   }
 
-  if (!isOccluded) {
-    return TileOcclusionState::NotOccluded;
-  } else if (historyMissing) {
+  if (historyMissing) {
     return TileOcclusionState::OcclusionUnavailable;
-  } else {
+  } else if (isOccluded) {
     return TileOcclusionState::Occluded;
+  } else {
+    return TileOcclusionState::NotOccluded;
   }
 }
 

--- a/Source/CesiumRuntime/Private/CesiumViewExtension.cpp
+++ b/Source/CesiumRuntime/Private/CesiumViewExtension.cpp
@@ -127,6 +127,48 @@ void CesiumViewExtension::PostRenderViewFamily_RenderThread(
         occlusionResults.PrimitiveOcclusionHistorySet =
             pViewState->PrimitiveOcclusionHistorySet;
       }
+
+      // Unreal will not execute occlusion queries that get frustum culled in a
+      // particular view, leaving the occlusion results indefinite. And by just looking
+      // at the PrimitiveOcclusionHistorySet, we can't distinguish occlusion
+      // queries that haven't completed "yet" from occlusion queries that were
+      // culled. So here we detect primitives that have been conclusively proven
+      // to be not visible (outside the view frustum) and also mark them
+      // definitely occluded.
+      FScene* pScene = InViewFamily.Scene->GetRenderScene();
+      if (pView->bIsViewInfo && pScene != nullptr) {
+        const FViewInfo* pViewInfo = static_cast<const FViewInfo*>(pView);
+        const FSceneBitArray& visibility = pViewInfo->PrimitiveVisibilityMap;
+        auto& occlusion = occlusionResults.PrimitiveOcclusionHistorySet;
+
+        const uint32 PrimitiveCount = pScene->Primitives.Num();
+        for (uint32 i = 0; i < PrimitiveCount;
+             ++i) {
+          // We're only concerned with primitives that are not visible
+          if (visibility[i])
+            continue;
+
+          FPrimitiveSceneInfo* pSceneInfo = pScene->Primitives[i];
+          if (pSceneInfo == nullptr)
+            continue;
+
+          const FPrimitiveOcclusionHistory* pHistory =
+              occlusion.Find(FPrimitiveOcclusionHistoryKey(
+                  pSceneInfo->PrimitiveComponentId,
+                  0));
+          if (!pHistory ||
+              pHistory->LastConsideredTime < pViewState->LastRenderTime) {
+            // No valid occlusion history for this culled primitive, so create it.
+            FPrimitiveOcclusionHistory historyEntry{};
+            historyEntry.PrimitiveId = pSceneInfo->PrimitiveComponentId;
+            historyEntry.LastConsideredTime = pViewState->LastRenderTime;
+            historyEntry.LastPixelsPercentage = 0.0f;
+            historyEntry.WasOccludedLastFrame = true;
+            historyEntry.OcclusionStateWasDefiniteLastFrame = true;
+            occlusion.Add(std::move(historyEntry));
+          }
+        }
+      }
     }
   }
 }

--- a/Source/CesiumRuntime/Private/CesiumViewExtension.cpp
+++ b/Source/CesiumRuntime/Private/CesiumViewExtension.cpp
@@ -129,12 +129,12 @@ void CesiumViewExtension::PostRenderViewFamily_RenderThread(
       }
 
       // Unreal will not execute occlusion queries that get frustum culled in a
-      // particular view, leaving the occlusion results indefinite. And by just looking
-      // at the PrimitiveOcclusionHistorySet, we can't distinguish occlusion
-      // queries that haven't completed "yet" from occlusion queries that were
-      // culled. So here we detect primitives that have been conclusively proven
-      // to be not visible (outside the view frustum) and also mark them
-      // definitely occluded.
+      // particular view, leaving the occlusion results indefinite. And by just
+      // looking at the PrimitiveOcclusionHistorySet, we can't distinguish
+      // occlusion queries that haven't completed "yet" from occlusion queries
+      // that were culled. So here we detect primitives that have been
+      // conclusively proven to be not visible (outside the view frustum) and
+      // also mark them definitely occluded.
       FScene* pScene = InViewFamily.Scene->GetRenderScene();
       if (pView->bIsViewInfo && pScene != nullptr) {
         const FViewInfo* pViewInfo = static_cast<const FViewInfo*>(pView);
@@ -142,8 +142,7 @@ void CesiumViewExtension::PostRenderViewFamily_RenderThread(
         auto& occlusion = occlusionResults.PrimitiveOcclusionHistorySet;
 
         const uint32 PrimitiveCount = pScene->Primitives.Num();
-        for (uint32 i = 0; i < PrimitiveCount;
-             ++i) {
+        for (uint32 i = 0; i < PrimitiveCount; ++i) {
           // We're only concerned with primitives that are not visible
           if (visibility[i])
             continue;
@@ -158,7 +157,8 @@ void CesiumViewExtension::PostRenderViewFamily_RenderThread(
                   0));
           if (!pHistory ||
               pHistory->LastConsideredTime < pViewState->LastRenderTime) {
-            // No valid occlusion history for this culled primitive, so create it.
+            // No valid occlusion history for this culled primitive, so create
+            // it.
             FPrimitiveOcclusionHistory historyEntry{};
             historyEntry.PrimitiveId = pSceneInfo->PrimitiveComponentId;
             historyEntry.LastConsideredTime = pViewState->LastRenderTime;

--- a/Source/CesiumRuntime/Private/CesiumViewExtension.h
+++ b/Source/CesiumRuntime/Private/CesiumViewExtension.h
@@ -53,7 +53,8 @@ public:
 
   Cesium3DTilesSelection::TileOcclusionState getPrimitiveOcclusionState(
       const FPrimitiveComponentId& id,
-      bool previouslyOccluded) const;
+      bool previouslyOccluded,
+      float frameTimeCutoff) const;
 
   void SetupViewFamily(FSceneViewFamily& InViewFamily) override;
   void SetupView(FSceneViewFamily& InViewFamily, FSceneView& InView) override;


### PR DESCRIPTION
Fixes #924. 

This turned out to be a very similar problem to the infamous flickering holes bug. It has to do with stale occlusion results for bounding volume proxies that are newly set to visible (ones that have been newly assigned to a tile). Particularly, when there was a bounding volume proxy that was previously occluded when assigned to a previous tile and then got unassigned and then much later reassigned to a new tile. The last occlusion result from the old tile assignment ended up being picked up and the selection mistakenly thinks the tile is occluded. The solution is to keep track of when a tile is assigned and ignore occlusion results from before the assignment.