### PR TITLE
Don't use dodgy Editor viewports.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 - The translucent parts of 3D Tiles are now correctly rendered as translucent.
 - Added a `TranslucentMaterial` property to `Cesium3DTileset`, allowing a custom material to be used to render the translucent portions of a tileset.
 
+##### Fixes :wrench:
+
+- Cesium for Unreal now only uses Editor viewports for tile selection if they are visible, real-time, and use a perspective projection. Previously, any viewport with a valid size was used, which could lead to tiles being loaded and rendered unnecessarily.
+
 ### v1.16.1 - 2022-08-01
 
 ##### Fixes :wrench:

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1442,6 +1442,12 @@ std::vector<FCesiumCamera> ACesium3DTileset::GetEditorCameras() const {
       continue;
     }
 
+    if (!pEditorViewportClient->IsVisible() ||
+        !pEditorViewportClient->IsRealtime() ||
+        !pEditorViewportClient->IsPerspective()) {
+      continue;
+    }
+
     const FVector& location = pEditorViewportClient->GetViewLocation();
     const FRotator& rotation = pEditorViewportClient->GetViewRotation();
     float fov = pEditorViewportClient->ViewFOV;


### PR DESCRIPTION
Now only viewports that are visible, real-time, and use a perspective projection are used for tile selection.

This is especially important in UE5 because collapsed Editor viewports seem to no longer get a 0,0 size in that version.

Probably the most controversial one here is the "visible", because Unreal considers all viewports non-visible if another application (other than the UE Editor) has the focus. That effectively means tile selection will stop when the Editor loses focus. I think we can live with this, though, especially since I wasn't able to find a better alternative.

Fixes #801
