### PR TITLE
Make tilesets apply collision settings to all glTF primitives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug where collision settings were only being applied to the first primitive in a glTF.
+
 ### v1.17.0 - 2022-09-01
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1640,7 +1640,7 @@ void applyActorCollisionSettings(
 
   for (USceneComponent* ChildComponent : ChildrenComponents) {
     UCesiumGltfPrimitiveComponent* PrimitiveComponent =
-        Cast<UCesiumGltfPrimitiveComponent, USceneComponent>(ChildComponent);
+        Cast<UCesiumGltfPrimitiveComponent>(ChildComponent);
     if (PrimitiveComponent != nullptr) {
       if (PrimitiveComponent->GetCollisionObjectType() !=
           BodyInstance.GetObjectType()) {

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1640,7 +1640,7 @@ void applyActorCollisionSettings(
 
   for (USceneComponent* ChildComponent : ChildrenComponents) {
     UCesiumGltfPrimitiveComponent* PrimitiveComponent =
-        static_cast<UCesiumGltfPrimitiveComponent*>(ChildComponent);
+        Cast<UCesiumGltfPrimitiveComponent, USceneComponent>(ChildComponent);
     if (PrimitiveComponent != nullptr) {
       if (PrimitiveComponent->GetCollisionObjectType() !=
           BodyInstance.GetObjectType()) {

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1635,8 +1635,7 @@ void removeCollisionForTiles(
 void applyActorCollisionSettings(
     const FBodyInstance& BodyInstance,
     UCesiumGltfComponent* Gltf) {
-  TArray<USceneComponent*> ChildrenComponents;
-  Gltf->GetChildrenComponents(false, ChildrenComponents);
+  const TArray<USceneComponent*>& ChildrenComponents = Gltf->GetAttachChildren();
 
   for (USceneComponent* ChildrenComponent : ChildrenComponents) {
     UCesiumGltfPrimitiveComponent* PrimitiveComponent =

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1635,11 +1635,12 @@ void removeCollisionForTiles(
 void applyActorCollisionSettings(
     const FBodyInstance& BodyInstance,
     UCesiumGltfComponent* Gltf) {
-  const TArray<USceneComponent*>& ChildrenComponents = Gltf->GetAttachChildren();
+  const TArray<USceneComponent*>& ChildrenComponents =
+      Gltf->GetAttachChildren();
 
-  for (USceneComponent* ChildrenComponent : ChildrenComponents) {
+  for (USceneComponent* ChildComponent : ChildrenComponents) {
     UCesiumGltfPrimitiveComponent* PrimitiveComponent =
-        static_cast<UCesiumGltfPrimitiveComponent*>(ChildrenComponent);
+        static_cast<UCesiumGltfPrimitiveComponent*>(ChildComponent);
     if (PrimitiveComponent != nullptr) {
       if (PrimitiveComponent->GetCollisionObjectType() !=
           BodyInstance.GetObjectType()) {

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1635,18 +1635,24 @@ void removeCollisionForTiles(
 void applyActorCollisionSettings(
     const FBodyInstance& BodyInstance,
     UCesiumGltfComponent* Gltf) {
-  UCesiumGltfPrimitiveComponent* PrimitiveComponent =
-      static_cast<UCesiumGltfPrimitiveComponent*>(Gltf->GetChildComponent(0));
-  if (PrimitiveComponent != nullptr) {
-    if (PrimitiveComponent->GetCollisionObjectType() !=
-        BodyInstance.GetObjectType()) {
-      PrimitiveComponent->SetCollisionObjectType(BodyInstance.GetObjectType());
-    }
-    const UEnum* ChannelEnum = StaticEnum<ECollisionChannel>();
-    if (ChannelEnum) {
-      FCollisionResponseContainer responseContainer =
-          BodyInstance.GetResponseToChannels();
-      PrimitiveComponent->SetCollisionResponseToChannels(responseContainer);
+  TArray<USceneComponent*> ChildrenComponents;
+  Gltf->GetChildrenComponents(false, ChildrenComponents);
+
+  for (USceneComponent* ChildrenComponent : ChildrenComponents) {
+    UCesiumGltfPrimitiveComponent* PrimitiveComponent =
+        static_cast<UCesiumGltfPrimitiveComponent*>(ChildrenComponent);
+    if (PrimitiveComponent != nullptr) {
+      if (PrimitiveComponent->GetCollisionObjectType() !=
+          BodyInstance.GetObjectType()) {
+        PrimitiveComponent->SetCollisionObjectType(
+            BodyInstance.GetObjectType());
+      }
+      const UEnum* ChannelEnum = StaticEnum<ECollisionChannel>();
+      if (ChannelEnum) {
+        FCollisionResponseContainer responseContainer =
+            BodyInstance.GetResponseToChannels();
+        PrimitiveComponent->SetCollisionResponseToChannels(responseContainer);
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #742 . This PR modifies `applyActorCollisionSettings` such that the function iterates over all of the `UCesiumGltfComponent`'s children and applies the setting.