### PR TITLE
Fix UE delegate removal error in ResolvedGeoreference->OnGeoreferenceUpdated

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -153,7 +153,7 @@ ACesiumGeoreference* ACesium3DTileset::ResolveGeoreference() {
 
 void ACesium3DTileset::InvalidateResolvedGeoreference() {
   if (IsValid(this->ResolvedGeoreference)) {
-    this->ResolvedGeoreference->OnGeoreferenceUpdated.RemoveAll(this);
+    this->ResolvedGeoreference->OnGeoreferenceUpdated.RemoveAll(this->RootComponent);
   }
   this->ResolvedGeoreference = nullptr;
 }


### PR DESCRIPTION
In function ACesium3DTileset::ResolveGeoreference(), OnGeoreferenceUpdated(delegate) binds to CesiumTileset's RootComponent;

`this->ResolvedGeoreference->OnGeoreferenceUpdated.AddUniqueDynamic(
        pRoot,
        &UCesium3DTilesetRoot::HandleGeoreferenceUpdated);`

However, in function ACesium3DTileset::InvalidateResolvedGeoreference(), OnGeoreferenceUpdated unbinds from Cesium3DTileset.

`this->ResolvedGeoreference->OnGeoreferenceUpdated.RemoveAll(this);`

This may cause unexpected problems in Cesium3DTileset when changing georeference.

By the way, this problem also exists in ue5 related branches.