### PR TITLE
Make credit system's widget publicly accessible.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Improved the dithered transition between levels-of-detail, making it faster and eliminating depth fighting.
+- `ACesiumCreditSystem` now has a Blueprint-accessible property for the `CreditsWidget`. This is useful to, for example, move the credits to an in-game billboard rather than a 2D overlay.
 
 ##### Fixes :wrench:
 

--- a/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
@@ -149,12 +149,12 @@ ACesiumCreditSystem::ACesiumCreditSystem()
 
 void ACesiumCreditSystem::BeginPlay() {
   Super::BeginPlay();
-  if (!_creditsWidget) {
-    _creditsWidget =
+  if (!CreditsWidget) {
+    CreditsWidget =
         CreateWidget<UScreenCreditsWidget>(GetWorld(), CreditsWidgetClass);
   }
-  if (IsValid(_creditsWidget) && !IsRunningDedicatedServer()) {
-    _creditsWidget->AddToViewport();
+  if (IsValid(CreditsWidget) && !IsRunningDedicatedServer()) {
+    CreditsWidget->AddToViewport();
   }
 }
 
@@ -163,7 +163,7 @@ bool ACesiumCreditSystem::ShouldTickIfViewportsOnly() const { return true; }
 void ACesiumCreditSystem::Tick(float DeltaTime) {
   Super::Tick(DeltaTime);
 
-  if (!_pCreditSystem || !IsValid(_creditsWidget)) {
+  if (!_pCreditSystem || !IsValid(CreditsWidget)) {
     return;
   }
 
@@ -207,7 +207,7 @@ void ACesiumCreditSystem::Tick(float DeltaTime) {
       }
     }
     OnScreenCredits += "<credits url=\"popup\" text=\" Data attribution\"/>";
-    _creditsWidget->SetCredits(Credits, OnScreenCredits);
+    CreditsWidget->SetCredits(Credits, OnScreenCredits);
   }
   _pCreditSystem->startNextFrame();
 }
@@ -283,7 +283,7 @@ FString ACesiumCreditSystem::ConvertHtmlToRtf(std::string html) {
   std::string output, url;
   err = tidyParseString(tdoc, html.c_str());
   if (err < 2) {
-    convertHtmlToRtf(output, url, tdoc, tidyGetRoot(tdoc), _creditsWidget);
+    convertHtmlToRtf(output, url, tdoc, tidyGetRoot(tdoc), CreditsWidget);
   }
   tidyBufFree(&tidy_errbuf);
   tidyRelease(tdoc);

--- a/Source/CesiumRuntime/Public/CesiumCreditSystem.h
+++ b/Source/CesiumRuntime/Public/CesiumCreditSystem.h
@@ -42,6 +42,9 @@ public:
   UPROPERTY(BlueprintReadOnly, Category = "Cesium")
   bool CreditsUpdated = false;
 
+  UPROPERTY(BlueprintReadOnly, Category = "Cesium")
+  class UScreenCreditsWidget* CreditsWidget;
+
   // Called every frame
   virtual bool ShouldTickIfViewportsOnly() const override;
   virtual void Tick(float DeltaTime) override;
@@ -53,9 +56,6 @@ public:
 
 private:
   static UClass* CesiumCreditSystemBP;
-
-  UPROPERTY()
-  class UScreenCreditsWidget* _creditsWidget;
 
   /**
    * A tag that is assigned to Credit Systems when they are created


### PR DESCRIPTION
This is useful for Project Anywhere XR so that the credits can be displayed on an in-game 3D billboard, rather than as a 2D overlay on the screen. CC @AlbanBERGERET-Epic 