### PR TITLE
Remove degenerate triangles from collision mesh

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 - `ACesium3DTileset` now emits a warning if the "Enable World Bounds Checks" option is enabled. That option can make the camera fly toward the origin unexpectedly.
 - Added new settings to the Cesium section of the Project Settings, allowing users to control how many requests to handle before pruning and also how many elements to keep in the cache after pruning.
 
+##### Fixes :wrench:
+
+- Remove degenerate triangles from collision mesh.
+
 ### v1.26.0 - 2023-05-09
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1218,7 +1218,13 @@ static void loadPrimitive(
     if (StaticMeshBuildVertices.Num() != 0 && indices.Num() != 0) {
       TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::ChaosCook)
       primitiveResult.pCollisionMesh =
-          BuildChaosTriangleMeshes(StaticMeshBuildVertices, indices);
+          StaticMeshBuildVertices.Num() < TNumericLimits<uint16>::Max()
+              ? BuildChaosTriangleMeshes<uint16>(
+                    StaticMeshBuildVertices,
+                    indices)
+              : BuildChaosTriangleMeshes<int32>(
+                    StaticMeshBuildVertices,
+                    indices);
     }
   }
 
@@ -2449,70 +2455,60 @@ void UCesiumGltfComponent::UpdateFade(float fadePercentage, bool fadingIn) {
   }
 }
 
-template <typename TIndex>
-static void fillTriangles(
-    TArray<Chaos::TVector<TIndex, 3>>& triangles,
-    const TArray<FStaticMeshBuildVertex>& vertexData,
-    const TArray<uint32>& indices,
-    int32 triangleCount) {
-
-  triangles.Reserve(triangleCount);
-
-  for (int32 i = 0; i < triangleCount; ++i) {
-    const int32 index0 = 3 * i;
-    triangles.Add(Chaos::TVector<int32, 3>(
-        indices[index0 + 1],
-        indices[index0],
-        indices[index0 + 2]));
-  }
+static bool isTriangleDegenerate(
+    const Chaos::FTriangleMeshImplicitObject::ParticleVecType& A,
+    const Chaos::FTriangleMeshImplicitObject::ParticleVecType& B,
+    const Chaos::FTriangleMeshImplicitObject::ParticleVecType& C) {
+  Chaos::FTriangleMeshImplicitObject::ParticleVecType AB = B - A;
+  Chaos::FTriangleMeshImplicitObject::ParticleVecType AC = C - A;
+  Chaos::FTriangleMeshImplicitObject::ParticleVecType Normal =
+      Chaos::FTriangleMeshImplicitObject::ParticleVecType::CrossProduct(AB, AC);
+  return (Normal.SafeNormalize() < UE_SMALL_NUMBER);
 }
 
+template <typename TIndex>
 static TSharedPtr<Chaos::FTriangleMeshImplicitObject, ESPMode::ThreadSafe>
 BuildChaosTriangleMeshes(
     const TArray<FStaticMeshBuildVertex>& vertexData,
     const TArray<uint32>& indices) {
 
   int32 vertexCount = vertexData.Num();
-  int32 triangleCount = indices.Num() / 3;
-
   Chaos::TParticles<Chaos::FRealSingle, 3> vertices;
   vertices.AddParticles(vertexCount);
-
   for (int32 i = 0; i < vertexCount; ++i) {
     vertices.X(i) = vertexData[i].Position;
   }
 
-  TArray<uint16> materials;
-  materials.SetNum(triangleCount);
-
+  int32 triangleCount = indices.Num() / 3;
+  TArray<Chaos::TVector<TIndex, 3>> triangles;
+  triangles.Reserve(triangleCount);
   TArray<int32> faceRemap;
-  faceRemap.SetNum(triangleCount);
+  faceRemap.Reserve(triangleCount);
 
   for (int32 i = 0; i < triangleCount; ++i) {
-    faceRemap[i] = i;
+    const int32 index0 = 3 * i;
+    int32 vIndex0 = indices[index0 + 1];
+    int32 vIndex1 = indices[index0];
+    int32 vIndex2 = indices[index0 + 2];
+
+    if (!isTriangleDegenerate(
+            vertices.X(vIndex0),
+            vertices.X(vIndex1),
+            vertices.X(vIndex2))) {
+      triangles.Add(Chaos::TVector<int32, 3>(vIndex0, vIndex1, vIndex2));
+      faceRemap.Add(i);
+    }
   }
 
   TUniquePtr<TArray<int32>> pFaceRemap = MakeUnique<TArray<int32>>(faceRemap);
+  TArray<uint16> materials;
+  materials.SetNum(triangles.Num());
 
-  if (vertexCount < TNumericLimits<uint16>::Max()) {
-    TArray<Chaos::TVector<uint16, 3>> triangles;
-    fillTriangles(triangles, vertexData, indices, triangleCount);
-    return MakeShared<Chaos::FTriangleMeshImplicitObject, ESPMode::ThreadSafe>(
-        MoveTemp(vertices),
-        MoveTemp(triangles),
-        MoveTemp(materials),
-        MoveTemp(pFaceRemap),
-        nullptr,
-        false);
-  } else {
-    TArray<Chaos::TVector<int32, 3>> triangles;
-    fillTriangles(triangles, vertexData, indices, triangleCount);
-    return MakeShared<Chaos::FTriangleMeshImplicitObject, ESPMode::ThreadSafe>(
-        MoveTemp(vertices),
-        MoveTemp(triangles),
-        MoveTemp(materials),
-        MoveTemp(pFaceRemap),
-        nullptr,
-        false);
-  }
+  return MakeShared<Chaos::FTriangleMeshImplicitObject, ESPMode::ThreadSafe>(
+      MoveTemp(vertices),
+      MoveTemp(triangles),
+      MoveTemp(materials),
+      MoveTemp(pFaceRemap),
+      nullptr,
+      false);
 }


### PR DESCRIPTION
Using the same condition found in TriangleMeshImplicitObject.cpp, this PR prevents degenerate triangles from being added to the collision mesh. Doesn't seem to have a performance hit.