### PR TITLE
Make CesiumSunSky member variables public

### DIFF
--- a/Source/CesiumRuntime/Public/CesiumSunSky.h
+++ b/Source/CesiumRuntime/Public/CesiumSunSky.h
@@ -51,29 +51,6 @@ public:
   UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Cesium")
   UCesiumGlobeAnchorComponent* GlobeAnchor;
 
-protected:
-  /**
-   * THIS PROPERTY IS DEPRECATED.
-   *
-   * Get the Georeference instance from the Globe Anchor Component instead.
-   */
-  UPROPERTY(
-      BlueprintReadOnly,
-      Category = "Cesium",
-      BlueprintGetter = GetGeoreference,
-      Meta =
-          (DeprecatedProperty,
-           DeprecationMessage =
-               "Get the Georeference instance from the Globe Anchor Component instead."))
-  ACesiumGeoreference* Georeference_DEPRECATED;
-
-  /**
-   * Gets the Georeference Actor associated with this instance. It is obtained
-   * from the Globe Anchor Component.
-   */
-  UFUNCTION(BlueprintGetter, Category = "Cesium")
-  ACesiumGeoreference* GetGeoreference() const;
-
   /**
    * Gets the time zone, represented as hours offset from GMT.
    *
@@ -164,6 +141,29 @@ protected:
       Category = "Cesium|Date and Time|Daylight Savings")
   bool UseDaylightSavingTime = true;
 
+protected:
+  /**
+   * THIS PROPERTY IS DEPRECATED.
+   *
+   * Get the Georeference instance from the Globe Anchor Component instead.
+   */
+  UPROPERTY(
+      BlueprintReadOnly,
+      Category = "Cesium",
+      BlueprintGetter = GetGeoreference,
+      Meta =
+          (DeprecatedProperty,
+           DeprecationMessage =
+               "Get the Georeference instance from the Globe Anchor Component instead."))
+  ACesiumGeoreference* Georeference_DEPRECATED;
+
+  /**
+   * Gets the Georeference Actor associated with this instance. It is obtained
+   * from the Globe Anchor Component.
+   */
+  UFUNCTION(BlueprintGetter, Category = "Cesium")
+  ACesiumGeoreference* GetGeoreference() const;
+  
   /**
    * Set the Date at which DST starts in the current year.
    *

--- a/Source/CesiumRuntime/Public/CesiumSunSky.h
+++ b/Source/CesiumRuntime/Public/CesiumSunSky.h
@@ -163,7 +163,7 @@ protected:
    */
   UFUNCTION(BlueprintGetter, Category = "Cesium")
   ACesiumGeoreference* GetGeoreference() const;
-  
+
   /**
    * Set the Date at which DST starts in the current year.
    *


### PR DESCRIPTION
Made the following variables public so they can be edited from other classes:
- TimeZone
- SolarTime
- Day, Month, Year
- NorthOffset
- UseDaylightSavingsTime

The goal was to make the SunSky flexible so that as the user travels around different parts of the globe, the time settings can change accordingly.