### PR TITLE
Add Scale property to CesiumGeoreference.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ##### Additions :tada:
 
+- Added a `Scale` property to `CesiumGeoreference`. This allows the entire globe to be scaled up or down within the Unreal world.
 - Tileset and raster overlay credits are now shown in Editor viewports.
 
 ##### Fixes :wrench:

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -572,6 +572,12 @@ void ACesiumGeoreference::PostEditChangeProperty(FPropertyChangedEvent& event) {
     this->UpdateGeoreference();
     return;
   } else if (
+      propertyName == GET_MEMBER_NAME_CHECKED(ACesiumGeoreference, Scale)) {
+    if (this->Scale < 1e-6) {
+      this->Scale = 1e-6;
+    }
+    this->UpdateGeoreference();
+  } else if (
       propertyName ==
       GET_MEMBER_NAME_CHECKED(ACesiumGeoreference, CesiumSubLevels)) {
   }
@@ -742,7 +748,8 @@ void ACesiumGeoreference::_updateGeoTransforms() {
           this->_ellipsoidRadii[0],
           this->_ellipsoidRadii[1],
           this->_ellipsoidRadii[2]),
-      center);
+      center,
+      this->Scale / 100.0);
 }
 
 void ACesiumGeoreference::Tick(float DeltaTime) {

--- a/Source/CesiumRuntime/Private/CesiumMaterialUserData.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMaterialUserData.cpp
@@ -15,7 +15,8 @@ void UCesiumMaterialUserData::PostEditChangeOwner() {
     const FStaticParameterSet& parameters = pMaterial->GetStaticParameters();
 
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
-    const TArray<FText>& layerNames = parameters.EditorOnly.MaterialLayers.LayerNames;
+    const TArray<FText>& layerNames =
+        parameters.EditorOnly.MaterialLayers.LayerNames;
 
     this->LayerNames.Reserve(layerNames.Num());
 

--- a/Source/CesiumRuntime/Private/CesiumSunSky.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.cpp
@@ -441,11 +441,15 @@ void ACesiumSunSky::UpdateAtmosphereRadius() {
       this->GetGeoreference()->TransformUnrealToLongitudeLatitudeHeight(
           VecMath::createVector3D(location));
 
+  double scale = this->GetGeoreference()->Scale / 100.0;
+
   // An atmosphere of this radius should circumscribe all Earth terrain.
   double maxRadius = 6387000.0;
 
   if (llh.z / 1000.0 > this->CircumscribedGroundThreshold) {
-    this->SetSkyAtmosphereGroundRadius(this->SkyAtmosphere, maxRadius / 1000.0);
+    this->SetSkyAtmosphereGroundRadius(
+        this->SkyAtmosphere,
+        maxRadius * scale / 1000.0);
   } else {
     // Find the ellipsoid radius 100m below the surface at this location. See
     // the comment at the top of this file.
@@ -458,13 +462,15 @@ void ACesiumSunSky::UpdateAtmosphereRadius() {
     if (llh.z / 1000.0 < this->InscribedGroundThreshold) {
       this->SetSkyAtmosphereGroundRadius(
           this->SkyAtmosphere,
-          minRadius / 1000.0);
+          minRadius * scale / 1000.0);
     } else {
       double t =
           ((llh.z / 1000.0) - this->InscribedGroundThreshold) /
           (this->CircumscribedGroundThreshold - this->InscribedGroundThreshold);
       double radius = glm::mix(minRadius, maxRadius, t);
-      this->SetSkyAtmosphereGroundRadius(this->SkyAtmosphere, radius / 1000.0);
+      this->SetSkyAtmosphereGroundRadius(
+          this->SkyAtmosphere,
+          radius * scale / 1000.0);
     }
   }
 }

--- a/Source/CesiumRuntime/Private/GeoTransforms.cpp
+++ b/Source/CesiumRuntime/Private/GeoTransforms.cpp
@@ -56,12 +56,16 @@ void GeoTransforms::updateTransforms() noexcept {
           _center,
           _ellipsoid);
   this->_ecefToGeoreferenced = glm::affineInverse(this->_georeferencedToEcef);
-  this->_ueAbsToEcef = this->_georeferencedToEcef *
-                       CesiumTransforms::scaleToCesium *
-                       CesiumTransforms::unrealToOrFromCesium;
-  this->_ecefToUeAbs = CesiumTransforms::unrealToOrFromCesium *
-                       CesiumTransforms::scaleToUnrealWorld *
-                       this->_ecefToGeoreferenced;
+  this->_ueAbsToEcef =
+      this->_georeferencedToEcef *
+      glm::dmat4x4(
+          glm::dmat3x3(CesiumTransforms::centimetersToMeters / this->_scale)) *
+      CesiumTransforms::unrealToOrFromCesium;
+  this->_ecefToUeAbs =
+      CesiumTransforms::unrealToOrFromCesium *
+      glm::dmat4x4(
+          glm::dmat3x3(CesiumTransforms::metersToCentimeters * this->_scale)) *
+      this->_ecefToGeoreferenced;
 
   UE_LOG(
       LogCesium,

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -96,6 +96,17 @@ public:
   TArray<FCesiumSubLevel> CesiumSubLevels;
 
   /**
+   * The percentage scale of the globe in the Unreal world. If this value is 50,
+   * for example, one meter on the globe occupies half a meter in the Unreal
+   * world.
+   */
+  UPROPERTY(
+      EditAnywhere,
+      Category = "Cesium",
+      Meta = (UIMin = 0.000001, UIMax = 100.0))
+  double Scale = 100.0;
+
+  /**
    * The placement of this Actor's origin (coordinate 0,0,0) within the tileset.
    *
    * 3D Tiles tilesets often use Earth-centered, Earth-fixed coordinates, such

--- a/Source/CesiumRuntime/Public/GeoTransforms.h
+++ b/Source/CesiumRuntime/Public/GeoTransforms.h
@@ -24,6 +24,7 @@ public:
   GeoTransforms()
       : _ellipsoid(CesiumGeospatial::Ellipsoid::WGS84),
         _center(glm::dvec3(0.0)),
+        _scale(1.0),
         _georeferencedToEcef(1.0),
         _ecefToGeoreferenced(1.0),
         _ueAbsToEcef(1.0),
@@ -39,12 +40,15 @@ public:
    *
    * @param ellipsoid The ellipsoid to use for the georeferenced coordinates
    * @param center The center position.
+   * @param scale The scale factor of the globe in the Unreal world.
    */
   GeoTransforms(
       const CesiumGeospatial::Ellipsoid& ellipsoid,
-      const glm::dvec3& center)
+      const glm::dvec3& center,
+      double scale)
       : _ellipsoid(ellipsoid),
         _center(center),
+        _scale(scale),
         _georeferencedToEcef(1.0),
         _ecefToGeoreferenced(1.0),
         _ueAbsToEcef(1.0),
@@ -267,6 +271,7 @@ private:
   // Modifiable state
   CesiumGeospatial::Ellipsoid _ellipsoid;
   glm::dvec3 _center;
+  double _scale;
 
   // Derived state
   glm::dmat4 _georeferencedToEcef;


### PR DESCRIPTION
Unreal equivalent of CesiumGS/cesium-unity#303. Unlike in Unity, here the scale is a percentage (so 100 is full size). I did that because Unreal has a weird arbitrary limit on how small a number you enter on the details panel (after which it rounds to 0.0). So using a percentage lets us scale down by two more orders of magnitude.

Some problems I know about:

* The CesiumSunSky adjusts the SkyAtmosphere's radius to account for the globe scale. But other SkyAtmosphere parameters, like "Atmosphere Height", need to be adjusted manually for small scales or else the atmosphere will look totally wonky. And this parameter appears to have an arbitrary minimum value of 0.1. So you can't get a globe with a correct atmosphere at a smaller scale than 0.1% (0.001) or so.
* The Water Mask effect fades in based on distance, so at small scales it appears too soon (i.e. while still zoomed out pretty far) and looks weird. There are shader parameters controlling this, and tweaking them will probably work, but users will need to create/copy a material instance to do this.

Fixes #295 
Partially addresses #1049 
