### PR TITLE
Fix crash when changing project default token

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,13 @@
 
 ### v1.23.0 - 2023-03-01
 
+##### Additions :tada:
+
 - Added support for rendering point clouds (`pnts`).
+
+##### Fixes :wrench:
+
+- Fixed bug that causes a crash when changing the project default token.
 
 ### v1.22.0 - 2023-02-01
 


### PR DESCRIPTION
Fixes #1042. The problem was that a main thread task is calling Destroy Tileset. The tileset would destroy itself when calling dispatch main thread tasks.