### PR TITLE
Add option to change mobility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Improved the dithered transition between levels-of-detail, making it faster and eliminating depth fighting.
+- Add an option on the `Cesium3DTileset` to change the tileset's mobility. This allows users to make tileset movable at runtime, if needed.  
 
 ##### Fixes :wrench:
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -108,7 +108,6 @@ ACesium3DTileset::ACesium3DTileset()
 
   this->RootComponent =
       CreateDefaultSubobject<UCesium3DTilesetRoot>(TEXT("Tileset"));
-  this->RootComponent->SetMobility(EComponentMobility::Static);
 
   PlatformName = UGameplayStatics::GetPlatformName();
 }
@@ -117,6 +116,13 @@ ACesium3DTileset::~ACesium3DTileset() { this->DestroyTileset(); }
 
 ACesiumGeoreference* ACesium3DTileset::GetGeoreference() const {
   return this->Georeference;
+}
+
+void ACesium3DTileset::SetMobility(EComponentMobility::Type NewMobility) {
+  if (NewMobility != this->Mobility) {
+    this->Mobility = NewMobility;
+    DestroyTileset();
+  }
 }
 
 void ACesium3DTileset::SetGeoreference(ACesiumGeoreference* NewGeoreference) {
@@ -855,6 +861,8 @@ void ACesium3DTileset::LoadTileset() {
   static TSharedRef<CesiumViewExtension, ESPMode::ThreadSafe>
       cesiumViewExtension =
           GEngine->ViewExtensions->NewExtension<CesiumViewExtension>();
+
+  this->RootComponent->SetMobility(Mobility);
 
   if (this->_pTileset) {
     // Tileset already loaded, do nothing.
@@ -1989,6 +1997,7 @@ void ACesium3DTileset::PostEditChangeProperty(
       PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, ApplyDpiScaling) ||
       PropName ==
           GET_MEMBER_NAME_CHECKED(ACesium3DTileset, EnableOcclusionCulling) ||
+      PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, Mobility) ||
       // For properties nested in structs, GET_MEMBER_NAME_CHECKED will prefix
       // with the struct name, so just do a manual string comparison.
       PropNameAsString == TEXT("RenderCustomDepth") ||

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -2018,8 +2018,7 @@ static void loadPrimitiveGameThreadPart(
   pBodySetup->bSupportUVsAndFaceRemap =
       UPhysicsSettings::Get()->bSupportUVFromHitResults;
 
-  // pMesh->SetMobility(EComponentMobility::Movable);
-  pMesh->SetMobility(EComponentMobility::Static);
+  pMesh->SetMobility(pGltf->Mobility);
 
   // pMesh->bDrawMeshCollisionIfComplex = true;
   // pMesh->bDrawMeshCollisionIfSimple = true;
@@ -2057,7 +2056,7 @@ UCesiumGltfComponent::CreateOffGameThread(
 
   UCesiumGltfComponent* Gltf = NewObject<UCesiumGltfComponent>(pParentActor);
   Gltf->SetUsingAbsoluteLocation(true);
-  Gltf->SetMobility(EComponentMobility::Static);
+  Gltf->SetMobility(pParentActor->GetRootComponent()->Mobility);
   Gltf->SetFlags(RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
 
   Gltf->Metadata = std::move(pReal->loadModelResult.Metadata);

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -12,6 +12,7 @@
 #include "CesiumGeoreference.h"
 #include "CoreMinimal.h"
 #include "CustomDepthParameters.h"
+#include "Engine/EngineTypes.h"
 #include "GameFramework/Actor.h"
 #include "Interfaces/IHttpRequest.h"
 #include "PrimitiveSceneProxy.h"
@@ -76,6 +77,34 @@ class CESIUMRUNTIME_API ACesium3DTileset : public AActor {
 public:
   ACesium3DTileset();
   virtual ~ACesium3DTileset();
+
+private:
+  /**
+   * The component mobility to use for the tileset.
+   */
+  UPROPERTY(
+      EditAnywhere,
+      BlueprintReadWrite,
+      BlueprintGetter = "GetMobility",
+      BlueprintSetter = "SetMobility",
+      Category = "Cesium",
+      Meta = (AllowPrivateAccess))
+  TEnumAsByte<EComponentMobility::Type> Mobility = EComponentMobility::Static;
+
+public:
+  /**
+   * Set a component mobility to use for this tileset.
+   */
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  EComponentMobility::Type GetMobility() const {
+    return (EComponentMobility::Type)Mobility;
+  }
+
+  /**
+   * Set a component mobility to use for this tileset.
+   */
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  void SetMobility(EComponentMobility::Type NewMobility);
 
 private:
   /**


### PR DESCRIPTION
We recently changed the components in Cesium3DTilesets to have static mobility (previously they were movable), allowing for several optimizations in the engine. In certain use cases however, it may still be useful to have a movable tileset. This PR adds an option in the Cesium3DTileset details panel to change the default mobility.

Fixes #970 