### PR TITLE
Put occlusion culling behind a feature flag.

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1906,6 +1906,7 @@ void ACesium3DTileset::Destroyed() {
   AActor::Destroyed();
 }
 
+#if WITH_EDITOR
 void ACesium3DTileset::RuntimeSettingsChanged(
     UObject* pObject,
     struct FPropertyChangedEvent& changed) {
@@ -1917,3 +1918,4 @@ void ACesium3DTileset::RuntimeSettingsChanged(
     this->RefreshTileset();
   }
 }
+#endif

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -217,6 +217,18 @@ void ACesium3DTileset::PostInitProperties() {
   Super::PostInitProperties();
 
   AddFocusViewportDelegate();
+
+  UCesiumRuntimeSettings* pSettings =
+      GetMutableDefault<UCesiumRuntimeSettings>();
+  if (pSettings) {
+    CanEnableOcclusionCulling =
+        pSettings->EnableExperimentalOcclusionCullingFeature;
+#if WITH_EDITOR
+    pSettings->OnSettingChanged().AddUObject(
+        this,
+        &ACesium3DTileset::RuntimeSettingsChanged);
+#endif
+  }
 }
 
 void ACesium3DTileset::SetTilesetSource(ETilesetSource InSource) {
@@ -261,6 +273,12 @@ void ACesium3DTileset::SetIonAssetEndpointUrl(
     }
     this->IonAssetEndpointUrl = InIonAssetEndpointUrl;
   }
+}
+
+bool ACesium3DTileset::GetEnableOcclusionCulling() const {
+  return GetDefault<UCesiumRuntimeSettings>()
+             ->EnableExperimentalOcclusionCullingFeature &&
+         EnableOcclusionCulling;
 }
 
 void ACesium3DTileset::SetEnableOcclusionCulling(bool bEnableOcclusionCulling) {
@@ -845,7 +863,9 @@ void ACesium3DTileset::LoadTileset() {
 
   this->_cesiumViewExtension = cesiumViewExtension;
 
-  if (this->EnableOcclusionCulling && !this->BoundingVolumePoolComponent) {
+  if (GetDefault<UCesiumRuntimeSettings>()
+          ->EnableExperimentalOcclusionCullingFeature &&
+      this->EnableOcclusionCulling && !this->BoundingVolumePoolComponent) {
     const glm::dmat4& cesiumToUnreal =
         GetCesiumTilesetToUnrealRelativeWorldTransform();
     this->BoundingVolumePoolComponent =
@@ -868,7 +888,9 @@ void ACesium3DTileset::LoadTileset() {
       asyncSystem,
       pCreditSystem ? pCreditSystem->GetExternalCreditSystem() : nullptr,
       spdlog::default_logger(),
-      (this->EnableOcclusionCulling && this->BoundingVolumePoolComponent)
+      (GetDefault<UCesiumRuntimeSettings>()
+           ->EnableExperimentalOcclusionCullingFeature &&
+       this->EnableOcclusionCulling && this->BoundingVolumePoolComponent)
           ? this->BoundingVolumePoolComponent->getPool()
           : nullptr};
 
@@ -876,7 +898,10 @@ void ACesium3DTileset::LoadTileset() {
 
   Cesium3DTilesSelection::TilesetOptions options;
 
-  options.enableOcclusionCulling = this->EnableOcclusionCulling;
+  options.enableOcclusionCulling =
+      GetDefault<UCesiumRuntimeSettings>()
+          ->EnableExperimentalOcclusionCullingFeature &&
+      this->EnableOcclusionCulling;
   options.delayRefinementForOcclusion = this->DelayRefinementForOcclusion;
 
   options.showCreditsOnScreen = ShowCreditsOnScreen;
@@ -1572,7 +1597,10 @@ void ACesium3DTileset::updateTilesetOptionsFromProperties() {
   options.maximumSimultaneousTileLoads = this->MaximumSimultaneousTileLoads;
   options.loadingDescendantLimit = this->LoadingDescendantLimit;
   options.enableFrustumCulling = this->EnableFrustumCulling;
-  options.enableOcclusionCulling = this->EnableOcclusionCulling;
+  options.enableOcclusionCulling =
+      GetDefault<UCesiumRuntimeSettings>()
+          ->EnableExperimentalOcclusionCullingFeature &&
+      this->EnableOcclusionCulling;
 
   options.delayRefinementForOcclusion = this->DelayRefinementForOcclusion;
   options.enableFogCulling = this->EnableFogCulling;
@@ -1876,4 +1904,16 @@ void ACesium3DTileset::Destroyed() {
   this->DestroyTileset();
 
   AActor::Destroyed();
+}
+
+void ACesium3DTileset::RuntimeSettingsChanged(
+    UObject* pObject,
+    struct FPropertyChangedEvent& changed) {
+  bool occlusionCullingAvailable =
+      GetDefault<UCesiumRuntimeSettings>()
+          ->EnableExperimentalOcclusionCullingFeature;
+  if (occlusionCullingAvailable != this->CanEnableOcclusionCulling) {
+    this->CanEnableOcclusionCulling = occlusionCullingAvailable;
+    this->RefreshTileset();
+  }
 }

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -430,8 +430,15 @@ public:
       meta = (EditCondition = "EnforceCulledScreenSpaceError", ClampMin = 0.0))
   float CulledScreenSpaceError = 64.0;
 
+  UPROPERTY(Transient, VisibleDefaultsOnly)
+  bool CanEnableOcclusionCulling = false;
+
   /**
    * Whether to cull tiles that are occluded.
+   *
+   * If this option is disabled, check that "Enable Experimental Occlusion
+   * Culling Feature" is enabled in the Plugins -> Cesium section of the Project
+   * Settings.
    *
    * When enabled, this feature will use Unreal's occlusion system to determine
    * if tiles are actually visible on the screen. For tiles found to be
@@ -450,7 +457,8 @@ public:
       EditAnywhere,
       BlueprintGetter = GetEnableOcclusionCulling,
       BlueprintSetter = SetEnableOcclusionCulling,
-      Category = "Cesium|Tile Occlusion")
+      Category = "Cesium|Tile Occlusion",
+      meta = (EditCondition = "CanEnableOcclusionCulling"))
   bool EnableOcclusionCulling = true;
 
   /**
@@ -465,7 +473,8 @@ public:
       BlueprintSetter = SetOcclusionPoolSize,
       Category = "Cesium|Tile Occlusion",
       meta =
-          (EditCondition = "EnableOcclusionCulling",
+          (EditCondition =
+               "EnableOcclusionCulling && CanEnableOcclusionCulling",
            ClampMin = "0",
            ClampMax = "1000"))
   int32 OcclusionPoolSize = 500;
@@ -483,7 +492,9 @@ public:
       BlueprintGetter = GetDelayRefinementForOcclusion,
       BlueprintSetter = SetDelayRefinementForOcclusion,
       Category = "Cesium|Tile Occlusion",
-      meta = (EditCondition = "EnableOcclusionCulling"))
+      meta =
+          (EditCondition =
+               "EnableOcclusionCulling && CanEnableOcclusionCulling"))
   bool DelayRefinementForOcclusion = true;
 
   /**
@@ -750,7 +761,7 @@ public:
   void SetIonAssetEndpointUrl(const FString& InIonAssetEndpointUrl);
 
   UFUNCTION(BlueprintGetter, Category = "Cesium|Tile Culling|Experimental")
-  bool GetEnableOcclusionCulling() const { return EnableOcclusionCulling; }
+  bool GetEnableOcclusionCulling() const;
 
   UFUNCTION(BlueprintSetter, Category = "Cesium|Tile Culling|Experimental")
   void SetEnableOcclusionCulling(bool bEnableOcclusionCulling);
@@ -947,6 +958,10 @@ private:
    * was given in the root tile.
    */
   void OnFocusEditorViewportOnThis();
+
+  void RuntimeSettingsChanged(
+      UObject* pObject,
+      struct FPropertyChangedEvent& changed);
 #endif
 
 private:

--- a/Source/CesiumRuntime/Public/CesiumRuntimeSettings.h
+++ b/Source/CesiumRuntime/Public/CesiumRuntimeSettings.h
@@ -44,4 +44,12 @@ public:
       Category = "Level of Detail",
       meta = (DisplayName = "Scale Level-of-Detail by Display DPI"))
   bool ScaleLevelOfDetailByDPI = true;
+
+  /**
+   * Uses Unreal's occlusion culling engine to drive Cesium 3D Tiles selection,
+   * reducing the detail of tiles that are occluded by other objects in the
+   * scene so that less data overall needs to be loaded and rendered.
+   */
+  UPROPERTY(Config, EditAnywhere, Category = "Experimental Feature Flags")
+  bool EnableExperimentalOcclusionCullingFeature = false;
 };


### PR DESCRIPTION
As mentioned in https://github.com/CesiumGS/cesium-unreal/pull/928#issuecomment-1200835178, this puts the occlusion culling feature behind a feature flag, which is found in Project Settings. The reason is:

1. I'm nervous to have occlusion culling "on by default" currently given the deep renderer integration and last-minute changes. While it's working well in our tests, it wouldn't be surprising to run into issues on some platforms or in some environments, or even to run into visual artifacts with certain tilesets in certain cases.
2. If we do the simple thing of just defaulting the "Enable Occlusion Culling" property on Cesium3DTileset to _off_, then later, when we do want it to be on by default, people with existing levels will need to re-enable it manually. We won't be able to easily distinguish "intentionally disabled" from "disabled just because that used to be the default."

By adding a "feature flag" at the project level, we can disable the entire feature by default, but let people enable it to try it out. And once we have more confidence in the feature (which doesn't need to wait until September), we can remove the feature flag and make the plugin act as if it's always enabled (subject to the Tileset setting).

Unfortunately, Unreal made this a little harder than I anticipated, because UPROPERTY `EditCondition` is so limited, but this should be a workable template for future feature flags if we need them as well.