### PR TITLE
Fix UE5 Line Tracing bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 
 - Cesium for Unreal now only uses Editor viewports for tile selection if they are visible, real-time, and use a perspective projection. Previously, any viewport with a valid size was used, which could lead to tiles being loaded and rendered unnecessarily.
 - Fixed a bug in the Globe Anchor Component that prevented changing/resetting the actor transform in the details panel.
+- Fixed a bug in UE5 where LineTrace occasionally failed to collide with tiles at a certain LOD.
 
 ### v1.16.2 - 2022-08-04
 

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -2373,12 +2373,12 @@ static void fillTriangles(
 
   triangles.Reserve(triangleCount);
 
-  for (TIndex i = 0; i < static_cast<TIndex>(triangleCount); ++i) {
-    TIndex index0 = 3 * i;
-    triangles.Add(Chaos::TVector<TIndex, 3>(
-        static_cast<TIndex>(indices[index0 + 1]),
-        static_cast<TIndex>(indices[index0]),
-        static_cast<TIndex>(indices[index0 + 2])));
+  for (int32 i = 0; i < triangleCount; ++i) {
+    const int32 index0 = 3 * i;
+    triangles.Add(Chaos::TVector<int32, 3>(
+        indices[index0 + 1],
+        indices[index0],
+        indices[index0 + 2]));
   }
 }
 


### PR DESCRIPTION
Fixes #900

When setting the Chaos triangles, the indices are set to uint16 if the number of vertices is less than 65536, and int32 otherwise.

However, for some reason, adding uint16 triangles causes the issue. 

In the Unreal Code, https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/Engine/Private/PhysicsEngine/Experimental/ChaosCooking.cpp#L302, they also create an array of uint16 triangles, however in the lamba function, they add int32 triangles to it (https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Runtime/Engine/Private/PhysicsEngine/Experimental/ChaosCooking.cpp#L254).

This PR changes the code to do the same thing.