### PR TITLE
Occlusion culling: handle nullptr State, disable the CesiumViewExtension when the feature is disabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+### v1.16.1 - 2022-08-01
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause a crash when using thumbnail rendering, notably on the Project Settings panel in UE5.
+- More fully disabled the occlusion culling system when the project-level feature flag is disabled.
+
 ### v1.16.0 - 2022-08-01
 
 ##### Breaking Changes :mega:

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -846,6 +846,12 @@ void ACesium3DTileset::LoadTileset() {
     return;
   }
 
+  // Both the feature flag and the CesiumViewExtension are global, not owned by
+  // the Tileset. We're just applying one to the other here out of convenience.
+  cesiumViewExtension->SetEnabled(
+      GetDefault<UCesiumRuntimeSettings>()
+          ->EnableExperimentalOcclusionCullingFeature);
+
   TArray<UCesiumRasterOverlay*> rasterOverlays;
   this->GetComponents<UCesiumRasterOverlay>(rasterOverlays);
 

--- a/Source/CesiumRuntime/Private/CesiumViewExtension.cpp
+++ b/Source/CesiumRuntime/Private/CesiumViewExtension.cpp
@@ -63,6 +63,8 @@ void CesiumViewExtension::SetupView(
 
 void CesiumViewExtension::BeginRenderViewFamily(
     FSceneViewFamily& InViewFamily) {
+  if (!this->_isEnabled)
+    return;
 
   TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::DequeueOcclusionResults)
   if (!_occlusionResultsQueue.IsEmpty()) {
@@ -92,6 +94,9 @@ void CesiumViewExtension::PreRenderView_RenderThread(
 void CesiumViewExtension::PostRenderViewFamily_RenderThread(
     FRHICommandListImmediate& RHICmdList,
     FSceneViewFamily& InViewFamily) {
+  if (!this->_isEnabled)
+    return;
+
   if (_frameNumber_renderThread != InViewFamily.FrameNumber) {
     TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::EnqueueAggregatedOcclusion)
     if (_frameNumber_renderThread != -1) {
@@ -105,6 +110,9 @@ void CesiumViewExtension::PostRenderViewFamily_RenderThread(
 
   TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::AggregateOcclusionForViewFamily)
   for (const FSceneView* pView : InViewFamily.Views) {
+    if (pView == nullptr || pView->State == nullptr)
+      continue;
+
     const FSceneViewState* pViewState = pView->State->GetConcreteViewState();
     if (pViewState && pViewState->PrimitiveOcclusionHistorySet.Num()) {
       SceneViewOcclusionResults& occlusionResults =
@@ -171,4 +179,8 @@ void CesiumViewExtension::PostRenderViewFamily_RenderThread(
       }
     }
   }
+}
+
+void CesiumViewExtension::SetEnabled(bool enabled) {
+  this->_isEnabled = enabled;
 }

--- a/Source/CesiumRuntime/Private/CesiumViewExtension.h
+++ b/Source/CesiumRuntime/Private/CesiumViewExtension.h
@@ -47,6 +47,8 @@ private:
   // results aggregation is complete.
   int64_t _frameNumber_renderThread = -1;
 
+  std::atomic<bool> _isEnabled = false;
+
 public:
   CesiumViewExtension(const FAutoRegister& autoRegister);
   ~CesiumViewExtension();
@@ -68,4 +70,6 @@ public:
   void PostRenderViewFamily_RenderThread(
       FRHICommandListImmediate& RHICmdList,
       FSceneViewFamily& InViewFamily) override;
+
+  void SetEnabled(bool enabled);
 };


### PR DESCRIPTION
This PR fixes a crash in UE5 when opening the Project Settings panel. It's caused by a `FSceneView` having a nullptr `State`, which can apparently (according to a comment above the field) happen when the view is used for thumbnail rendering.

It also "fixes" (very much in quotes) a crash at startup in UE4.26. The crash happens when we try to copy the `PrimitiveOcclusionHistorySet`, and it may actually be a 4.26 bug. What I've done here is to more fully disable the `CesiumViewExtension` when the Occlusion Culling feature is disabled. This way the crash doesn't happen at startup, but instead happens when the user tries to enable the experimental occlusion culling feature. Disabling the CesiumViewExtension is a good idea anyway, to reduce the chances of problems caused by our interaction with the renderer.