### PR TITLE
Use legacy texture creation for mac and linux

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -40,6 +40,25 @@ void legacy_populateMips(
     bool generateMipMaps) {
   uint32 width = static_cast<uint32>(image.width);
   uint32 height = static_cast<uint32>(image.height);
+
+  if (image.mipPositions.empty()) {
+    // Only the full image is available.
+    FTexture2DMipMap* pMip = new FTexture2DMipMap();
+    platformData.Mips.Add(pMip);
+    pMip->SizeX = width;
+    pMip->SizeY = height;
+
+    pMip->BulkData.Lock(LOCK_READ_WRITE);
+    void* pDest =
+        pMip->BulkData.Realloc(static_cast<int64>(image.pixelData.size()));
+
+    FMemory::Memcpy(pDest, image.pixelData.data(), image.pixelData.size());
+
+    pMip->BulkData.Unlock();
+
+    return;
+  }
+
   for (const CesiumGltf::ImageCesiumMipPosition& mipPos : image.mipPositions) {
     FTexture2DMipMap* pMip = new FTexture2DMipMap();
     platformData.Mips.Add(pMip);

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -613,7 +613,6 @@ TUniquePtr<LoadedTextureResult> loadTextureAnyThreadPart(
     // data.
     pResult->textureSource = LegacyTextureSource{};
   }
-#endif
 
   return pResult;
 }

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -35,8 +35,10 @@ using namespace CesiumGltf;
 
 namespace {
 #if LEGACY_TEXTURE_CREATION
-// Legacy texture creation code path. Only for testing, no safety checks are
-// done.
+// Legacy texture creation code path - creates textures using Unreal's
+// FTexture2DMipMap and Texture2D::UpdateResource(). While this is slightly
+// less efficient than other approaches we've found, this is still the only
+// approach that works on certain platforms (as far as we currently know).
 
 void legacy_populateMips(
     FTexturePlatformData& platformData,

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -25,21 +25,15 @@
 #include <stb_image_resize.h>
 #include <variant>
 
-#if PLATFORM_LINUX || PLATFORM_MAC
-#define LEGACY_TEXTURE_CREATION 1
-#else
-#define LEGACY_TEXTURE_CREATION 0
-#endif
-
 using namespace CesiumGltf;
 
 namespace {
-#if LEGACY_TEXTURE_CREATION
 // Legacy texture creation code path - creates textures using Unreal's
 // FTexture2DMipMap and Texture2D::UpdateResource(). While this is slightly
-// less efficient than other approaches we've found, this is still the only
-// approach that works on certain platforms (as far as we currently know).
-
+// less efficient than other approaches we've found, the other approaches
+// are not always supported on certain platforms. Once image sources from tiles
+// and raster tiles can be safely read from the render-thread, this approach
+// should no longer be necessary.
 void legacy_populateMips(
     FTexturePlatformData& platformData,
     const CesiumGltf::ImageCesium& image,
@@ -76,7 +70,6 @@ void legacy_populateMips(
     }
   }
 }
-#endif
 
 struct GetImageFromSource {
   CesiumGltf::ImageCesium*
@@ -294,6 +287,12 @@ public:
         GetOrCreateSamplerState(deferredSamplerStateInitializer);
 
     if (!this->TextureRHI) {
+      // TODO: Currently copying from `ImageCesium` on the render-thread is
+      // unsafe. Currently we should never hit this code. Remove this in the
+      // future when images from tiles and raster tiles can be safely accessed
+      // from the render thread.
+      checkNoEntry();
+
       // Asynchronous RHI texture creation was not available. So create it now
       // directly from the in-memory cesium mips.
       CesiumGltf::ImageCesium* pImage =
@@ -593,13 +592,6 @@ TUniquePtr<LoadedTextureResult> loadTextureAnyThreadPart(
   pResult->sRGB = sRGB;
   pResult->generateMipMaps = generateMipMaps;
 
-#if LEGACY_TEXTURE_CREATION
-  // Legacy texture creation copies mip data into the FTexturePlatformData.
-  legacy_populateMips(*pResult->pTextureData, image, generateMipMaps);
-  // Mark the image source as legacy, so we later know where to look for image
-  // data.
-  pResult->textureSource = LegacyTextureSource{};
-#else
   if (GRHISupportsAsyncTextureCreation) {
     // Create RHI texture resource asynchronously.
     TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::CreateRHITexture2D)
@@ -609,7 +601,17 @@ TUniquePtr<LoadedTextureResult> loadTextureAnyThreadPart(
   } else {
     // The RHI texture will be created later on the render thread, directly
     // from this texture source.
-    pResult->textureSource = std::move(imageSource);
+    // pResult->textureSource = std::move(imageSource);
+
+    // TODO: Use the above texture creation path instead when the image source
+    // becomes render-thread safe in the future. Currently that is not the
+    // case for any `CesiumGltf::ImageCesium` from tiles or raster tiles.
+
+    // Legacy texture creation copies mip data into the FTexturePlatformData.
+    legacy_populateMips(*pResult->pTextureData, image, generateMipMaps);
+    // Mark the image source as legacy, so we later know where to look for image
+    // data.
+    pResult->textureSource = LegacyTextureSource{};
   }
 #endif
 

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -25,7 +25,11 @@
 #include <stb_image_resize.h>
 #include <variant>
 
+#if PLATFORM_LINUX || PLATFORM_MAC
+#define LEGACY_TEXTURE_CREATION 1
+#else
 #define LEGACY_TEXTURE_CREATION 0
+#endif
 
 using namespace CesiumGltf;
 


### PR DESCRIPTION
Hopefully this is a workaround for #1007, although it would be slightly better to get the current texture creation path to work for mac and linux. Both the Vulkan and Metal RHI implementations in Unreal do not have async texture creation implemented, so the current texture creation path on these platforms does the next best thing by avoiding a texture memcpy on the game thread (by wrapping the source texture memory into an Unreal-specific interface for direct GPU upload). But it won't be a huge loss to go back to the legacy texture creation code paths on these platforms.

TODO:
- Do we need to hardcode any other platforms to use the legacy code path, Android maybe? 