### PR TITLE
Don't crash when building lighting for a level with a Cesium3DTileset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - `ACesiumGeoreference`, `ACesiumCameraManager`, and `ACesiumCreditSystem` are now created in the Persistent Level, even if the object that triggered their automatic creation (such as `ACesium3DTileset`) exists in a sub-level. It is very rarely useful to have instances of these objects within a sub-level.
 - An instance of `ACesiumCreditSystem` in a sub-level will no longer cause overlapping and broken-looking credits. However, we still recommend deleting credit system instances from sub-levels.
 - Fixed a bug introduced in v1.28.0 that prevented point clouds from rendering with attenuation.
+- Fixed a bug that caused `UnrealLightmass` to crash when attempting to build lighting containing static meshes created by a `Cesium3DTileset`.
 
 ### v1.28.0 - 2023-07-03
 

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -2134,6 +2134,7 @@ static void loadPrimitiveGameThreadPart(
 
   pStaticMesh->AddMaterial(pMaterial);
 
+  pStaticMesh->SetLightingGuid();
   pStaticMesh->InitResources();
 
   // Set up RenderData bounds and LOD data


### PR DESCRIPTION
Fixes #1180 

UnrealLightmass.exe is a separate process run via Swarm when building lighting. As reported in #1180, it (always? usually?) crashes when we attempt to build lighting (Build -> Build Lighting Only) for a level that has a Cesium3DTileset in it. Unfortunately it's build without any debug symbols, so I had to build it myself to debug it.

Having done that, I learned that the problem is that every `FStaticMeshLightingMesh` pointed to the same `FStaticMesh` instance, which really couldn't be right. And I learned that that was happening because, on import, all the static mesh references had the same GUID (all zeros!). Ok, so the problem seemed to be back in the Unreal Editor on the export side.

So, I traced through the code that exported the lightmass data, and yep, it was writing a GUID of all zeros. It got that GUID from a property on the `UStaticMesh` called `LightingGuid`. So how is that property set? I searched for it in the UE source code, and saw that things like `DatasmithStaticMeshImporter` call `SetLightingGuid` on the static just before they called `InitResources`. I added the same to our code that creates the static mesh in CesiumGltfComponent, and the lightmass crash went away.

I'll spare everyone the rant about how ridiculous it is that we have to call some random undocumented method on every static mesh we create in order to prevent UE's static lighting baking system from crashing. 🤷