### PR TITLE
Fix Android game package failure in UE 5.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,6 +294,7 @@ jobs:
           ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.0.0"','"EngineVersion": "5.1.0"') | Set-Content -Path CesiumForUnreal.uplugin
           $ENV:ANDROID_NDK_ROOT=$ENV:ANDROID_NDK_ROOT25
           $ENV:NDKROOT=$ENV:NDKROOT25
+
           # UE 5.1 seems to have a bug where the Android precompiled files are in the wrong place.
           # See https://forums.unrealengine.com/t/5-1-missing-precompiled-manifest-error-when-building-code-plugin-for-android/691983
           # So we fix it here.
@@ -306,9 +307,14 @@ jobs:
             mkdir -p "$newPath"
             New-Item -ItemType Junction -Path "$newPath\UnrealGame" -Target "$_"
           }
+
           # Do the actual plugin build
           cd "C:/Program Files/Epic Games/UE_5.1/Engine/Build/BatchFiles"
           ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Android -NoHostPlatform
+
+          # But then the built plugin will have `Intermediate/Build/Android/arm64/UnrealGame` instead of `Intermediate/Build/Android/arm64/UnrealGame`
+          # which will cause problems when we try to package a game for Android. So fix that up.
+          mv $ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal/Intermediate/Build/Android/arm64/UnrealGame $ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal/Intermediate/Build/Android/UnrealGame
       - name: Publish plugin package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
UE 5.1 seems to have [a bug](https://forums.unrealengine.com/t/5-1-missing-precompiled-manifest-error-when-building-code-plugin-for-android/691983) that prevents packaging plugins for Android. I worked around this by moving some files around in the  UE directory. That allows us to package the plugin for Android successfully, but unfortunately when we later try to package a _game_ using that plugin, we get errors. These errors are basically the opposite of the errors during plugin packaging: the plugin includes an `arm64` directory and the game packaging doesn't expect it. So this PR adds a step to hack up the plugin after it's packaged so that it will later work at game package time.