### PR TITLE
adds the BlueprintReadWrite property specifier to GlobeAwareDefaultPawn FlyTo variables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Additions :tada:
+
+- The `FlyToAltitudeProfileCurve`, `FlyToProgressCurve`, `FlyToMaximumAltitudeCurve`, `FlyToDuration`, and `FlyToGranularityDegrees` properties of `GlobeAwareDefaultPawn`  / `DynamicPawn` may now be read and written from Blueprints.
+
 ### v1.23.0 - 2023-03-01
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
+++ b/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
@@ -78,7 +78,7 @@ public:
    * 1 range on both axes. The {@see FlyToMaximumAltitudeCurve} dictates the
    * actual max altitude at each point along the curve.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium")
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
   UCurveFloat* FlyToAltitudeProfileCurve;
 
   /**
@@ -86,7 +86,7 @@ public:
    * curves. This allows us to accelerate and deaccelerate as wanted throughout
    * the curve.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium")
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
   UCurveFloat* FlyToProgressCurve;
 
   /**
@@ -94,20 +94,20 @@ public:
    * This can be used in conjunction with the {@see FlyToAltitudeProfileCurve}
    * to allow the pawn to take some altitude during the flight.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium")
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
   UCurveFloat* FlyToMaximumAltitudeCurve;
 
   /**
    * The length in seconds that the flight should last.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium", meta = (ClampMin = 0.0))
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium", meta = (ClampMin = 0.0))
   double FlyToDuration = 5.0;
 
   /**
    * The granularity in degrees with which keypoints should be generated for
    * the flight interpolation.
    */
-  UPROPERTY(EditAnywhere, Category = "Cesium", meta = (ClampMin = 0.0))
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium", meta = (ClampMin = 0.0))
   double FlyToGranularityDegrees = 0.01;
 
   /**


### PR DESCRIPTION
Fixes #1052 

https://community.cesium.com/t/transition-between-more-than-one-geo-marker/22612