### PR TITLE
Copy UV data to physics mesh only when using metadata textures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 
 - Cesium for Unreal now only uses Editor viewports for tile selection if they are visible, real-time, and use a perspective projection. Previously, any viewport with a valid size was used, which could lead to tiles being loaded and rendered unnecessarily.
 - Fixed a bug in the Globe Anchor Component that prevented changing/resetting the actor transform in the details panel.
-- Reduce the size of physics meshes by only copying UV data if "Support UV from Hit Results" is enabled and if the model uses feature ID textures.
+- Reduce the size of physics meshes by only copying UV data if "Support UV from Hit Results" is enabled.
 
 ### v1.16.2 - 2022-08-04
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 - Cesium for Unreal now only uses Editor viewports for tile selection if they are visible, real-time, and use a perspective projection. Previously, any viewport with a valid size was used, which could lead to tiles being loaded and rendered unnecessarily.
 - Fixed a bug in the Globe Anchor Component that prevented changing/resetting the actor transform in the details panel.
+- To reduce unnecessarily copying UV data to physics meshes, will only copy if the model contains feature textures to save on memory.coordinates to the physics mesh.
+- Reduce the size of physics meshes by only copying UV data if "Support UV from Hit Results" is enabled and if the model uses feature ID textures.
 
 ### v1.16.2 - 2022-08-04
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,6 @@
 
 - Cesium for Unreal now only uses Editor viewports for tile selection if they are visible, real-time, and use a perspective projection. Previously, any viewport with a valid size was used, which could lead to tiles being loaded and rendered unnecessarily.
 - Fixed a bug in the Globe Anchor Component that prevented changing/resetting the actor transform in the details panel.
-- To reduce unnecessarily copying UV data to physics meshes, will only copy if the model contains feature textures to save on memory.coordinates to the physics mesh.
 - Reduce the size of physics meshes by only copying UV data if "Support UV from Hit Results" is enabled and if the model uses feature ID textures.
 
 ### v1.16.2 - 2022-08-04

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -286,7 +286,6 @@ static void computeFlatNormals(
 static void BuildPhysXTriangleMeshes(
     PxTriangleMesh*& pCollisionMesh,
     FBodySetupUVInfo& uvInfo,
-    const TMap<FString, uint32_t>& metadataTextureCoordinateParameters,
     IPhysXCookingModule* pPhysXCooking,
     const TArray<FStaticMeshBuildVertex>& vertexData,
     const TArray<uint32>& indices);
@@ -1174,7 +1173,6 @@ static void loadPrimitive(
     BuildPhysXTriangleMeshes(
         createdCollisionMesh,
         primitiveResult.uvInfo,
-        primitiveResult.metadataTextureCoordinateParameters,
         options.pMeshOptions->pNodeOptions->pModelOptions->pPhysXCookingModule,
         StaticMeshBuildVertices,
         indices);
@@ -2018,8 +2016,7 @@ static void loadPrimitiveGameThreadPart(
   // the game thread, because that would be slow.
   pBodySetup->bCreatedPhysicsMeshes = true;
   pBodySetup->bSupportUVsAndFaceRemap =
-      UPhysicsSettings::Get()->bSupportUVFromHitResults &&
-      loadResult.metadataTextureCoordinateParameters.Num();
+      UPhysicsSettings::Get()->bSupportUVFromHitResults;
 
   // pMesh->SetMobility(EComponentMobility::Movable);
   pMesh->SetMobility(EComponentMobility::Static);
@@ -2315,7 +2312,6 @@ void UCesiumGltfComponent::BeginDestroy() {
 static void BuildPhysXTriangleMeshes(
     PxTriangleMesh*& pCollisionMesh,
     FBodySetupUVInfo& uvInfo,
-    const TMap<FString, uint32_t>& metadataTextureCoordinateParameters,
     IPhysXCookingModule* pPhysXCookingModule,
     const TArray<FStaticMeshBuildVertex>& vertexData,
     const TArray<uint32>& indices) {
@@ -2327,8 +2323,7 @@ static void BuildPhysXTriangleMeshes(
 
     FPhysXCookHelper cookHelper(pPhysXCookingModule);
 
-    bool copyUVs = UPhysicsSettings::Get()->bSupportUVFromHitResults &&
-                   metadataTextureCoordinateParameters.Num();
+    bool copyUVs = UPhysicsSettings::Get()->bSupportUVFromHitResults;
 
     cookHelper.CookInfo.TriMeshCookFlags = EPhysXMeshCookFlags::Default;
     cookHelper.CookInfo.OuterDebugName = "CesiumGltfComponent";

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -38,6 +38,7 @@
 #include "Materials/MaterialInstanceDynamic.h"
 #include "MeshTypes.h"
 #include "PhysicsEngine/BodySetup.h"
+#include "PhysicsEngine/PhysicsSettings.h"
 #include "PixelFormat.h"
 #include "Runtime/Launch/Resources/Version.h"
 #include "StaticMeshOperations.h"
@@ -2014,7 +2015,11 @@ static void loadPrimitiveGameThreadPart(
   // mesh or not. We don't want the editor creating collision meshes itself in
   // the game thread, because that would be slow.
   pBodySetup->bCreatedPhysicsMeshes = true;
-  pBodySetup->bSupportUVsAndFaceRemap = true;
+  pBodySetup->bSupportUVsAndFaceRemap =
+      UPhysicsSettings::Get()->bSupportUVFromHitResults &&
+      UCesiumMetadataPrimitiveBlueprintLibrary::GetFeatureIdTextures(
+          loadResult.Metadata)
+          .Num();
 
   // pMesh->SetMobility(EComponentMobility::Movable);
   pMesh->SetMobility(EComponentMobility::Static);


### PR DESCRIPTION
Fixes #874

We need to copy texture coordinates for all three types, Feature Textures, Feature ID textures and Feature ID attributes. 

An easy way to tell if a model/primitive may need the UV data is if ```metadataTextureCoordinateParameters``` is not empty.

TODO: Only copy the UV channels associated with metadata.