### PR TITLE
Fix errors caused by blueprint-accessible doubles.

### DIFF
--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -107,7 +107,9 @@ void AGlobeAwareDefaultPawn::FlyToLocationECEF(
   double flyTotalAngle = glm::angle(flyQuat);
   glm::dvec3 flyRotationAxis = glm::axis(flyQuat);
   int steps = glm::max(
-      int(flyTotalAngle / glm::radians(this->FlyToGranularityDegrees)) - 1,
+      int(flyTotalAngle /
+          glm::radians(static_cast<double>(this->FlyToGranularityDegrees))) -
+          1,
       0);
   this->_keypoints.clear();
   this->_currentFlyTime = 0.0;
@@ -153,8 +155,9 @@ void AGlobeAwareDefaultPawn::FlyToLocationECEF(
   for (int step = 1; step <= steps; step++) {
     double percentage = (double)step / (steps + 1);
     double altitude = glm::mix(sourceAltitude, destinationAltitude, percentage);
-    double phi =
-        glm::radians(this->FlyToGranularityDegrees * static_cast<double>(step));
+    double phi = glm::radians(
+        static_cast<double>(this->FlyToGranularityDegrees) *
+        static_cast<double>(step));
 
     glm::dvec3 rotated = glm::rotate(sourceUpVector, phi, flyRotationAxis);
     if (auto scaled = ellipsoid.scaleToGeodeticSurface(rotated)) {
@@ -265,7 +268,7 @@ void AGlobeAwareDefaultPawn::_handleFlightStep(float DeltaSeconds) {
   }
 
   // If we reached the end, set actual destination location and orientation
-  if (this->_currentFlyTime >= this->FlyToDuration) {
+  if (this->_currentFlyTime >= static_cast<double>(this->FlyToDuration)) {
     const glm::dvec3& finalPoint = _keypoints.back();
     this->GlobeAnchor->MoveToECEF(finalPoint);
     Controller->SetControlRotation(this->_flyToDestinationRotation.Rotator());
@@ -281,7 +284,8 @@ void AGlobeAwareDefaultPawn::_handleFlightStep(float DeltaSeconds) {
 
   // We're currently in flight. Interpolate the position and orientation:
 
-  double rawPercentage = this->_currentFlyTime / this->FlyToDuration;
+  double rawPercentage =
+      this->_currentFlyTime / static_cast<double>(this->FlyToDuration);
 
   // In order to accelerate at start and slow down at end, we use a progress
   // profile curve

--- a/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
+++ b/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
@@ -105,7 +105,7 @@ public:
       BlueprintReadWrite,
       Category = "Cesium",
       meta = (ClampMin = 0.0))
-  double FlyToDuration = 5.0;
+  float FlyToDuration = 5.0f;
 
   /**
    * The granularity in degrees with which keypoints should be generated for
@@ -116,7 +116,7 @@ public:
       BlueprintReadWrite,
       Category = "Cesium",
       meta = (ClampMin = 0.0))
-  double FlyToGranularityDegrees = 0.01;
+  float FlyToGranularityDegrees = 0.01f;
 
   /**
    * A delegate that will be called whenever the pawn finishes flying


### PR DESCRIPTION
I was a little too quick to merge #1059. It doesn't work in UE4 because properties of type double cannot be accessible from Blueprints. This PR changes the problematic properties, `FlyToDuration` and `FlyToGranularityDegrees`, to floats instead of doubles. This change shouldn't make any difference from a precision perspective, because these properties will have relatively small numbers that don't need to be extraordinarily precise.