### PR TITLE
Declare UE modules as public dependencies, not private

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug where Cesium for Unreal depended on a number of Unreal modules _privately_, but then used them from public headers. These are now declared as public dependencies. This could lead to compile errors in previous versions when attempting to include Cesium for Unreal headers from outside the project without also explicitly declaring `UMG` and other modules as dependencies.
+
 ### v1.20.1 - 2022-12-09
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -134,14 +134,6 @@ public class CesiumRuntime : ModuleRules
             new string[]
             {
                 "Core",
-                // ... add other public dependencies that you statically link with here ...
-            }
-        );
-
-
-        PrivateDependencyModuleNames.AddRange(
-            new string[]
-            {
                 "RHI",
                 "CoreUObject",
                 "Engine",


### PR DESCRIPTION
This is necessary because, at least in some cases, we `#include` headers from these modules in our own public headers. If these modules aren't declared public, projects that try to include our headers will get compiler errors unless they explicitly depend on the necessary modules.

See:
https://community.cesium.com/t/unable-to-package-ue5-0-3-project-with-cesium-v1-19-0/21162
