### PR TITLE
Fix broken materials in Unreal Engine 5.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
           fetch-depth: 0 # so that `git describe` works.
       - name: Set environment variables
         run: |
+          choco install -y visualstudio2019-workload-manageddesktop
           $ENV:CESIUM_UNREAL_VERSION=$(git describe)
           $ENV:BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-50-windows-${ENV:CESIUM_UNREAL_VERSION}"
           # Make these available to subsequent steps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
           fetch-depth: 0 # so that `git describe` works.
       - name: Set environment variables
         run: |
-          choco install -y dotnetcore-runtime.install --version=3.1.1
+          choco install -y dotnetcore-sdk
           $ENV:CESIUM_UNREAL_VERSION=$(git describe)
           $ENV:BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-50-windows-${ENV:CESIUM_UNREAL_VERSION}"
           # Make these available to subsequent steps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,7 +292,7 @@ jobs:
             $oldPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PWD, $_))
             $newPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PWD, $_, "..", "arm64"))
             mkdir -p "$newPath"
-            New-Item -ItemType Junction -Path "$newPath\UnrealGame" -Target "$_"
+            New-Item -ItemType Junction -Path "$newPath\UnrealGame" -Target "$oldPath"
           }
 
           # Do the actual plugin build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
           fetch-depth: 0 # so that `git describe` works.
       - name: Set environment variables
         run: |
-          choco install -y visualstudio2019-workload-manageddesktop
+          choco install -y dotnetcore-runtime.install --version=3.1.1
           $ENV:CESIUM_UNREAL_VERSION=$(git describe)
           $ENV:BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-50-windows-${ENV:CESIUM_UNREAL_VERSION}"
           # Make these available to subsequent steps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
           name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}.zip
           path: packages
   macOS50:
-    runs-on: macos-latest
+    runs-on: macos-11
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -140,7 +140,7 @@ jobs:
           name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}.zip
           path: packages
   iOS50:
-    runs-on: macos-latest
+    runs-on: macos-11
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ##### Fixes :wrench:
 
+- Fixed a bug that caused raster overlays to not work for materials created or saved in Unreal Engine 5.1.
 - Disable normals for unlit materials, which caused photogrammetry to appear too dark, when "KHR\_materials\_unlit" extension is used.
 
 ### v1.21.0 - 2023-01-02

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Fixes :wrench:
 
-- Fixed a bug that caused raster overlays to not work for materials created or saved in Unreal Engine 5.1.
+- Fixed a bug that caused raster overlays and other materials features to not work for materials created or saved in Unreal Engine 5.1.
 - Disable normals for unlit materials, which caused photogrammetry to appear too dark, when "KHR\_materials\_unlit" extension is used.
 
 ### v1.21.0 - 2023-01-02

--- a/Source/CesiumRuntime/Private/CesiumMaterialUserData.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMaterialUserData.cpp
@@ -14,17 +14,23 @@ void UCesiumMaterialUserData::PostEditChangeOwner() {
   if (pMaterial) {
     const FStaticParameterSet& parameters = pMaterial->GetStaticParameters();
 
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+    const TArray<FText>& layerNames = parameters.EditorOnly.MaterialLayers.LayerNames;
+
+    this->LayerNames.Reserve(layerNames.Num());
+
+    for (int32 i = 0; i < layerNames.Num(); ++i) {
+      this->LayerNames.Add(layerNames[i].ToString());
+    }
+#else
     const auto& layerParameters = parameters.MaterialLayers;
 
     this->LayerNames.Reserve(layerParameters.Layers.Num());
 
     for (int32 i = 0; i < layerParameters.Layers.Num(); ++i) {
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION == 0
       this->LayerNames.Add(layerParameters.GetLayerName(i).ToString());
-#else
-      this->LayerNames.Add(layerParameters.Layers[i].GetName());
-#endif
     }
+#endif
   }
 #endif
 }


### PR DESCRIPTION
UE 5.1 introduced breaking changes in how we obtain the names of material layers. I updated the code to compile, but didn't realize that the "Layer Name" I was now accessing was actually the name of the material layer _asset_, not the name of the material layer itself. So, for example, for this layer:

![image](https://user-images.githubusercontent.com/924374/215462172-92b8e6d8-16e9-4d8c-83b8-0a18e6c093b9.png)

we wanted to get `Overlay0`, but in UE 5.1 we were instead getting `ML_CesiumRasterOverlay`.

Because various material parameters are assigned based on these names, Cesium materials pretty much completely stopped working in UE 5.1. This was most obvious for tilesets with raster overlays, which would just appear white.

You might wonder how this went unnoticed. Well, as long as the material was last saved in a _previous_ version of Unreal Engine, it worked fine even in UE 5.1. It was only if we created or saved the material in UE 5.1 that it would fail to work.

Exactly this symptom was reported on the forum here:
https://community.cesium.com/t/material-instance-error-too-many-texture-coordinate-sets-defined-on-gpuskin-vertex-input-max-4/21693

I initially thought it was a bug in UE 5.1, and reported it on UDN, and Epic in fact found and fixed a bug. But even after the fix, our materials were still not working. So today I dug deeper and noticed the problem with the layer names.