### PR TITLE
fixed issue#1025 wherein GlobeAwareDefaultPawn causes stall when flyToGranularityDegrees is 0

### DIFF
--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -106,6 +106,13 @@ void AGlobeAwareDefaultPawn::FlyToLocationECEF(
       glm::normalize(ECEFDestination));
   double flyTotalAngle = glm::angle(flyQuat);
   glm::dvec3 flyRotationAxis = glm::axis(flyQuat);
+  if (this->FlyTOGranularityDegrees == 0.0f)
+  {
+    UE_LOG(LogCesium, Error, TEXT("CesiumFlyToController cannot fly when flyToGranularityDegrees " +
+                    "is set to 0."));
+    return;
+  }
+  
   int steps = glm::max(
       int(flyTotalAngle /
           glm::radians(static_cast<double>(this->FlyToGranularityDegrees))) -

--- a/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
+++ b/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
@@ -117,6 +117,7 @@ public:
       Category = "Cesium",
       meta = (ClampMin = 0.0))
   float FlyToGranularityDegrees = 0.01f;
+  
 
   /**
    * A delegate that will be called whenever the pawn finishes flying

--- a/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
+++ b/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
@@ -117,7 +117,6 @@ public:
       Category = "Cesium",
       meta = (ClampMin = 0.0))
   float FlyToGranularityDegrees = 0.01f;
-  
 
   /**
    * A delegate that will be called whenever the pawn finishes flying


### PR DESCRIPTION
- [x] fixes #1025 
- [x] added early return when flyToGranularityDegrees is 0
- [x] added an error log for when flyToGranularityDegrees is 0