### PR TITLE
Fix ue5.2 errors

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumEncodedMetadataUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumEncodedMetadataUtility.cpp
@@ -21,6 +21,7 @@
 #include <CesiumUtility/Tracing.h>
 #include <glm/gtx/integer.hpp>
 #include <unordered_map>
+#include "TextureResource.h"
 
 using namespace CesiumTextureUtility;
 

--- a/Source/CesiumRuntime/Private/CesiumSunSky.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.cpp
@@ -9,6 +9,7 @@
 #include "TimerManager.h"
 #include "UObject/ConstructorHelpers.h"
 #include "VecMath.h"
+#include "GameFramework/Pawn.h"
 
 #if WITH_EDITOR
 #include "Editor.h"

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -15,6 +15,7 @@
 #include "RenderUtils.h"
 #include "Runtime/Launch/Resources/Version.h"
 #include "TextureResource.h"
+#include "UObject/Package.h"
 #include <CesiumGltf/ExtensionKhrTextureBasisu.h>
 #include <CesiumGltf/ExtensionTextureWebp.h>
 #include <CesiumGltf/ImageCesium.h>

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.h
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.h
@@ -4,6 +4,7 @@
 
 #include "CesiumGltf/Model.h"
 #include "CesiumMetadataValueType.h"
+#include "RHIResources.h"
 #include "Engine/Texture.h"
 #include "Engine/Texture2D.h"
 #include "Engine/TextureDefines.h"
@@ -21,7 +22,7 @@ namespace CesiumTextureUtility {
  * @brief A texture that has already been asynchronously created.
  */
 struct AsyncCreatedTexture {
-  FTexture2DRHIRef rhiTextureRef{};
+  FTextureRHIRef rhiTextureRef{};
 };
 
 /**


### PR DESCRIPTION
Fixed only errors for compiling for UE5.2 but at least it works now. Still some warnings of use of deprecated features that should be fixed.