### PR TITLE
Fix broken euler angles and quaternion conversions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,11 @@
 - Significantly reduced frame-rate dips during asynchronous tile loading by eliminating thread pool monopilaztion by Cesium tasks.
 - Improved the tile destruction sequence by allowing it to defer being destroyed to future frames if it is waiting on asynchronous work to finish. Previously we would essentially block the main thread waiting for tiles to become ready for destruction.
 
+
+##### Breaking Changes :mega:
+
+- Removed a number of buggy funnctions on the `CesiumGeoreference`: `ComputeEastNorthUp`, `TransformRotatorEastNorthUpToUnreal`, and `TransformRotatorUnrealToEastNorthUp`. These functions were replaced with "EastSouthUp" counterparts.
+
 ### v1.18.0 - 2022-10-03
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -911,55 +911,55 @@ ACesiumGeoreference::InaccurateTransformUnrealToEcef(const FVector& ue) const {
   return FVector(ecef.x, ecef.y, ecef.z);
 }
 
-glm::dquat ACesiumGeoreference::TransformRotatorUnrealToEastNorthUp(
+glm::dquat ACesiumGeoreference::TransformRotatorUnrealToEastSouthUp(
     const glm::dquat& UeRotator,
     const glm::dvec3& UeLocation) const {
-  return this->_geoTransforms.TransformRotatorUnrealToEastNorthUp(
+  return this->_geoTransforms.TransformRotatorUnrealToEastSouthUp(
       glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       UeRotator,
       UeLocation);
 }
 
-FRotator ACesiumGeoreference::InaccurateTransformRotatorUnrealToEastNorthUp(
+FRotator ACesiumGeoreference::InaccurateTransformRotatorUnrealToEastSouthUp(
     const FRotator& UERotator,
     const FVector& ueLocation) const {
-  glm::dquat q = TransformRotatorUnrealToEastNorthUp(
+  glm::dquat q = TransformRotatorUnrealToEastSouthUp(
       VecMath::createQuaternion(UERotator.Quaternion()),
       VecMath::createVector3D(ueLocation));
   return VecMath::createRotator(q);
 }
 
-glm::dquat ACesiumGeoreference::TransformRotatorEastNorthUpToUnreal(
-    const glm::dquat& EnuRotator,
+glm::dquat ACesiumGeoreference::TransformRotatorEastSouthUpToUnreal(
+    const glm::dquat& EsuRotator,
     const glm::dvec3& UeLocation) const {
-  return this->_geoTransforms.TransformRotatorEastNorthUpToUnreal(
+  return this->_geoTransforms.TransformRotatorEastSouthUpToUnreal(
       glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
-      EnuRotator,
+      EsuRotator,
       UeLocation);
 }
 
-FRotator ACesiumGeoreference::InaccurateTransformRotatorEastNorthUpToUnreal(
-    const FRotator& ENURotator,
+FRotator ACesiumGeoreference::InaccurateTransformRotatorEastSouthUpToUnreal(
+    const FRotator& EsuRotator,
     const FVector& ueLocation) const {
-  glm::dquat q = TransformRotatorEastNorthUpToUnreal(
-      VecMath::createQuaternion(ENURotator.Quaternion()),
+  glm::dquat q = TransformRotatorEastSouthUpToUnreal(
+      VecMath::createQuaternion(EsuRotator.Quaternion()),
       VecMath::createVector3D(ueLocation));
   return VecMath::createRotator(q);
 }
 
 glm::dmat3
-ACesiumGeoreference::ComputeEastNorthUpToUnreal(const glm::dvec3& ue) const {
-  return _geoTransforms.ComputeEastNorthUpToUnreal(
+ACesiumGeoreference::ComputeEastSouthUpToUnreal(const glm::dvec3& ue) const {
+  return _geoTransforms.ComputeEastSouthUpToUnreal(
       glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       ue);
 }
 
-FMatrix ACesiumGeoreference::InaccurateComputeEastNorthUpToUnreal(
+FMatrix ACesiumGeoreference::InaccurateComputeEastSouthUpToUnreal(
     const FVector& ue) const {
-  glm::dmat3 enuToUnreal = this->_geoTransforms.ComputeEastNorthUpToUnreal(
+  glm::dmat3 esuToUe = this->_geoTransforms.ComputeEastSouthUpToUnreal(
       glm::dvec3(CesiumActors::getWorldOrigin4D(this)),
       glm::dvec3(ue.X, ue.Y, ue.Z));
-  return VecMath::createMatrix(enuToUnreal);
+  return VecMath::createMatrix(esuToUe);
 }
 
 glm::dmat3

--- a/Source/CesiumRuntime/Private/GeoTransforms.cpp
+++ b/Source/CesiumRuntime/Private/GeoTransforms.cpp
@@ -137,8 +137,6 @@ glm::dquat GeoTransforms::TransformRotatorUnrealToEastSouthUp(
     const glm::dvec3& ueLocation) const noexcept {
   glm::dmat3 esuToUe = this->ComputeEastSouthUpToUnreal(origin, ueLocation);
   glm::dmat3 ueToEsu = glm::affineInverse(esuToUe);
-  // TODO: check this mat-->quat conversion isn't affected by handedness
-  // (needs to work in left-handed system)
   glm::dquat ueToEsuQuat = glm::quat_cast(ueToEsu);
   return ueToEsuQuat * UERotator;
 }
@@ -149,9 +147,6 @@ glm::dquat GeoTransforms::TransformRotatorEastSouthUpToUnreal(
     const glm::dvec3& ueLocation) const noexcept {
 
   glm::dmat3 esuToUe = this->ComputeEastSouthUpToUnreal(origin, ueLocation);
-  // TODO: is this matrix to quaternion conversion affected by handedness?
-  // Remember we are in Unreal's left-handedness. In fact that's why we use
-  // ESU instead of ENU.
   glm::dquat esuToUeQuat = glm::quat_cast(esuToUe);
   return esuToUeQuat * ESURotator;
 }

--- a/Source/CesiumRuntime/Private/GeoTransforms.cpp
+++ b/Source/CesiumRuntime/Private/GeoTransforms.cpp
@@ -131,36 +131,37 @@ glm::dvec3 GeoTransforms::TransformUnrealToEcef(
   return glm::dvec3(this->_ueAbsToEcef * glm::dvec4(ueAbs, 1.0));
 }
 
-glm::dquat GeoTransforms::TransformRotatorUnrealToEastNorthUp(
+glm::dquat GeoTransforms::TransformRotatorUnrealToEastSouthUp(
     const glm::dvec3& origin,
     const glm::dquat& UERotator,
     const glm::dvec3& ueLocation) const noexcept {
-  glm::dmat3 enuToFixedUE =
-      this->ComputeEastNorthUpToUnreal(origin, ueLocation);
-  glm::dquat enuAdjustmentQuat = glm::quat_cast(enuToFixedUE);
-  return enuAdjustmentQuat * UERotator;
+  glm::dmat3 esuToUe = this->ComputeEastSouthUpToUnreal(origin, ueLocation);
+  glm::dmat3 ueToEsu = glm::affineInverse(esuToUe);
+  // TODO: check this mat-->quat conversion isn't affected by handedness
+  // (needs to work in left-handed system)
+  glm::dquat ueToEsuQuat = glm::quat_cast(ueToEsu);
+  return ueToEsuQuat * UERotator;
 }
 
-glm::dquat GeoTransforms::TransformRotatorEastNorthUpToUnreal(
+glm::dquat GeoTransforms::TransformRotatorEastSouthUpToUnreal(
     const glm::dvec3& origin,
-    const glm::dquat& ENURotator,
+    const glm::dquat& ESURotator,
     const glm::dvec3& ueLocation) const noexcept {
 
-  glm::dmat3 enuToFixedUE =
-      this->ComputeEastNorthUpToUnreal(origin, ueLocation);
-  glm::dmat3 fixedUeToEnu = glm::affineInverse(enuToFixedUE);
-  glm::dquat fixedUeToEnuQuat = glm::quat_cast(fixedUeToEnu);
-  return fixedUeToEnuQuat * ENURotator;
+  glm::dmat3 esuToUe = this->ComputeEastSouthUpToUnreal(origin, ueLocation);
+  // TODO: is this matrix to quaternion conversion affected by handedness?
+  // Remember we are in Unreal's left-handedness. In fact that's why we use
+  // ESU instead of ENU.
+  glm::dquat esuToUeQuat = glm::quat_cast(esuToUe);
+  return esuToUeQuat * ESURotator;
 }
 
-glm::dmat3 GeoTransforms::ComputeEastNorthUpToUnreal(
+glm::dmat3 GeoTransforms::ComputeEastSouthUpToUnreal(
     const glm::dvec3& origin,
     const glm::dvec3& ue) const noexcept {
   glm::dvec3 ecef = this->TransformUnrealToEcef(origin, ue);
   glm::dmat3 enuToEcef = this->ComputeEastNorthUpToEcef(ecef);
 
-  // Camera Axes = ENU
-  // Unreal Axes = controlled by Georeference
   glm::dmat3 rotationCesium =
       glm::dmat3(this->_ecefToGeoreferenced) * enuToEcef;
 

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -70,11 +70,11 @@ FRotator AGlobeAwareDefaultPawn::GetViewRotation() const {
   FRotator localRotation = Controller->GetControlRotation();
 
   // Transform the rotation in the ESU frame to the Unreal world frame.
-  FMatrix enuAdjustmentMatrix =
-      this->GetGeoreference()->InaccurateComputeEastNorthUpToUnreal(
+  FMatrix esuAdjustmentMatrix =
+      this->GetGeoreference()->InaccurateComputeEastSouthUpToUnreal(
           this->GetPawnViewLocation());
 
-  return FRotator(enuAdjustmentMatrix.ToQuat() * localRotation.Quaternion());
+  return FRotator(esuAdjustmentMatrix.ToQuat() * localRotation.Quaternion());
 }
 
 FRotator AGlobeAwareDefaultPawn::GetBaseAimRotation() const {

--- a/Source/CesiumRuntime/Private/VecMath.cpp
+++ b/Source/CesiumRuntime/Private/VecMath.cpp
@@ -157,18 +157,29 @@ FVector VecMath::createVector(const glm::dvec3& v) noexcept {
 FRotator VecMath::createRotator(const glm::dmat4& m) noexcept {
   // Avoid converting to Unreal single-precision types until the very end, so
   // that all intermediate conversions are performed in double-precision.
+  // TODO: does handedness affect this?
   return VecMath::createRotator(quat_cast(m));
 }
 
 FRotator VecMath::createRotator(const glm::dmat3& m) noexcept {
+  // TODO: does handedness affect this?
   return VecMath::createRotator(quat_cast(m));
 }
 
 FRotator VecMath::createRotator(const glm::dquat& q) noexcept {
-  return FRotator(
+  // TODO: I think this is wrong - this uses glm's pitch, yaw, roll.
+  // GLM is usually agnostic of what "world" directions each axis represents,
+  // but here pitch, yaw, and roll assume a particular interpretation of
+  // the axes as forward, left, and up. In addition to all of this, glm is
+  // right-handed and Unreal is left-handed!
+  /*return FRotator(
       CesiumUtility::Math::radiansToDegrees(pitch(q)),
       CesiumUtility::Math::radiansToDegrees(yaw(q)),
-      CesiumUtility::Math::radiansToDegrees(roll(q)));
+      CesiumUtility::Math::radiansToDegrees(roll(q)));*/
+
+  // This assumes that this quaternion is associated with the left-handed UE
+  // coordinate system.
+  return FRotator(FQuat(q.x, q.y, q.z, q.w));
 }
 
 FQuat VecMath::createQuaternion(const glm::dquat& q) noexcept {

--- a/Source/CesiumRuntime/Private/VecMath.cpp
+++ b/Source/CesiumRuntime/Private/VecMath.cpp
@@ -157,21 +157,14 @@ FVector VecMath::createVector(const glm::dvec3& v) noexcept {
 FRotator VecMath::createRotator(const glm::dmat4& m) noexcept {
   // Avoid converting to Unreal single-precision types until the very end, so
   // that all intermediate conversions are performed in double-precision.
-
-  // This assumes that this transform is associated with the left-handed UE
-  // coordintae system.
   return VecMath::createRotator(quat_cast(m));
 }
 
 FRotator VecMath::createRotator(const glm::dmat3& m) noexcept {
-  // This assumes that this matrix is associated with the left-handed UE
-  // coordintae system.
   return VecMath::createRotator(quat_cast(m));
 }
 
 FRotator VecMath::createRotator(const glm::dquat& q) noexcept {
-  // This assumes that this quaternion is associated with the left-handed UE
-  // coordinate system.
   return FRotator(FQuat(q.x, q.y, q.z, q.w));
 }
 

--- a/Source/CesiumRuntime/Private/VecMath.cpp
+++ b/Source/CesiumRuntime/Private/VecMath.cpp
@@ -157,26 +157,19 @@ FVector VecMath::createVector(const glm::dvec3& v) noexcept {
 FRotator VecMath::createRotator(const glm::dmat4& m) noexcept {
   // Avoid converting to Unreal single-precision types until the very end, so
   // that all intermediate conversions are performed in double-precision.
-  // TODO: does handedness affect this?
+
+  // This assumes that this transform is associated with the left-handed UE
+  // coordintae system.
   return VecMath::createRotator(quat_cast(m));
 }
 
 FRotator VecMath::createRotator(const glm::dmat3& m) noexcept {
-  // TODO: does handedness affect this?
+  // This assumes that this matrix is associated with the left-handed UE
+  // coordintae system.
   return VecMath::createRotator(quat_cast(m));
 }
 
 FRotator VecMath::createRotator(const glm::dquat& q) noexcept {
-  // TODO: I think this is wrong - this uses glm's pitch, yaw, roll.
-  // GLM is usually agnostic of what "world" directions each axis represents,
-  // but here pitch, yaw, and roll assume a particular interpretation of
-  // the axes as forward, left, and up. In addition to all of this, glm is
-  // right-handed and Unreal is left-handed!
-  /*return FRotator(
-      CesiumUtility::Math::radiansToDegrees(pitch(q)),
-      CesiumUtility::Math::radiansToDegrees(yaw(q)),
-      CesiumUtility::Math::radiansToDegrees(roll(q)));*/
-
   // This assumes that this quaternion is associated with the left-handed UE
   // coordinate system.
   return FRotator(FQuat(q.x, q.y, q.z, q.w));

--- a/Source/CesiumRuntime/Private/VecMath.h
+++ b/Source/CesiumRuntime/Private/VecMath.h
@@ -183,6 +183,9 @@ public:
    * The result will be an `FRotator`. Note that any translation and scaling
    * information will be lost.
    *
+   * This method assumes that `m` is already associated with the left-handed UE
+   * coordinate system.
+   *
    * @param m The `gl` matrix.
    * @return The `FRotator`.
    */
@@ -191,6 +194,9 @@ public:
   /**
    * @brief Create a `FRotator` from the given `glm` matrix.
    *
+   * This method assumes that `m` is already associated with the left-handed UE
+   * coordinate system.
+   *
    * @param m The `glm` matrix.
    * @return The `FRotator`.
    */
@@ -198,6 +204,9 @@ public:
 
   /**
    * @brief Create a `FRotator` from the given `glm` quaternion.
+   *
+   * This method assumes that `q` is already associated with the left-handed UE
+   * coordinate system.
    *
    * @param q The `glm` quaternion.
    * @return The `FRotator`.

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -404,67 +404,67 @@ public:
   FVector InaccurateTransformUnrealToEcef(const FVector& Unreal) const;
 
   /**
-   * Transforms a rotator from Unreal world to East-North-Up at the given
+   * Transforms a rotator from Unreal world to East-South-Up at the given
    * Unreal world location (relative to the floating origin).
    */
-  glm::dquat TransformRotatorUnrealToEastNorthUp(
+  glm::dquat TransformRotatorUnrealToEastSouthUp(
       const glm::dquat& UnrealRotator,
       const glm::dvec3& UnrealLocation) const;
 
   /**
-   * Transforms a rotator from Unreal world to East-North-Up at the given
+   * Transforms a rotator from Unreal world to East-South-Up at the given
    * Unreal world location (relative to the floating origin).
    *
    * This function peforms the computation in single-precision. When using
    * the C++ API, corresponding double-precision function
-   * TransformRotatorUnrealToEastNorthUp can be used.
+   * TransformRotatorUnrealToEastSouthUp can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
-  FRotator InaccurateTransformRotatorUnrealToEastNorthUp(
+  FRotator InaccurateTransformRotatorUnrealToEastSouthUp(
       const FRotator& UnrealRotator,
       const FVector& UnrealLocation) const;
 
   /**
-   * Transforms a rotator from East-North-Up to Unreal world at the given
+   * Transforms a rotator from East-South-Up to Unreal world at the given
    * Unreal world location (relative to the floating origin).
    */
-  glm::dquat TransformRotatorEastNorthUpToUnreal(
-      const glm::dquat& EnuRotator,
+  glm::dquat TransformRotatorEastSouthUpToUnreal(
+      const glm::dquat& EsuRotator,
       const glm::dvec3& UnrealLocation) const;
 
   /**
-   * Transforms a rotator from East-North-Up to Unreal world at the given
+   * Transforms a rotator from East-South-Up to Unreal world at the given
    * Unreal world location (relative to the floating origin).
    *
    * This function peforms the computation in single-precision. When using
    * the C++ API, corresponding double-precision function
-   * TransformRotatorEastNorthUpToUnreal can be used.
+   * TransformRotatorEastSouthUpToUnreal can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
-  FRotator InaccurateTransformRotatorEastNorthUpToUnreal(
-      const FRotator& EnuRotator,
+  FRotator InaccurateTransformRotatorEastSouthUpToUnreal(
+      const FRotator& EsuRotator,
       const FVector& UnrealLocation) const;
 
   /**
-   * Computes the rotation matrix from the local East-North-Up to Unreal at the
+   * Computes the rotation matrix from the local East-South-Up to Unreal at the
    * specified Unreal world location (relative to the floating
    * origin). The returned transformation works in Unreal's left-handed
    * coordinate system.
    */
-  glm::dmat3 ComputeEastNorthUpToUnreal(const glm::dvec3& unreal) const;
+  glm::dmat3 ComputeEastSouthUpToUnreal(const glm::dvec3& unreal) const;
 
   /**
-   * Computes the rotation matrix from the local East-North-Up to Unreal at the
+   * Computes the rotation matrix from the local East-South-Up to Unreal at the
    * specified Unreal world location (relative to the floating
    * origin). The returned transformation works in Unreal's left-handed
    * coordinate system.
    *
    * This function peforms the computation in single-precision. When using
    * the C++ API, corresponding double-precision function
-   * ComputeEastNorthUpToUnreal can be used.
+   * ComputeEastSouthUpToUnreal can be used.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
-  FMatrix InaccurateComputeEastNorthUpToUnreal(const FVector& Unreal) const;
+  FMatrix InaccurateComputeEastSouthUpToUnreal(const FVector& Unreal) const;
 
   /**
    * Computes the rotation matrix from the local East-North-Up to

--- a/Source/CesiumRuntime/Public/GeoTransforms.h
+++ b/Source/CesiumRuntime/Public/GeoTransforms.h
@@ -120,30 +120,30 @@ public:
       const glm::dvec3& Ue) const noexcept;
 
   /**
-   * Transforms a rotator from Unreal world to East-North-Up at the given
+   * Transforms a rotator from Unreal world to East-South-Up at the given
    * Unreal relative world location (relative to the floating origin).
    */
-  glm::dquat TransformRotatorUnrealToEastNorthUp(
+  glm::dquat TransformRotatorUnrealToEastSouthUp(
       const glm::dvec3& origin,
       const glm::dquat& UeRotator,
       const glm::dvec3& UeLocation) const noexcept;
 
   /**
-   * Transforms a rotator from East-North-Up to Unreal world at the given
+   * Transforms a rotator from East-South-Up to Unreal world at the given
    * Unreal world location (relative to the floating origin).
    */
-  glm::dquat TransformRotatorEastNorthUpToUnreal(
+  glm::dquat TransformRotatorEastSouthUpToUnreal(
       const glm::dvec3& origin,
       const glm::dquat& EnuRotator,
       const glm::dvec3& UeLocation) const noexcept;
 
   /**
-   * Computes the rotation matrix from the local East-North-Up to Unreal at the
+   * Computes the rotation matrix from the local East-South-Up to Unreal at the
    * specified Unreal world location (relative to the floating
    * origin). The returned transformation works in Unreal's left-handed
    * coordinate system.
    */
-  glm::dmat3 ComputeEastNorthUpToUnreal(
+  glm::dmat3 ComputeEastSouthUpToUnreal(
       const glm::dvec3& origin,
       const glm::dvec3& Ue) const noexcept;
 


### PR DESCRIPTION
Somewhat related to #265 and #733.

I think our East-North-Up <--> Unreal conversion functions in the Georeferencing API are quite broken. This PR attempts to fix some if not all of it. 

We had functions to transform rotators (pitch, yaw, roll) from ENU to Unreal and vice-versa. These were implemented by:
Step 1: Convert FRotators (pitch, yaw, roll) into quaternions.
Step 2: Compute the Unreal <--> ENU matrix and convert the rotation part into a quaternion.
Step 3: And then multiply the above two quaternions to transform a rotation between Unreal and ENU.
Step 4: And of course convert back from quaternion to pitch, yaw, roll at the end in the destination coordinate system.

Implementation mistakes fixed:
- There was a glaring mistake (made by me!) that flipped the direction of conversions between UE and ENU. So UE to ENU mistakenly converted from ENU to UE and vice-versa. In fact I had started fixing it here #733 but found that rotations still remained broken overall.
- It turns out ComputeEastNorthUpToUnreal was _actually_ computing a East-South-Up to Unreal pure rotation matrix! In fact some code calling this function from the GlobeAwareDefaultPawn and the GlobeAnchorComponent seemed to acknowledge in comments that the result was an ESU to Unreal rotation. 
- The rotator and quaternion conversion functions were built upon the above function and so were mistakenly doing ESU to UE and vice versa. In fact, an _actual_ ENU --> Unreal matrix converted to a quaternion (step 2) might be undefined (or at least incorrect to use) since ENU and Unreal have opposite handedness.
- Some code to convert back from glm quaternions to Unreal FRotators was innocently using the pitch(..), yaw(..), and roll(..) functions from the glm library. While glm is usually agnostic of coordinate system conventions (e.g., handedness, up-direction, etc.), computing pitch, yaw, and roll from a quaternion implies some assumed convention of which axis is up, right, and forward and an implied rotation-order convention for euler angles (or yaw, pitch, roll in this case). Even determining whether positive angles rotate CW or CCW for each axis comes down to convention. So it's no surprise that the assumed conventions of glm's quaternion --> pitch, yaw, roll did not match that of Unreal. 

My solution was primarily to get rid of ENU <--> UE conversions and just do ESU <--> UE instead. This will make it much easier to reason about the rotations since the rotation conventions and handedness will remain the same through the conversion.

TODOs before merge:
* [x] Address and remove TODOs in the code
* [x] Add backward compatibility via core-redirects where possible. Some of these functions were completely broken, so we'll have to weigh how likely it is somebody is relying on the broken version.
* [ ] Find a way to unit test this, even if it is ad-hoc! Or alternatively move this into Cesium Native and unit test there??

I started looking into this after seeing this community forum post recently:
https://community.cesium.com/t/correct-way-to-set-euler-angles-for-actor-in-c/20808