### PR TITLE
Fix World Partion crash by removing RF_Public

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 
 - Fixed a bug introduced in v1.26.0 that caused an error when attempting to save a sub-level containing Cesium objects.
 - Fixed a bug in `CesiumGlTFFunction` that caused glTF and 3D Tiles "Ambient Occlusion" value to be 0.0 (instead of the expected 1.0) when the model does not specify an explicit occlusion texture. This could cause some extremely dark shadows.
+- Fixed a bug that could cause a crash when using Cesium Actors with World Partitioning.
 
 ### v1.26.0 - 2023-05-09
 

--- a/Source/CesiumEditor/Private/CesiumEditor.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditor.cpp
@@ -474,7 +474,7 @@ FCesiumEditorModule::CreateTileset(const std::string& name, int64_t assetID) {
       ACesium3DTileset::StaticClass(),
       FTransform(),
       false,
-      RF_Public | RF_Transactional);
+      RF_Transactional);
   ACesium3DTileset* pTilesetActor = Cast<ACesium3DTileset>(pNewActor);
   pTilesetActor->SetActorLabel(UTF8_TO_TCHAR(name.c_str()));
   if (assetID != -1) {
@@ -530,7 +530,7 @@ UCesiumIonRasterOverlay* FCesiumEditorModule::AddOverlay(
   UCesiumIonRasterOverlay* pOverlay = NewObject<UCesiumIonRasterOverlay>(
       pTilesetActor,
       FName(name.c_str()),
-      RF_Public | RF_Transactional);
+      RF_Transactional);
   pOverlay->MaterialLayerKey = overlayKey;
   pOverlay->IonAssetID = assetID;
   pOverlay->SetActive(true);

--- a/Source/CesiumEditor/Private/IonQuickAddPanel.cpp
+++ b/Source/CesiumEditor/Private/IonQuickAddPanel.cpp
@@ -263,7 +263,7 @@ void IonQuickAddPanel::AddCartographicPolygonToLevel() {
       ACesiumCartographicPolygon::StaticClass(),
       FTransform(),
       false,
-      RF_Public | RF_Transactional);
+      RF_Transactional);
 }
 
 namespace {
@@ -339,7 +339,7 @@ void IonQuickAddPanel::AddBlankTilesetToLevel() {
       ACesium3DTileset::StaticClass(),
       FTransform(),
       false,
-      RF_Public | RF_Transactional);
+      RF_Transactional);
 }
 
 void IonQuickAddPanel::AddItemToLevel(TSharedRef<QuickAddItem> item) {

--- a/Source/CesiumRuntime/Private/CesiumEncodedMetadataComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumEncodedMetadataComponent.cpp
@@ -419,7 +419,7 @@ void UCesiumEncodedMetadataComponent::GenerateMaterial() {
             UMaterialFunctionMaterialLayer::StaticClass(),
             Package,
             *MaterialName,
-            RF_Standalone | RF_Public | RF_Transactional,
+            RF_Standalone | RF_Transactional,
             NULL,
             GWarn);
     FAssetRegistryModule::AssetCreated(this->TargetMaterialLayer);

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -2014,7 +2014,7 @@ static void loadPrimitiveGameThreadPart(
       pCesiumData = NewObject<UCesiumMaterialUserData>(
           pBaseAsMaterialInstance,
           NAME_None,
-          RF_Public);
+          RF_Transactional);
       pBaseAsMaterialInstance->AddAssetUserData(pCesiumData);
       pCesiumData->PostEditChangeOwner();
     }


### PR DESCRIPTION
While playing around with World Partition, I ran into https://github.com/CesiumGS/cesium-unreal/issues/941, where the Editor crashes when attempting to unload a level with World Partition and a Cesium Actor. The crash is caused by Unreal attempting to CastChecked our Actor to UMetaData. Our Actor is not a UMetaData, so this checked cast fails, which is treated as a fatal error.

This cast happens inside [FWorldPartitionActorDesc::Unload](https://github.com/EpicGames/UnrealEngine/blob/5.2.0-release/Engine/Source/Runtime/Engine/Private/WorldPartition/WorldPartitionActorDesc.cpp#L605). Basically if the Actor `IsPackageExternal` (docs helpfully say "returns true if object has a different package than its outer's package"), and also it has the `RF_Public` or `RF_Standalone` flags, then it will be CastChecked to `UMetaData`. Why? I really don't know. A large comment explains some cases where the Actor might _not_ be "package external" (ours is), but those don't seem to apply to us. There's no hint in a comment or otherwise why this cast of some random Actor to `UMetaData` could ever work, nevermind be a good idea. Perhaps you're wondering what `UMetaData` even is? The docs only say "An object that holds a map of key/value pairs", which doesn't really clear it up for me.

But fortunately, I happened to notice that this crash _only_ happens if the Actor is added via the Cesium Quick Add panel. If we instead add a Cesium3DTileset by dragging it in from the Place Actors panel, there's no problem. So I went spelunking through the UE source code, and learned that the Editor UI, when you drag in an Actor, creates it with _only_ the `RF_Transactional` flag, whereas our Quick Add panel also adds `RF_Public`.

So, I removed `RF_Public`. And the problem goes away.

I wish I could tell you what this flag actually does, and why it's there in the first place, but no. I think I added it originally because some of the very early DataSmith glTF import code I was looking at used it, maybe. But that code was mostly importing models as assets, so it was probably not the best example to follow. Or maybe I just thought "public" sounded good? 🤷 The docs say RF_Public means "Object is visible outside its package", which doesn't mean very much to me.

Long story short, removing `RF_Public` makes us consistent with the Place Actors panel, it fixes this bug, and it doesn't have any obvious negative side effects that I've noticed yet. So :shipit:?

Fixes #941 
