### PR TITLE
Fixed PlatformFileManager naming

### DIFF
--- a/Source/CesiumEditor/Private/CesiumSourceControl.cpp
+++ b/Source/CesiumEditor/Private/CesiumSourceControl.cpp
@@ -1,6 +1,6 @@
 #include "CesiumSourceControl.h"
 #include "Framework/Notifications/NotificationManager.h"
-#include "HAL/PlatformFilemanager.h"
+#include "HAL/PlatformFileManager.h"
 #include "ISourceControlModule.h"
 #include "ISourceControlProvider.h"
 #include "Misc/MessageDialog.h"


### PR DESCRIPTION
Changed `#include "HAL/PlatformFilemanager.h"` to `#include "HAL/PlatformFileManager.h"` inline with Unreal Engine 5's name change

Related Issue: #953 