### PR TITLE
Globe Anchor Component - Rotation offset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 - The translucent parts of 3D Tiles are now correctly rendered as translucent.
 - Added a `TranslucentMaterial` property to `Cesium3DTileset`, allowing a custom material to be used to render the translucent portions of a tileset.
-- Added in 'SetRotationOffset' function to the 'CesiumGlobeAnchorComponent' so that 'SnapLocalUpToEllipsoidNormal' applies a rotational offset instead of matching the normal ellipsoid rotation.
+- Added in 'SetRotationOffset' function to the 'CesiumGlobeAnchorComponent' so that 'SnapToEastSouthUp' applies a rotational offset.
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - The translucent parts of 3D Tiles are now correctly rendered as translucent.
 - Added a `TranslucentMaterial` property to `Cesium3DTileset`, allowing a custom material to be used to render the translucent portions of a tileset.
+- Added in 'SetRotationOffset' function to the 'CesiumGlobeAnchorComponent' so that 'SnapLocalUpToEllipsoidNormal' applies a rotational offset instead of matching the normal ellipsoid rotation.
 
 ##### Fixes :wrench:
 

--- a/Source/CesiumRuntime/Public/CesiumGlobeAnchorComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGlobeAnchorComponent.h
@@ -245,14 +245,19 @@ public:
   /**
    * Rotates the Actor so that its +X axis points in the local East direction,
    * its +Y axis points in the local South direction, and its +Z axis points in
-   * the local Up direction.
+   * the local Up direction. Rotation offset is then applied to all three axes.
    */
   UFUNCTION(BlueprintCallable, CallInEditor, Category = "Cesium")
   void SnapToEastSouthUp();
 
   /**
-   * Sets the rotation offset to be applied when snapping to east/south/up or
-   * ellipsoid normal.
+   * Gets the rotation offset applied when snapping to east/south/up.
+   */
+  UFUNCTION(BlueprintCallable, CallInEditor, Category = "Cesium")
+  FRotator GetRotationOffset();
+
+  /**
+   * Sets the rotation offset applied when snapping to east/south/up.
    */
   UFUNCTION(BlueprintCallable, CallInEditor, Category = "Cesium")
   void SetRotationOffset(const FRotator& rotationOffset);
@@ -467,7 +472,7 @@ private:
   void _updateCartographicProperties();
 
   /**
-   * Rotation offset applied to the Actor.
+   * Rotation offset applied to the Actor when snapping to east/south/up.
    */
-  glm::dmat3 _rotationOffset;
+  FRotator _rotationOffset;
 };

--- a/Source/CesiumRuntime/Public/CesiumGlobeAnchorComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGlobeAnchorComponent.h
@@ -250,6 +250,13 @@ public:
   UFUNCTION(BlueprintCallable, CallInEditor, Category = "Cesium")
   void SnapToEastSouthUp();
 
+  /**
+   * Sets the rotation offset to be applied when snapping to east/south/up or
+   * ellipsoid normal.
+   */
+  UFUNCTION(BlueprintCallable, CallInEditor, Category = "Cesium")
+  void SetRotationOffset(const FRotator& rotationOffset);
+
 public:
   /**
    * Using the teleport flag will move objects to the updated transform
@@ -458,4 +465,9 @@ private:
    * globe transform.
    */
   void _updateCartographicProperties();
+
+  /**
+   * Rotation offset applied to the Actor.
+   */
+  glm::dmat3 _rotationOffset;
 };


### PR DESCRIPTION
This PR adds a rotation offset FRotator to the CesiumGlobeAnchorComponent so that when calling "SnapToEastSouthUp" the actor can have a rotational offset applied to it. This is particularly useful if working in blueprints with a class that has a strict un-editable root hierarchy.

I attempted to apply the offset to SnapLocalUpToEllipsoidNormal but thinking through it's purpose, it didn't make much sense to do so. A possible adjustment would be to apply the offset without tampering the actor's Yaw as that is preserved with this function and makes it very useful. Any ideas about that would be helpful, thank you!

Related issue #943 
CC: @xuelongmu, @nithinp7, @kring, @baothientran 

