### PR TITLE
Fix disappearing tiles when camera is orbiting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 ##### Fixes :wrench:
 
 - Cesium for Unreal now only uses Editor viewports for tile selection if they are visible, real-time, and use a perspective projection. Previously, any viewport with a valid size was used, which could lead to tiles being loaded and rendered unnecessarily.
+- Fixed a bug that causes tiles to dissapear when the Editor viewport is in Orbit mode.
 
 ### v1.16.2 - 2022-08-04
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1447,18 +1447,17 @@ std::vector<FCesiumCamera> ACesium3DTileset::GetEditorCameras() const {
         !pEditorViewportClient->IsPerspective()) {
       continue;
     }
-    auto GetViewRotation = [pEditorViewportClient]() {
-      if (pEditorViewportClient->bUsingOrbitCamera) {
 
-        return (pEditorViewportClient->GetLookAtLocation() -
-                pEditorViewportClient->GetViewLocation())
-            .Rotation();
-      } else {
-        return pEditorViewportClient->GetViewRotation();
-      }
-    };
+    FRotator rotation;
+    if (pEditorViewportClient->bUsingOrbitCamera) {
+      rotation = (pEditorViewportClient->GetLookAtLocation() -
+                  pEditorViewportClient->GetViewLocation())
+                     .Rotation();
+    } else {
+      rotation = pEditorViewportClient->GetViewRotation();
+    }
+
     const FVector& location = pEditorViewportClient->GetViewLocation();
-    const FRotator& rotation = GetViewRotation();
     float fov = pEditorViewportClient->ViewFOV;
     FIntPoint offset;
     FIntPoint size;

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1447,9 +1447,18 @@ std::vector<FCesiumCamera> ACesium3DTileset::GetEditorCameras() const {
         !pEditorViewportClient->IsPerspective()) {
       continue;
     }
+    auto GetViewRotation = [pEditorViewportClient]() {
+      if (pEditorViewportClient->bUsingOrbitCamera) {
 
+        return (pEditorViewportClient->GetLookAtLocation() -
+                pEditorViewportClient->GetViewLocation())
+            .Rotation();
+      } else {
+        return pEditorViewportClient->GetViewRotation();
+      }
+    };
     const FVector& location = pEditorViewportClient->GetViewLocation();
-    const FRotator& rotation = pEditorViewportClient->GetViewRotation();
+    const FRotator& rotation = GetViewRotation();
     float fov = pEditorViewportClient->ViewFOV;
     FIntPoint offset;
     FIntPoint size;


### PR DESCRIPTION
This PR fixes the problem where pressing ALT and the drag left mouse button in the Editor viewport causes tiles to disappear.