### PR TITLE
Fix Credits Crash when creating new scene

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
@@ -20,7 +20,7 @@
 #include "Modules/ModuleManager.h"
 #endif
 
-/*static*/ UClass* ACesiumCreditSystem::CesiumCreditSystemBP = nullptr;
+/*static*/ UObject* ACesiumCreditSystem::CesiumCreditSystemBP = nullptr;
 namespace {
 
 /**
@@ -75,7 +75,7 @@ ACesiumCreditSystem::GetDefaultCreditSystem(const UObject* WorldContextObject) {
   if (!CesiumCreditSystemBP) {
     UCesiumCreditSystemBPLoader* bpLoader =
         NewObject<UCesiumCreditSystemBPLoader>();
-    CesiumCreditSystemBP = bpLoader->CesiumCreditSystemBP.Get();
+    CesiumCreditSystemBP = bpLoader->CesiumCreditSystemBP.LoadSynchronous();
     bpLoader->ConditionalBeginDestroy();
   }
 
@@ -132,7 +132,7 @@ ACesiumCreditSystem::GetDefaultCreditSystem(const UObject* WorldContextObject) {
     spawnParameters.SpawnCollisionHandlingOverride =
         ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
     pCreditSystem = world->SpawnActor<ACesiumCreditSystem>(
-        CesiumCreditSystemBP,
+        dynamic_cast<UClass*>(CesiumCreditSystemBP),
         spawnParameters);
     // Null check so the editor doesn't crash when it makes arbitrary calls to
     // this function without a valid world context object.

--- a/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
@@ -132,7 +132,7 @@ ACesiumCreditSystem::GetDefaultCreditSystem(const UObject* WorldContextObject) {
     spawnParameters.SpawnCollisionHandlingOverride =
         ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
     pCreditSystem = world->SpawnActor<ACesiumCreditSystem>(
-        dynamic_cast<UClass*>(CesiumCreditSystemBP),
+        Cast<UClass>(CesiumCreditSystemBP),
         spawnParameters);
     // Null check so the editor doesn't crash when it makes arbitrary calls to
     // this function without a valid world context object.

--- a/Source/CesiumRuntime/Private/CesiumCreditSystemBPLoader.h
+++ b/Source/CesiumRuntime/Private/CesiumCreditSystemBPLoader.h
@@ -12,7 +12,7 @@ public:
   UCesiumCreditSystemBPLoader();
 
   UPROPERTY()
-  TSoftClassPtr<UClass> CesiumCreditSystemBP = TSoftClassPtr<
-      UClass>(FSoftObjectPath(TEXT(
+  TSoftObjectPtr<UObject> CesiumCreditSystemBP = TSoftObjectPtr<
+      UObject>(FSoftObjectPath(TEXT(
       "Class'/CesiumForUnreal/CesiumCreditSystemBP.CesiumCreditSystemBP_C'")));
 };

--- a/Source/CesiumRuntime/Public/CesiumCreditSystem.h
+++ b/Source/CesiumRuntime/Public/CesiumCreditSystem.h
@@ -72,7 +72,7 @@ public:
 #endif
 
 private:
-  static UClass* CesiumCreditSystemBP;
+  static UObject* CesiumCreditSystemBP;
 
   /**
    * A tag that is assigned to Credit Systems when they are created


### PR DESCRIPTION
Fixes #1100 

It looks like the credits worked before because a Credits System was already in the Level and when a new Level was created, the code was not able to load the Blueprint class, perhaps because the class is not static. Loading it as an object instead of a class seems to fix the issue.