### PR TITLE
Account for y-inversion when rendering attenuated points

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 - Fixed a bug in `ACesiumSunSky` that could cause an error when it was created inside a sub-level.
 - `ACesiumGeoreference`, `ACesiumCameraManager`, and `ACesiumCreditSystem` are now created in the Persistent Level, even if the object that triggered their automatic creation (such as `ACesium3DTileset`) exists in a sub-level. It is very rarely useful to have instances of these objects within a sub-level.
 - An instance of `ACesiumCreditSystem` in a sub-level will no longer cause overlapping and broken-looking credits. However, we still recommend deleting credit system instances from sub-levels.
+- Fixed a bug introduced in v1.28.0 that prevented point clouds from rendering with attenuation.
 
 ### v1.28.0 - 2023-07-03
 

--- a/Shaders/Private/CesiumPointAttenuationVertexFactory.ush
+++ b/Shaders/Private/CesiumPointAttenuationVertexFactory.ush
@@ -235,15 +235,19 @@ float4 VertexFactoryGetPreviousWorldPosition(FVertexFactoryInput Input, FVertexF
 }
 
 float4 ApplyAttenuation(float4 WorldPosition, uint CornerIndex) {
-  	// Unreal uses counter-clockwise winding order.
+    // These offsets generate the quad like so:
+   	// 1 --- 2
+  	// |  /  |
   	// 0 --- 3
-  	// |  \  |
-  	// 1 --- 2
+  	// Unreal uses counter-clockwise winding order, but Cesium models are created
+    // with a y-inverting transform. To compensate, we create the quad facing the
+    // wrong way, such that when the transform is applied, the quad faces the right
+    // way.
 
   	// Results in -0.5 for 0, 1 and 0.5 for 2, 3
   	float OffsetX = CornerIndex / 2 - 0.5;
   	float OffsetY = -0.5f;
-  	if (CornerIndex == 0 || CornerIndex == 3) {
+  	if (CornerIndex == 1 || CornerIndex == 2) {
   	  	OffsetY = 0.5;
   	}
 


### PR DESCRIPTION
#1126 broke point cloud shading -- when attenuation is enabled, the point cloud disappears (though the outline is visible in the editor). The y-inversion matrix introduced in that change caused the quads to face the wrong way, so they wouldn't show up with back-face culling. You can confirm this by enabling "Two - Sided" on the Cesium base material; the point cloud does show up, although really dark because we're looking at the "back side" of all the quads.

This PR inverts the Y-offsets of the points in the shader, such that they will be corrected by the y-inversion matrix. 