### PR TITLE
Prevent dedicated server from adding a ScreenCreditWidget.

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
@@ -153,7 +153,7 @@ void ACesiumCreditSystem::BeginPlay() {
     _creditsWidget =
         CreateWidget<UScreenCreditsWidget>(GetWorld(), CreditsWidgetClass);
   }
-  if (IsValid(_creditsWidget)) {
+  if (IsValid(_creditsWidget) && !IsRunningDedicatedServer()) {
     _creditsWidget->AddToViewport();
   }
 }


### PR DESCRIPTION
When trying to run CesiumForUnreal inside a dedicated server it will crash after trying to add the widget to the viewport. 

https://github.com/CesiumGS/cesium-unreal/issues/931