### PR TITLE
Fix for failed to destroy cartographic polygon at runtime

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumCartographicPolygon.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCartographicPolygon.cpp
@@ -34,7 +34,10 @@ void ACesiumCartographicPolygon::OnConstruction(const FTransform& Transform) {
   this->MakeLinear();
 }
 
-void ACesiumCartographicPolygon::BeginPlay() { this->MakeLinear(); }
+void ACesiumCartographicPolygon::BeginPlay() {
+  Super::BeginPlay();
+  this->MakeLinear();
+}
 
 CesiumGeospatial::CartographicPolygon
 ACesiumCartographicPolygon::CreateCartographicPolygon() const {


### PR DESCRIPTION
Missing calling `Super::BeginPlay()` in `ACartographicPolygon::BeginPlay()` causes we cannot destroy an `ACartographicPolygon` actor at runtime. Because before destroy the actor, we will check the actor `AActor::ActorHasBegunPlay` state. If the value is `EActorBeginPlayState::HasBegunPlay`, the actor will be mark pending killing. But `AActor::ActorHasBegunPlay` will be set to `EActorBeginPlayState::HasBegunPlay` in `AActor::BeginPlay()`. 