### PR TITLE
Fix flipped longitude/latitude on newly-created sub-levels.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that caused newly-created sub-levels to have their longitude and latitude parameters flipped relative to the current location of the `CesiumGeoreference`.
+
 ### v1.20.1 - 2022-12-09
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -337,8 +337,8 @@ void ACesiumGeoreference::_updateCesiumSubLevels() {
       this->CesiumSubLevels.Add(FCesiumSubLevel{
           longPackageNameToCesiumName(pWorld, level.PackageName),
           canBeEnabled,
-          OriginLongitude,
           OriginLatitude,
+          OriginLongitude,
           OriginHeight,
           1000.0,
           canBeEnabled});
@@ -1092,8 +1092,8 @@ FCesiumSubLevel* ACesiumGeoreference::_findCesiumSubLevelByName(
     this->CesiumSubLevels.Add(FCesiumSubLevel{
         cesiumName,
         true,
-        this->OriginLongitude,
         this->OriginLatitude,
+        this->OriginLongitude,
         this->OriginHeight,
         1000.0,
         true});


### PR DESCRIPTION
As reported here:
https://community.cesium.com/t/sublevels-in-ue5-broken/21475/5