### PR TITLE
Fix !IsGarbageCollecting() assertion in ACesiumCreditSystem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 - Removed the `GetGeoreferencedToEllipsoidCenteredTransform` and `GetEllipsoidCenteredToGeoreferencedTransform` methods from `GeoTransforms`. Because these were transformations between two right-handed coordinate systems, they are not of much use with Unreal's left-handed coordinate system.
 - Deprecated the `FlyToGranularityDegrees` property for `AGlobeAwareDefaultPawn`. Flight interpolation is now computed per-frame, so this property is no longer needed. Any code that refers to `FlyToGranularityDegrees` should be removed or changed to `FlyToGranularityDegrees_DEPRECATED` to still compile.
 
+##### Fixes :wrench:
+
+- Fixed a debug assertion `!IsGarbageCollecting()` that could occur within `ACesiumCreditSystem` when flying to different sublevels.
+
 ### v1.27.0 - 2023-06-1
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
@@ -202,8 +202,6 @@ void ACesiumCreditSystem::OnConstruction(const FTransform& Transform) {
 }
 
 void ACesiumCreditSystem::BeginDestroy() {
-  this->removeCreditsFromViewports();
-
 #if WITH_EDITOR
   FLevelEditorModule* pLevelEditorModule =
       FModuleManager::GetModulePtr<FLevelEditorModule>(LevelEditorName);

--- a/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
@@ -161,6 +161,11 @@ void ACesiumCreditSystem::BeginPlay() {
   this->updateCreditsViewport(true);
 }
 
+void ACesiumCreditSystem::EndPlay(const EEndPlayReason::Type EndPlayReason) {
+  this->removeCreditsFromViewports();
+  Super::EndPlay(EndPlayReason);
+}
+
 static const FName LevelEditorName("LevelEditor");
 
 void ACesiumCreditSystem::OnConstruction(const FTransform& Transform) {

--- a/Source/CesiumRuntime/Public/CesiumCreditSystem.h
+++ b/Source/CesiumRuntime/Public/CesiumCreditSystem.h
@@ -36,7 +36,9 @@ public:
 
   ACesiumCreditSystem();
 
-  void BeginPlay() override;
+  virtual void BeginPlay() override;
+  virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
   virtual void OnConstruction(const FTransform& Transform) override;
   virtual void BeginDestroy() override;
 


### PR DESCRIPTION
Move `::removeCreditsFromViewports` call out of `::BeginDestroy` and into `::EndPlay`. This prevents more work for the garbage collector being created, while the garbage collector is actively destroying an object.

Fixes #1121 