### PR TITLE
Add property for custom ion endpoint in CesiumIonRasterOverlay

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumIonRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumIonRasterOverlay.cpp
@@ -22,6 +22,14 @@ UCesiumIonRasterOverlay::CreateOverlay(
       this->IonAccessToken.IsEmpty()
           ? GetDefault<UCesiumRuntimeSettings>()->DefaultIonAccessToken
           : this->IonAccessToken;
+  if(!this->IonAssetEndpointUrl.IsEmpty()) {
+    return std::make_unique<Cesium3DTilesSelection::IonRasterOverlay>(
+      TCHAR_TO_UTF8(*this->MaterialLayerKey),
+      this->IonAssetID,
+      TCHAR_TO_UTF8(*token),
+      options,
+      TCHAR_TO_UTF8(*this->IonAssetEndpointUrl));
+  }
   return std::make_unique<Cesium3DTilesSelection::IonRasterOverlay>(
       TCHAR_TO_UTF8(*this->MaterialLayerKey),
       this->IonAssetID,

--- a/Source/CesiumRuntime/Public/CesiumIonRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumIonRasterOverlay.h
@@ -33,6 +33,17 @@ public:
   FString IonAccessToken;
 
   /**
+ * The URL of the ion asset endpoint. Defaults to Cesium ion but a custom
+ * endpoint can be specified.
+ */
+  UPROPERTY(
+      EditAnywhere,
+      BlueprintReadWrite,
+      Category = "Cesium",
+      AdvancedDisplay)
+  FString IonAssetEndpointUrl;
+
+  /**
    * Check if the Cesium ion token used to access this raster overlay is working
    * correctly, and fix it if necessary.
    */


### PR DESCRIPTION
Corresponding Unreal PR https://github.com/CesiumGS/cesium-native/pull/580 to to add a UPROPERTY field IonAssetEndpointUrl to the CesiumIonRasterOverlay component.