### PR TITLE
Fix rare-ish camera jump when arriving at a flight destination

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 - Added ability to set CesiumGeoreference Scale via Blueprints.
 
+##### Fixes :wrench:
+
+- Fixed a bug that could cause the `AGlobeAwareDefaultPawn` / `DynamicPawn`  to suddenly move to a very high height for one render frame just as it arrives at its destination during a flight.
+
 ### v1.27.1 - 2023-06-19
 
 ##### Fixes :wrench:

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -129,7 +129,9 @@ void AGlobeAwareDefaultPawn::FlyToLocationECEF(
 
   // The source and destination rotations are expressed in East-South-Up
   // coordinates.
-  this->_flyToSourceRotation = Controller->GetControlRotation().Quaternion();
+  this->_flyToSourceRotation =
+      IsValid(Controller) ? Controller->GetControlRotation().Quaternion()
+                          : FQuat::Identity;
   this->_flyToDestinationRotation =
       FRotator(PitchAtDestination, YawAtDestination, 0).Quaternion();
   this->_flyToECEFDestination = ECEFDestination;

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -120,6 +120,19 @@ void AGlobeAwareDefaultPawn::FlyToLocationECEF(
     bool CanInterruptByMoving) {
 
   if (this->_bFlyingToLocation) {
+    UE_LOG(
+        LogCesium,
+        Error,
+        TEXT("Cannot start a flight because one is already in progress."));
+    return;
+  }
+
+  if (!IsValid(this->Controller)) {
+    UE_LOG(
+        LogCesium,
+        Error,
+        TEXT(
+            "Cannot start a flight because the pawn does not have a Controller. You probably need to \"possess\" it before attempting to initiate a flight."));
     return;
   }
 
@@ -129,9 +142,7 @@ void AGlobeAwareDefaultPawn::FlyToLocationECEF(
 
   // The source and destination rotations are expressed in East-South-Up
   // coordinates.
-  this->_flyToSourceRotation =
-      IsValid(Controller) ? Controller->GetControlRotation().Quaternion()
-                          : FQuat::Identity;
+  this->_flyToSourceRotation = Controller->GetControlRotation().Quaternion();
   this->_flyToDestinationRotation =
       FRotator(PitchAtDestination, YawAtDestination, 0).Quaternion();
   this->_flyToECEFDestination = ECEFDestination;

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -81,7 +81,7 @@ FRotator AGlobeAwareDefaultPawn::GetBaseAimRotation() const {
 }
 
 void AGlobeAwareDefaultPawn::_interpolateFlightPosition(
-    double percentage,
+    float percentage,
     glm::dvec3& out) const {
 
   // Rotate our normalized source direction, interpolating with time
@@ -265,14 +265,30 @@ void AGlobeAwareDefaultPawn::_handleFlightStep(float DeltaSeconds) {
     return;
   }
 
-  this->_currentFlyTime += static_cast<double>(DeltaSeconds);
+  this->_currentFlyTime += DeltaSeconds;
 
-  // If we reached the end, set actual destination location and orientation
-  if (this->_currentFlyTime >= static_cast<double>(this->FlyToDuration)) {
+  // In order to accelerate at start and slow down at end, we use a progress
+  // profile curve
+  float flyPercentage;
+  if (this->_currentFlyTime >= this->FlyToDuration) {
+    flyPercentage = 1.0f;
+  } else if (this->FlyToProgressCurve) {
+    flyPercentage = glm::clamp(
+        this->FlyToProgressCurve->GetFloatValue(
+            this->_currentFlyTime / this->FlyToDuration),
+        0.0f,
+        1.0f);
+  } else {
+    flyPercentage = this->_currentFlyTime / this->FlyToDuration;
+  }
+
+  // If we reached the end, set actual destination location and
+  // orientation
+  if (flyPercentage >= 1.0f) {
     this->GlobeAnchor->MoveToECEF(this->_flyToECEFDestination);
     Controller->SetControlRotation(this->_flyToDestinationRotation.Rotator());
     this->_bFlyingToLocation = false;
-    this->_currentFlyTime = 0.0;
+    this->_currentFlyTime = 0.0f;
 
     // Trigger callback accessible from BP
     UE_LOG(LogCesium, Verbose, TEXT("Broadcasting OnFlightComplete"));
@@ -282,20 +298,6 @@ void AGlobeAwareDefaultPawn::_handleFlightStep(float DeltaSeconds) {
   }
 
   // We're currently in flight. Interpolate the position and orientation:
-
-  double rawPercentage =
-      this->_currentFlyTime / static_cast<double>(this->FlyToDuration);
-
-  // In order to accelerate at start and slow down at end, we use a progress
-  // profile curve
-  double flyPercentage = rawPercentage;
-  if (this->FlyToProgressCurve != NULL) {
-    flyPercentage = glm::clamp(
-        static_cast<double>(
-            this->FlyToProgressCurve->GetFloatValue(rawPercentage)),
-        0.0,
-        1.0);
-  }
 
   // Get the current position by interpolating with flyPercentage
   glm::dvec3 currentPosition;

--- a/Source/CesiumRuntime/Private/Tests/CesiumCameraManager.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumCameraManager.spec.cpp
@@ -1,5 +1,7 @@
+// Copyright 2020-2023 CesiumGS, Inc. and Contributors
+
 #include "CesiumCameraManager.h"
-#include "Engine/Engine.h"
+#include "CesiumTestHelpers.h"
 #include "Engine/World.h"
 #include "Misc/AutomationTest.h"
 
@@ -10,18 +12,11 @@ BEGIN_DEFINE_SPEC(
         EAutomationTestFlags::ProductFilter)
 END_DEFINE_SPEC(FCesiumCameraManagerSpec)
 
-UWorld* getGlobalWorldContext() {
-  const TIndirectArray<FWorldContext>& worldContexts =
-      GEngine->GetWorldContexts();
-  FWorldContext firstWorldContext = worldContexts[0];
-  return firstWorldContext.World();
-}
-
 void FCesiumCameraManagerSpec::Define() {
 
   Describe("GetDefaultCameraManager", [this]() {
     It("should get the default camera manager", [this]() {
-      UWorld* world = getGlobalWorldContext();
+      UWorld* world = CesiumTestHelpers::getGlobalWorldContext();
       ACesiumCameraManager* cameraManager =
           ACesiumCameraManager::GetDefaultCameraManager(world);
       TestNotNull("Returned pointer is valid", cameraManager);
@@ -37,7 +32,7 @@ void FCesiumCameraManagerSpec::Define() {
 
   Describe("AddCamera", [this]() {
     It("should add and remove a single camera", [this]() {
-      UWorld* world = getGlobalWorldContext();
+      UWorld* world = CesiumTestHelpers::getGlobalWorldContext();
       ACesiumCameraManager* cameraManager =
           ACesiumCameraManager::GetDefaultCameraManager(world);
       TestNotNull("Returned pointer is valid", cameraManager);
@@ -59,7 +54,7 @@ void FCesiumCameraManagerSpec::Define() {
     });
 
     It("should fail to remove a camera, when the id is invalid", [this]() {
-      UWorld* world = getGlobalWorldContext();
+      UWorld* world = CesiumTestHelpers::getGlobalWorldContext();
       ACesiumCameraManager* cameraManager =
           ACesiumCameraManager::GetDefaultCameraManager(world);
       TestNotNull("Returned pointer is valid", cameraManager);

--- a/Source/CesiumRuntime/Private/Tests/CesiumTestHelpers.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumTestHelpers.cpp
@@ -1,0 +1,11 @@
+// Copyright 2020-2023 CesiumGS, Inc. and Contributors
+
+#include "CesiumTestHelpers.h"
+#include "Engine/Engine.h"
+
+UWorld* CesiumTestHelpers::getGlobalWorldContext() {
+  const TIndirectArray<FWorldContext>& worldContexts =
+      GEngine->GetWorldContexts();
+  FWorldContext firstWorldContext = worldContexts[0];
+  return firstWorldContext.World();
+}

--- a/Source/CesiumRuntime/Private/Tests/CesiumTestHelpers.h
+++ b/Source/CesiumRuntime/Private/Tests/CesiumTestHelpers.h
@@ -1,0 +1,10 @@
+// Copyright 2020-2023 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+class UWorld;
+
+class CesiumTestHelpers {
+public:
+  static UWorld* getGlobalWorldContext();
+};

--- a/Source/CesiumRuntime/Private/Tests/GeoTransforms.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/GeoTransforms.spec.cpp
@@ -1,3 +1,5 @@
+// Copyright 2020-2023 CesiumGS, Inc. and Contributors
+
 #include "CesiumGeospatial/Ellipsoid.h"
 #include "CesiumUtility/Math.h"
 #include "GeoTransforms.h"

--- a/Source/CesiumRuntime/Private/Tests/GlobeAwareDefaultPawn.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/GlobeAwareDefaultPawn.spec.cpp
@@ -2,12 +2,12 @@
 
 #if WITH_EDITOR
 
-#include "GlobeAwareDefaultPawn.h"
 #include "CesiumGlobeAnchorComponent.h"
 #include "CesiumTestHelpers.h"
 #include "Editor.h"
 #include "Engine/World.h"
 #include "EngineUtils.h"
+#include "GlobeAwareDefaultPawn.h"
 #include "Misc/AutomationTest.h"
 #include "Tests/AutomationEditorCommon.h"
 

--- a/Source/CesiumRuntime/Private/Tests/GlobeAwareDefaultPawn.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/GlobeAwareDefaultPawn.spec.cpp
@@ -23,7 +23,7 @@ END_DEFINE_SPEC(FGlobeAwareDefaultPawnSpec)
 
 void FGlobeAwareDefaultPawnSpec::Define() {
   Describe(
-      "does not spike altitude when very close to final destination",
+      "should not spike altitude when very close to final destination",
       [this]() {
         LatentBeforeEach(
             EAsyncExecution::TaskGraphMainThread,

--- a/Source/CesiumRuntime/Private/Tests/GlobeAwareDefaultPawn.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/GlobeAwareDefaultPawn.spec.cpp
@@ -1,0 +1,83 @@
+// Copyright 2020-2023 CesiumGS, Inc. and Contributors
+
+#if WITH_EDITOR
+
+#include "GlobeAwareDefaultPawn.h"
+#include "CesiumGlobeAnchorComponent.h"
+#include "CesiumTestHelpers.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationEditorCommon.h"
+
+BEGIN_DEFINE_SPEC(
+    FGlobeAwareDefaultPawnSpec,
+    "Cesium.GlobeAwareDefaultPawn",
+    EAutomationTestFlags::ApplicationContextMask |
+        EAutomationTestFlags::ProductFilter)
+
+FDelegateHandle subscriptionPostPIEStarted;
+
+END_DEFINE_SPEC(FGlobeAwareDefaultPawnSpec)
+
+void FGlobeAwareDefaultPawnSpec::Define() {
+  Describe(
+      "does not spike altitude when very close to final destination",
+      [this]() {
+        LatentBeforeEach(
+            EAsyncExecution::TaskGraphMainThread,
+            [this](const FDoneDelegate& done) {
+              UWorld* pWorld = FAutomationEditorCommonUtils::CreateNewMap();
+
+              TSoftObjectPtr<UObject> DynamicPawn =
+                  TSoftObjectPtr<UObject>(FSoftObjectPath(TEXT(
+                      "Class'/CesiumForUnreal/DynamicPawn.DynamicPawn_C'")));
+              AGlobeAwareDefaultPawn* pPawn =
+                  pWorld->SpawnActor<AGlobeAwareDefaultPawn>(
+                      Cast<UClass>(DynamicPawn.LoadSynchronous()));
+
+              subscriptionPostPIEStarted =
+                  FEditorDelegates::PostPIEStarted.AddLambda(
+                      [done](bool isSimulating) { done.Execute(); });
+              FRequestPlaySessionParams params{};
+              GEditor->RequestPlaySession(params);
+            });
+        BeforeEach(EAsyncExecution::TaskGraphMainThread, [this]() {
+          FEditorDelegates::PostPIEStarted.Remove(subscriptionPostPIEStarted);
+        });
+        AfterEach(EAsyncExecution::TaskGraphMainThread, [this]() {
+          GEditor->RequestEndPlayMap();
+        });
+        It("", [this]() {
+          UWorld* pWorld = GEditor->PlayWorld;
+
+          TActorIterator<AGlobeAwareDefaultPawn> it(pWorld);
+          AGlobeAwareDefaultPawn* pPawn = *it;
+          pPawn->FlyToDuration = 5.0f;
+          UCesiumGlobeAnchorComponent* pGlobeAnchor =
+              pPawn->FindComponentByClass<UCesiumGlobeAnchorComponent>();
+          TestNotNull("pGlobeAnchor", pGlobeAnchor);
+
+          // Start flying somewhere else
+          pPawn->FlyToLocationLongitudeLatitudeHeight(
+              FVector(25.0, 10.0, 100.0),
+              0.0,
+              0.0,
+              false);
+
+          // Tick almost to the end
+          pPawn->Tick(4.9999f);
+
+          // The height should be close to the final height.
+          FVector llh = pGlobeAnchor->GetLongitudeLatitudeHeight();
+          TestTrue(
+              "Height is close to final height",
+              FMath::IsNearlyEqual(llh.Z, 100.0, 10.0));
+
+          pPawn->Destroy();
+        });
+      });
+}
+
+#endif

--- a/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
+++ b/Source/CesiumRuntime/Public/GlobeAwareDefaultPawn.h
@@ -227,7 +227,7 @@ private:
   void _moveAlongViewAxis(EAxis::Type axis, double Val);
   void _moveAlongVector(const FVector& axis, double Val);
   void _interruptFlight();
-  void _interpolateFlightPosition(double percentage, glm::dvec3& out) const;
+  void _interpolateFlightPosition(float percentage, glm::dvec3& out) const;
 
   /**
    * @brief Advance the camera flight based on the given time delta.
@@ -248,7 +248,7 @@ private:
   // helper variables for FlyToLocation
   bool _bFlyingToLocation = false;
   bool _bCanInterruptFlight = false;
-  double _currentFlyTime = 0.0;
+  float _currentFlyTime = 0.0f;
 
   double _flyToSourceAltitude = 0.0;
   double _flyToDestinationAltitude = 0.0;


### PR DESCRIPTION
In the Sublevels Sample, sometimes, upon arrival in Paris, the flight interpolation percentage would be exactly 1.0. Not just "displays as 1.0", but exactly equal to 1.0. And when that happened, the interpolation of the altitude flight curve would return 1.0, so the flight would put the altitude at its maximum rather than its destination height. This makes absolutely no sense, because the altitude interpolation key points are (0.0, 0.0), (0.5, 1.0), (1.0, 0.0). In other words, it should be 0.0 (minimum height) at the start and end, and 1.0 (maximum height) in the middle, just what you'd expect for altitude on a camera flight. Yet asking for the interpolated value at exactly 1.0 would return that value at 0.5 instead of the value at 1.0.

So stepping into UE's curve interpolation, I found it's doing some fancy cubic interpolation with tangents and whatnot. Ok, fine, but I'm literally asking for one of the keypoints! Well apparently the implementation of this cubic interpolation solves some cubic equation and comes up with three roots. It then picks one that is between 0.0 and 1.0. Three of the roots are well outside that range, but one is very very very slightly larger than 1.0. So Unreal decides none of these solutions are correct and decides to just make up an answer instead, 0.0. The one slightly larger than 1.0 is the correct answer here, but floating point rounding has nudged it to the wrong side of the range.

So, during a camera flight, just as the pawn should be arriving at its destination, it (very briefly, one frame) is given a height equal to the maximum during the flight, before it settles back down to the right place on the next frame.

This PR works around this problem by ensuring that we never interpolate at t=1.0, even if that t=1.0 came from the FlyToProgressCurve, rather than being 1.0 initially. Instead, t=1.0 is simply treated as being at the end of the flight.

I also switched to using `float` instead of `double` for the time variables. The extra precision should be unnecessary, and in theory we could end up with a value that is slightly less than 1.0 as a double, but exactly equal to 1.0 as a float. So using float consistently avoids this (remote) possibility.