### PR TITLE
Added Renderer as a private include path

### DIFF
--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -22,6 +22,7 @@ public class CesiumRuntime : ModuleRules
         PrivateIncludePaths.AddRange(
             new string[] {
                 // ... add other private include paths required here ...
+                Path.Combine(GetModuleDirectory("Renderer"), "Private")
             }
         );
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -47,6 +47,7 @@
 #include "GameFramework/PlayerController.h"
 #include "Kismet/GameplayStatics.h"
 #include "LevelSequenceActor.h"
+#include "LevelSequencePlayer.h"
 #include "Math/UnrealMathUtility.h"
 #include "Misc/EnumRange.h"
 #include "PhysicsPublicCore.h"


### PR DESCRIPTION
## Changes
 - Added Renderer as a private include path
 - included `LevelSequencePlayer.h` inside `Cesium3DTileset.cpp`

## Tests
 - Successfully packaged on Linux for Linux using RunUAT.sh
 - Successfully packaged on Windows for Windows in UE5.1 Editor

**Fixes**:
- #1000
- Issue mentioned [here](https://community.cesium.com/t/cesium-for-ue-5-1/21093/11) 
