### PR TITLE
Merge the v1.27.1 release back into ue5-main

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 - Added ability to set CesiumGeoreference Scale via Blueprints.
 
+### v1.27.1 - 2023-06-19
+
 ##### Fixes :wrench:
 
 - Fixed a shader compilation error introduced in v1.27.0 that prevented projects from opening in Unreal Engine 5.1 and 5.2.

--- a/CesiumForUnreal.uplugin
+++ b/CesiumForUnreal.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 44,
-	"VersionName": "1.27.0",
+	"Version": 45,
+	"VersionName": "1.27.1",
 	"FriendlyName": "Cesium for Unreal",
 	"Description": "Unlock the 3D geospatial ecosystem in Unreal Engine with real-world 3D content and a high accuracy full-scale WGS84 globe.",
 	"Category": "Geospatial",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-unreal",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Cesium for Unreal",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
I branched it off the v1.27.0 tag in order to keep it a small, bugfix only release.