### PR TITLE
Remove Android path hack after upgrade to UE 5.1.1.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,22 +12,22 @@ jobs:
           npm install
           npm run format -- --dry-run -Werror
   Windows50:
-    uses: ./.github/workflows/buildWindows.yml    
+    uses: ./.github/workflows/buildWindows.yml
     with:
       unreal-engine-version: "5.0.0"
       unreal-runner-label: "unreal-50"
       unreal-batch-files-path: "C:/Program Files/Epic Games/UE_5.0/Engine/Build/BatchFiles"
       upload-package-base-name: "CesiumForUnreal-50-windows"
-    secrets: inherit    
+    secrets: inherit
   TestWindows50:
     needs: [Windows50]
-    uses: ./.github/workflows/testWindows.yml    
+    uses: ./.github/workflows/testWindows.yml
     with:
       unreal-runner-label: "unreal-50"
       unreal-binaries-path: "C:/Program Files/Epic Games/UE_5.0/Engine/Binaries/Win64"
       unreal-plugins-path: "C:/Program Files/Epic Games/UE_5.0/Engine/Plugins"
       test-package-base-name: "CesiumForUnreal-50-windows"
-    secrets: inherit    
+    secrets: inherit
   Android50:
     runs-on: ["self-hosted","windows","x64","unreal-50"]
     steps:
@@ -220,7 +220,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: CesiumForUnreal-50-linux-${{ env.CESIUM_UNREAL_VERSION}}
-          path: combine          
+          path: combine
       - name: Download Windows build
         uses: actions/download-artifact@v3
         with:
@@ -234,7 +234,7 @@ jobs:
           path: combine
   TestPackage50:
     needs: [Combine50]
-    uses: ./.github/workflows/testPackageOnWindows.yml    
+    uses: ./.github/workflows/testPackageOnWindows.yml
     with:
       unreal-engine-association: "5.0"
       unreal-runner-label: "unreal-50"
@@ -242,24 +242,24 @@ jobs:
       unreal-batch-files-path: "C:/Program Files/Epic Games/UE_5.0/Engine/Build/BatchFiles"
       unreal-plugins-path: "C:/Program Files/Epic Games/UE_5.0/Engine/Plugins"
       test-package-base-name: "CesiumForUnreal-50"
-    secrets: inherit    
+    secrets: inherit
   Windows51:
-    uses: ./.github/workflows/buildWindows.yml    
+    uses: ./.github/workflows/buildWindows.yml
     with:
       unreal-engine-version: "5.1.0"
       unreal-runner-label: "unreal-51"
       unreal-batch-files-path: "C:/Program Files/Epic Games/UE_5.1/Engine/Build/BatchFiles"
       upload-package-base-name: "CesiumForUnreal-51-windows"
-    secrets: inherit  
+    secrets: inherit
   TestWindows51:
     needs: [Windows51]
-    uses: ./.github/workflows/testWindows.yml    
+    uses: ./.github/workflows/testWindows.yml
     with:
       unreal-runner-label: "unreal-51"
       unreal-binaries-path: "C:/Program Files/Epic Games/UE_5.1/Engine/Binaries/Win64"
       unreal-plugins-path: "C:/Program Files/Epic Games/UE_5.1/Engine/Plugins"
       test-package-base-name: "CesiumForUnreal-51-windows"
-    secrets: inherit    
+    secrets: inherit
   Android51:
     runs-on: ["self-hosted","windows","x64","unreal-51"]
     steps:
@@ -285,26 +285,8 @@ jobs:
       - name: Build plugin
         run: |
           ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.0.0"','"EngineVersion": "5.1.0"') | Set-Content -Path CesiumForUnreal.uplugin
-          # UE 5.1 seems to have a bug where the Android precompiled files are in the wrong place.
-          # See https://forums.unrealengine.com/t/5-1-missing-precompiled-manifest-error-when-building-code-plugin-for-android/691983
-          # So we fix it here.
-          mkdir -p "C:\Program Files\Epic Games\UE_5.1\Engine\Intermediate\Build\Android\arm64"
-          New-Item -ItemType Junction -Path "C:\Program Files\Epic Games\UE_5.1\Engine\Intermediate\Build\Android\arm64\UnrealGame" -Target "C:\Program Files\Epic Games\UE_5.1\Engine\Intermediate\Build\Android\UnrealGame"
-          cd "C:\Program Files\Epic Games\UE_5.1\Engine\Plugins"
-          Get-ChildItem -Recurse -Directory -Name | Where-Object {$_.EndsWith("Android\UnrealGame")} | ForEach-Object {
-            $oldPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PWD, $_))
-            $newPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PWD, $_, "..", "arm64"))
-            mkdir -p "$newPath"
-            New-Item -ItemType Junction -Path "$newPath\UnrealGame" -Target "$oldPath"
-          }
-
-          # Do the actual plugin build
           cd "C:/Program Files/Epic Games/UE_5.1/Engine/Build/BatchFiles"
           ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Android -NoHostPlatform
-
-          # But then the built plugin will have `Intermediate/Build/Android/arm64/UnrealGame` instead of `Intermediate/Build/Android/arm64/UnrealGame`
-          # which will cause problems when we try to package a game for Android. So fix that up.
-          mv $ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal/Intermediate/Build/Android/arm64/UnrealGame $ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal/Intermediate/Build/Android/UnrealGame
       - name: Publish plugin package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
@@ -493,7 +475,7 @@ jobs:
           path: combine
   TestPackage51:
     needs: [Combine51]
-    uses: ./.github/workflows/testPackageOnWindows.yml    
+    uses: ./.github/workflows/testPackageOnWindows.yml
     with:
       unreal-engine-association: "5.1"
       unreal-runner-label: "unreal-51"
@@ -501,9 +483,9 @@ jobs:
       unreal-batch-files-path: "C:/Program Files/Epic Games/UE_5.1/Engine/Build/BatchFiles"
       unreal-plugins-path: "C:/Program Files/Epic Games/UE_5.1/Engine/Plugins"
       test-package-base-name: "CesiumForUnreal-51"
-    secrets: inherit    
+    secrets: inherit
   Windows52:
-    uses: ./.github/workflows/buildWindows.yml    
+    uses: ./.github/workflows/buildWindows.yml
     with:
       unreal-engine-version: "5.2.0"
       unreal-runner-label: "unreal-52"
@@ -511,13 +493,13 @@ jobs:
       upload-package-base-name: "CesiumForUnreal-52-windows"
   TestWindows52:
     needs: [Windows52]
-    uses: ./.github/workflows/testWindows.yml    
+    uses: ./.github/workflows/testWindows.yml
     with:
       unreal-runner-label: "unreal-52"
       unreal-binaries-path: "C:/Program Files/Epic Games/UE_5.2/Engine/Binaries/Win64"
       unreal-plugins-path: "C:/Program Files/Epic Games/UE_5.2/Engine/Plugins"
       test-package-base-name: "CesiumForUnreal-52-windows"
-    secrets: inherit    
+    secrets: inherit
   Android52:
     runs-on: ["self-hosted","windows","x64","unreal-52"]
     steps:
@@ -753,7 +735,7 @@ jobs:
           path: combine
   TestPackage52:
     needs: [Combine52]
-    uses: ./.github/workflows/testPackageOnWindows.yml    
+    uses: ./.github/workflows/testPackageOnWindows.yml
     with:
       unreal-engine-association: "5.2"
       unreal-runner-label: "unreal-52"
@@ -761,4 +743,4 @@ jobs:
       unreal-batch-files-path: "C:/Program Files/Epic Games/UE_5.2/Engine/Build/BatchFiles"
       unreal-plugins-path: "C:/Program Files/Epic Games/UE_5.2/Engine/Plugins"
       test-package-base-name: "CesiumForUnreal-52"
-    secrets: inherit    
+    secrets: inherit


### PR DESCRIPTION
Our UE 5.1 build machine image previously used UE 5.1.0, and it has an apparent bug when doing Android builds. Some details here:
https://forums.unrealengine.com/t/5-1-missing-precompiled-manifest-error-when-building-code-plugin-for-android/691983

We had some hacky code in the build process to work around this. But after upgrading the build machine to use UE 5.1.1, the hack no longer works and should also no longer be necessary. So this PR removes it.