### PR TITLE
Make the credit system's link to the widget transient.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug introduced in v1.26.0 that caused an error when attempting to save a sub-level containing Cesium objects.
+
 ### v1.26.0 - 2023-05-09
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Public/CesiumCreditSystem.h
+++ b/Source/CesiumRuntime/Public/CesiumCreditSystem.h
@@ -49,7 +49,7 @@ public:
   UPROPERTY(BlueprintReadOnly, Category = "Cesium")
   bool CreditsUpdated = false;
 
-  UPROPERTY(BlueprintReadOnly, Category = "Cesium")
+  UPROPERTY(BlueprintReadOnly, Transient, Category = "Cesium")
   class UScreenCreditsWidget* CreditsWidget;
 
   // Called every frame


### PR DESCRIPTION
This avoids an error when attempting to save a sub-level, and that sub-level has a credit system whose widget exists in the persistent level.

As reported here:
https://community.cesium.com/t/latest-update-broke-level-streaming/23967