### PR TITLE
Generate navigation mesh on Cesium3DTileset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - The `FlyToAltitudeProfileCurve`, `FlyToProgressCurve`, `FlyToMaximumAltitudeCurve`, `FlyToDuration`, and `FlyToGranularityDegrees` properties of `GlobeAwareDefaultPawn`  / `DynamicPawn` may now be read and written from Blueprints.
 - Added an option on `Cesium3DTileset` to ignore the `KHR_materials_unlit` extension entirely and use normal lighting and shadows.
+- Added `CreateNavCollision` property to `Cesium3DTileset`. When enabled, `CreateNavCollision` is called on the static meshes created for tiles.
 
 ##### Fixes :wrench:
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -319,6 +319,13 @@ void ACesium3DTileset::SetCreatePhysicsMeshes(bool bCreatePhysicsMeshes) {
   }
 }
 
+void ACesium3DTileset::SetCreateNavCollision(bool bCreateNavCollision) {
+  if (this->CreateNavCollision != bCreateNavCollision) {
+    this->CreateNavCollision = bCreateNavCollision;
+    this->DestroyTileset();
+  }
+}
+
 void ACesium3DTileset::SetAlwaysIncludeTangents(bool bAlwaysIncludeTangents) {
   if (this->AlwaysIncludeTangents != bAlwaysIncludeTangents) {
     this->AlwaysIncludeTangents = bAlwaysIncludeTangents;
@@ -679,7 +686,8 @@ public:
           this->_pActor->GetTranslucentMaterial(),
           this->_pActor->GetWaterMaterial(),
           this->_pActor->GetCustomDepthParameters(),
-          tile.getContentBoundingVolume().value_or(tile.getBoundingVolume()));
+          tile.getContentBoundingVolume().value_or(tile.getBoundingVolume()),
+          this->_pActor->GetCreateNavCollision());
     }
     // UE_LOG(LogCesium, VeryVerbose, TEXT("No content for tile"));
     return nullptr;
@@ -2029,6 +2037,8 @@ void ACesium3DTileset::PostEditChangeProperty(
           GET_MEMBER_NAME_CHECKED(ACesium3DTileset, IonAssetEndpointUrl) ||
       PropName ==
           GET_MEMBER_NAME_CHECKED(ACesium3DTileset, CreatePhysicsMeshes) ||
+      PropName ==
+          GET_MEMBER_NAME_CHECKED(ACesium3DTileset, CreateNavCollision) ||
       PropName ==
           GET_MEMBER_NAME_CHECKED(ACesium3DTileset, AlwaysIncludeTangents) ||
       PropName ==

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -26,6 +26,7 @@
 #include "CesiumMaterialUserData.h"
 #include "CesiumRasterOverlays.h"
 #include "CesiumRuntime.h"
+#include "CesiumRuntimeSettings.h"
 #include "CesiumTextureUtility.h"
 #include "CesiumTransforms.h"
 #include "CesiumUtility/Tracing.h"
@@ -2104,7 +2105,11 @@ static void loadPrimitiveGameThreadPart(
 #endif
   pStaticMesh->CreateBodySetup();
   
-  pStaticMesh->CreateNavCollision(true);
+  UCesiumRuntimeSettings* pSettings =
+      GetMutableDefault<UCesiumRuntimeSettings>();
+  if (pSettings && pSettings->EnableExperimentalCreateNavCollisionFeature) {
+    pStaticMesh->CreateNavCollision(true);
+  }
 
   UBodySetup* pBodySetup = pMesh->GetBodySetup();
 

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -2103,6 +2103,8 @@ static void loadPrimitiveGameThreadPart(
   pStaticMesh->GetRenderData()->ScreenSize[0].Default = 1.0f;
 #endif
   pStaticMesh->CreateBodySetup();
+  
+  pStaticMesh->CreateNavCollision(true);
 
   UBodySetup* pBodySetup = pMesh->GetBodySetup();
 

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -2111,7 +2111,7 @@ static void loadPrimitiveGameThreadPart(
   pStaticMesh->GetRenderData()->ScreenSize[0].Default = 1.0f;
 #endif
   pStaticMesh->CreateBodySetup();
-  
+
   if (createNavCollision) {
     pStaticMesh->CreateNavCollision(true);
   }

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -26,7 +26,6 @@
 #include "CesiumMaterialUserData.h"
 #include "CesiumRasterOverlays.h"
 #include "CesiumRuntime.h"
-#include "CesiumRuntimeSettings.h"
 #include "CesiumTextureUtility.h"
 #include "CesiumTransforms.h"
 #include "CesiumUtility/Tracing.h"
@@ -1882,7 +1881,8 @@ static void loadPrimitiveGameThreadPart(
     UCesiumGltfComponent* pGltf,
     LoadPrimitiveResult& loadResult,
     const glm::dmat4x4& cesiumToUnrealTransform,
-    const Cesium3DTilesSelection::BoundingVolume& boundingVolume) {
+    const Cesium3DTilesSelection::BoundingVolume& boundingVolume,
+    bool createNavCollision) {
   TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::LoadPrimitive)
 
   FName meshName = createSafeName(loadResult.name, "");
@@ -2105,9 +2105,7 @@ static void loadPrimitiveGameThreadPart(
 #endif
   pStaticMesh->CreateBodySetup();
   
-  UCesiumRuntimeSettings* pSettings =
-      GetMutableDefault<UCesiumRuntimeSettings>();
-  if (pSettings && pSettings->EnableExperimentalCreateNavCollisionFeature) {
+  if (createNavCollision) {
     pStaticMesh->CreateNavCollision(true);
   }
 
@@ -2157,7 +2155,8 @@ UCesiumGltfComponent::CreateOffGameThread(
     UMaterialInterface* pBaseTranslucentMaterial,
     UMaterialInterface* pBaseWaterMaterial,
     FCustomDepthParameters CustomDepthParameters,
-    const Cesium3DTilesSelection::BoundingVolume& boundingVolume) {
+    const Cesium3DTilesSelection::BoundingVolume& boundingVolume,
+    bool createNavCollision) {
 
   TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::LoadModel)
 
@@ -2201,7 +2200,8 @@ UCesiumGltfComponent::CreateOffGameThread(
             Gltf,
             primitive,
             cesiumToUnrealTransform,
-            boundingVolume);
+            boundingVolume,
+            createNavCollision);
       }
     }
   }

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.h
@@ -76,7 +76,8 @@ public:
       UMaterialInterface* BaseTranslucentMaterial,
       UMaterialInterface* BaseWaterMaterial,
       FCustomDepthParameters CustomDepthParameters,
-      const Cesium3DTilesSelection::BoundingVolume& boundingVolume);
+      const Cesium3DTilesSelection::BoundingVolume& boundingVolume,
+      bool createNavCollision);
 
   UCesiumGltfComponent();
   virtual ~UCesiumGltfComponent();

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -704,6 +704,21 @@ private:
   bool CreatePhysicsMeshes = true;
 
   /**
+   * Whether to generate navigation collisions for this tileset.
+   *
+   * Enabling this option creates collisions for navigation when a 3D Tiles
+   * tileset is loaded. It is recommended to set "Runtime Generation" to
+   * "Static" in the navigation mesh settings in the project settings, as
+   * collision calculations become very slow.
+   */
+  UPROPERTY(
+      EditAnywhere,
+      BlueprintGetter = GetCreateNavCollision,
+      BlueprintSetter = SetCreateNavCollision,
+      Category = "Cesium|Navigation")
+  bool CreateNavCollision = false;
+
+  /**
    * Whether to always generate a correct tangent space basis for tiles that
    * don't have them.
    *
@@ -880,6 +895,12 @@ public:
 
   UFUNCTION(BlueprintSetter, Category = "Cesium|Physics")
   void SetCreatePhysicsMeshes(bool bCreatePhysicsMeshes);
+
+  UFUNCTION(BlueprintGetter, Category = "Cesium|Navigation")
+  bool GetCreateNavCollision() const { return CreateNavCollision; }
+
+  UFUNCTION(BlueprintSetter, Category = "Cesium|Navigation")
+  void SetCreateNavCollision(bool bCreateNavCollision);
 
   UFUNCTION(BlueprintGetter, Category = "Cesium|Rendering")
   bool GetAlwaysIncludeTangents() const { return AlwaysIncludeTangents; }

--- a/Source/CesiumRuntime/Public/CesiumRuntimeSettings.h
+++ b/Source/CesiumRuntime/Public/CesiumRuntimeSettings.h
@@ -52,4 +52,13 @@ public:
    */
   UPROPERTY(Config, EditAnywhere, Category = "Experimental Feature Flags")
   bool EnableExperimentalOcclusionCullingFeature = false;
+  
+  /**
+  * Creates collisions for navigation when a 3D Tiles tileset is loaded.
+  * It is recommended to set "Runtime Generation" to "Static" in the
+  * navigation mesh settings in the project settings, as collision
+  * calculations become very slow when enabled.
+  */
+  UPROPERTY(Config, EditAnywhere, Category = "Experimental Feature Flags")
+  bool EnableExperimentalCreateNavCollisionFeature = false;
 };

--- a/Source/CesiumRuntime/Public/CesiumRuntimeSettings.h
+++ b/Source/CesiumRuntime/Public/CesiumRuntimeSettings.h
@@ -52,13 +52,4 @@ public:
    */
   UPROPERTY(Config, EditAnywhere, Category = "Experimental Feature Flags")
   bool EnableExperimentalOcclusionCullingFeature = false;
-  
-  /**
-  * Creates collisions for navigation when a 3D Tiles tileset is loaded.
-  * It is recommended to set "Runtime Generation" to "Static" in the
-  * navigation mesh settings in the project settings, as collision
-  * calculations become very slow when enabled.
-  */
-  UPROPERTY(Config, EditAnywhere, Category = "Experimental Feature Flags")
-  bool EnableExperimentalCreateNavCollisionFeature = false;
 };


### PR DESCRIPTION
This PR accommodates #327. The latest version(v1.22.0) of Cesium for Unreal can not generate a NavMesh for a Cesium3DTileset
actor. However, this PR make it possible to generate a NavMesh on a Cesium3DTileset actor.

We have confirmed that NavMesh is generated after our modification using the "New York City 3D Buildings" asset provided by
Cesium Ion. The first image is before our modification and the second image is after our modification.

BeforeNavCollision
![BeforeNavCollision](https://user-images.githubusercontent.com/79615787/220961091-adbe200b-d05c-419b-9fe5-70a320e3fd1f.png)

AfterNavCollision
![AfterNavCollision](https://user-images.githubusercontent.com/79615787/220961159-0966014b-597e-4683-ab29-65f263898154.png)
