### PR TITLE
Remove compilation of PhysX

### DIFF
--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -176,10 +176,7 @@ public class CesiumRuntime : ModuleRules
             }
         );
 
-        if (Target.bUseChaos)
-        {
-            PrivateDependencyModuleNames.Add("Chaos");
-        }
+        PrivateDependencyModuleNames.Add("Chaos");
 
         if (Target.bBuildEditor == true)
         {

--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -176,12 +176,7 @@ public class CesiumRuntime : ModuleRules
             }
         );
 
-        if (Target.bCompilePhysX && !Target.bUseChaos)
-        {
-            PrivateDependencyModuleNames.Add("PhysXCooking");
-            PrivateDependencyModuleNames.Add("PhysicsCore");
-        }
-        else
+        if (Target.bUseChaos)
         {
             PrivateDependencyModuleNames.Add("Chaos");
         }


### PR DESCRIPTION
We're getting warnings in  `\Plugins\CesiumForUnreal\Source\CesiumRuntime\CesiumRuntime.Build.cs(179,13)` that say `'ReadOnlyTargetRules.bCompilePhysX' is obsolete: 'Deprecated in UE5.1 - No longer used as Chaos is always enabled.'` This PR removes that check from the file.

@kring can you check if this is correct?