### PR TITLE
Prevent crash when setting credit widget subclass

### DIFF
--- a/Source/CesiumRuntime/Public/CesiumCreditSystem.h
+++ b/Source/CesiumRuntime/Public/CesiumCreditSystem.h
@@ -44,7 +44,7 @@ public:
   virtual void BeginDestroy() override;
 
   UPROPERTY(EditDefaultsOnly, Category = "Cesium")
-  TSubclassOf<UUserWidget> CreditsWidgetClass;
+  TSubclassOf<class UScreenCreditsWidget> CreditsWidgetClass;
 
   /**
    * Whether the credit string has changed since last frame.


### PR DESCRIPTION
There is a widget subclass `CreditsWidgetClass` specified in CesiumCreditSystem.h that is currently set to be a subclass of a UUserWidget, so any user-created widget can be set in the editor for this variable. However, later code that uses this variable assumes that it is a subclass of UScreenCreditsWidget:

CesiumCreditSystem.cpp:254
```
    CreditsWidget =
        CreateWidget<UScreenCreditsWidget>(GetWorld(), CreditsWidgetClass);
```

At this point, if the user has inadvertently set an arbitrary widget for CreditsWidgetClass, then CreditsWidget will be invalid because CreditsWidgetClass is assumed to be a subclass of UScreenCreditsWidget.

This PR addresses that issue by making the TSubclassOf variable set to a UScreenCreditsWidget type in the first place, so that the user cannot specify an incompatible class.