### PR TITLE
Deprecate GeoTransforms class

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -20,6 +20,7 @@
 #include "CesiumCustomVersion.h"
 #include "CesiumGeospatial/Cartographic.h"
 #include "CesiumGeospatial/Ellipsoid.h"
+#include "CesiumGeospatial/GlobeTransforms.h"
 #include "CesiumGltf/ImageCesium.h"
 #include "CesiumGltf/Ktx2TranscodeTargets.h"
 #include "CesiumGltfComponent.h"
@@ -474,13 +475,10 @@ void ACesium3DTileset::OnFocusEditorViewportOnThis() {
       *this->GetName());
 
   struct CalculateECEFCameraPosition {
-
-    const GeoTransforms& localGeoTransforms;
-
     glm::dvec3 operator()(const CesiumGeometry::BoundingSphere& sphere) {
       const glm::dvec3& center = sphere.getCenter();
       glm::dmat4 ENU =
-          glm::dmat4(localGeoTransforms.ComputeEastNorthUpToEcef(center));
+          CesiumGeospatial::GlobeTransforms::eastNorthUpToFixedFrame(center);
       glm::dvec3 offset =
           sphere.getRadius() *
           glm::normalize(
@@ -493,7 +491,7 @@ void ACesium3DTileset::OnFocusEditorViewportOnThis() {
     operator()(const CesiumGeometry::OrientedBoundingBox& orientedBoundingBox) {
       const glm::dvec3& center = orientedBoundingBox.getCenter();
       glm::dmat4 ENU =
-          glm::dmat4(localGeoTransforms.ComputeEastNorthUpToEcef(center));
+          CesiumGeospatial::GlobeTransforms::eastNorthUpToFixedFrame(center);
       const glm::dmat3& halfAxes = orientedBoundingBox.getHalfAxes();
       glm::dvec3 offset =
           glm::length(halfAxes[0] + halfAxes[1] + halfAxes[2]) *
@@ -529,39 +527,37 @@ void ACesium3DTileset::OnFocusEditorViewportOnThis() {
   const Cesium3DTilesSelection::BoundingVolume& boundingVolume =
       pRootTile->getBoundingVolume();
 
+  ACesiumGeoreference* pGeoreference = this->ResolveGeoreference();
+
   // calculate unreal camera position
   const glm::dmat4& transform =
       this->GetCesiumTilesetToUnrealRelativeWorldTransform();
-  glm::dvec3 ecefCameraPosition = std::visit(
-      CalculateECEFCameraPosition{
-          this->ResolveGeoreference()->GetGeoTransforms()},
-      boundingVolume);
-  glm::dvec3 unrealCameraPosition =
-      glm::dvec3(transform * glm::dvec4(ecefCameraPosition, 1.0));
+  glm::dvec3 ecefCameraPosition =
+      std::visit(CalculateECEFCameraPosition{}, boundingVolume);
+  FVector unrealCameraPosition =
+      pGeoreference->TransformEarthCenteredEarthFixedPositionToUnreal(
+          VecMath::createVector(ecefCameraPosition));
 
   // calculate unreal camera orientation
   glm::dvec3 ecefCenter =
       Cesium3DTilesSelection::getBoundingVolumeCenter(boundingVolume);
-  glm::dvec3 unrealCenter = glm::dvec3(transform * glm::dvec4(ecefCenter, 1.0));
-  glm::dvec3 unrealCameraFront =
-      glm::normalize(unrealCenter - unrealCameraPosition);
-  glm::dvec3 unrealCameraRight =
-      glm::normalize(glm::cross(glm::dvec3(0.0, 0.0, 1.0), unrealCameraFront));
-  glm::dvec3 unrealCameraUp =
-      glm::normalize(glm::cross(unrealCameraFront, unrealCameraRight));
-  FRotator cameraRotator =
-      FMatrix(
-          FVector(
-              unrealCameraFront.x,
-              unrealCameraFront.y,
-              unrealCameraFront.z),
-          FVector(
-              unrealCameraRight.x,
-              unrealCameraRight.y,
-              unrealCameraRight.z),
-          FVector(unrealCameraUp.x, unrealCameraUp.y, unrealCameraUp.z),
-          FVector(0.0f, 0.0f, 0.0f))
-          .Rotator();
+  FVector unrealCenter =
+      pGeoreference->TransformEarthCenteredEarthFixedPositionToUnreal(
+          VecMath::createVector(ecefCenter));
+  FVector unrealCameraFront =
+      (unrealCenter - unrealCameraPosition).GetSafeNormal();
+  FVector unrealCameraRight =
+      FVector::CrossProduct(FVector::ZAxisVector, unrealCameraFront)
+          .GetSafeNormal();
+  FVector unrealCameraUp =
+      FVector::CrossProduct(unrealCameraFront, unrealCameraRight)
+          .GetSafeNormal();
+  FRotator cameraRotator = FMatrix(
+                               unrealCameraFront,
+                               unrealCameraRight,
+                               unrealCameraUp,
+                               FVector::ZeroVector)
+                               .Rotator();
 
   // Update all viewports.
   for (FLevelEditorViewportClient* LinkedViewportClient :
@@ -571,10 +567,7 @@ void ACesium3DTileset::OnFocusEditorViewportOnThis() {
       FViewportCameraTransform& ViewTransform =
           LinkedViewportClient->GetViewTransform();
       LinkedViewportClient->SetViewRotation(cameraRotator);
-      LinkedViewportClient->SetViewLocation(FVector(
-          unrealCameraPosition.x,
-          unrealCameraPosition.y,
-          unrealCameraPosition.z));
+      LinkedViewportClient->SetViewLocation(unrealCameraPosition);
       LinkedViewportClient->Invalidate();
     }
   }

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -530,8 +530,6 @@ void ACesium3DTileset::OnFocusEditorViewportOnThis() {
   ACesiumGeoreference* pGeoreference = this->ResolveGeoreference();
 
   // calculate unreal camera position
-  const glm::dmat4& transform =
-      this->GetCesiumTilesetToUnrealRelativeWorldTransform();
   glm::dvec3 ecefCameraPosition =
       std::visit(CalculateECEFCameraPosition{}, boundingVolume);
   FVector unrealCameraPosition =

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -621,7 +621,7 @@ ACesiumGeoreference::ComputeEastNorthUpToEcef(const FVector& ecef) const {
   return UCesiumWgs84Ellipsoid::EastNorthUpToEarthCenteredEarthFixed(ecef);
 }
 
-ACesiumGeoreference::ACesiumGeoreference() : AActor(), _geoTransforms() {
+ACesiumGeoreference::ACesiumGeoreference() : AActor() {
   PrimaryActorTick.bCanEverTick = true;
 
   this->Root = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
@@ -664,13 +664,12 @@ void ACesiumGeoreference::UpdateGeoreference() {
   OnGeoreferenceUpdated.Broadcast();
 }
 
-const GeoTransforms& ACesiumGeoreference::GetGeoTransforms() const noexcept {
+GeoTransforms ACesiumGeoreference::GetGeoTransforms() const noexcept {
   // Because GeoTransforms is deprecated, we only lazily update it.
-  this->_geoTransforms = GeoTransforms(
+  return GeoTransforms(
       Ellipsoid::WGS84,
       glm::dvec3(this->_coordinateSystem.getLocalToEcefTransformation()[3]),
       this->GetScale() / 100.0);
-  return this->_geoTransforms;
 }
 
 FName ACesiumGeoreference::DEFAULT_GEOREFERENCE_TAG =

--- a/Source/CesiumRuntime/Private/CesiumSunSky.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.cpp
@@ -525,10 +525,9 @@ void ACesiumSunSky::UpdateAtmosphereRadius() {
   } else {
     // Find the ellipsoid radius 100m below the surface at this location. See
     // the comment at the top of this file.
-    glm::dvec3 ecef = this->GetGeoreference()
-                          ->GetGeoTransforms()
-                          .TransformLongitudeLatitudeHeightToEcef(
-                              glm::dvec3(llh.X, llh.Y, -100.0));
+    glm::dvec3 ecef =
+        CesiumGeospatial::Ellipsoid::WGS84.cartographicToCartesian(
+            CesiumGeospatial::Cartographic::fromDegrees(llh.X, llh.Y, -100.0));
     double minRadius = glm::length(ecef);
 
     if (llh.Z / 1000.0 < this->InscribedGroundThreshold) {

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -45,14 +45,10 @@ void AGlobeAwareDefaultPawn::MoveUp_World(float Val) {
     return;
   }
 
-  glm::dvec4 upEcef(
-      this->_ellipsoid.geodeticSurfaceNormal(
-          VecMath::createVector3D(this->GlobeAnchor->GetECEF())),
-      0.0);
-  glm::dvec4 up = this->GlobeAnchor->ResolveGeoreference()
-                      ->GetGeoTransforms()
-                      .GetEllipsoidCenteredToAbsoluteUnrealWorldTransform() *
-                  upEcef;
+  FVector upEcef = UCesiumWgs84Ellipsoid::GeodeticSurfaceNormal(
+      this->GlobeAnchor->GetECEF());
+  FVector up = this->GlobeAnchor->ResolveGeoreference()
+                   ->TransformEarthCenteredEarthFixedDirectionToUnreal(upEcef);
 
   FTransform transform{};
   USceneComponent* pRootComponent = this->GetRootComponent();
@@ -63,9 +59,7 @@ void AGlobeAwareDefaultPawn::MoveUp_World(float Val) {
     }
   }
 
-  this->_moveAlongVector(
-      transform.TransformVector(FVector(up.x, up.y, up.z)),
-      Val);
+  this->_moveAlongVector(transform.TransformVector(up), Val);
 }
 
 FRotator AGlobeAwareDefaultPawn::GetViewRotation() const {

--- a/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
+++ b/Source/CesiumRuntime/Private/GlobeAwareDefaultPawn.cpp
@@ -41,14 +41,19 @@ void AGlobeAwareDefaultPawn::MoveForward(float Val) {
 }
 
 void AGlobeAwareDefaultPawn::MoveUp_World(float Val) {
-  if (Val == 0.0f || !IsValid(this->GlobeAnchor)) {
+  if (Val == 0.0f) {
+    return;
+  }
+
+  ACesiumGeoreference* pGeoreference = this->GetGeoreference();
+  if (!IsValid(pGeoreference)) {
     return;
   }
 
   FVector upEcef = UCesiumWgs84Ellipsoid::GeodeticSurfaceNormal(
       this->GlobeAnchor->GetECEF());
-  FVector up = this->GlobeAnchor->ResolveGeoreference()
-                   ->TransformEarthCenteredEarthFixedDirectionToUnreal(upEcef);
+  FVector up =
+      pGeoreference->TransformEarthCenteredEarthFixedDirectionToUnreal(upEcef);
 
   FTransform transform{};
   USceneComponent* pRootComponent = this->GetRootComponent();
@@ -64,6 +69,11 @@ void AGlobeAwareDefaultPawn::MoveUp_World(float Val) {
 
 FRotator AGlobeAwareDefaultPawn::GetViewRotation() const {
   if (!Controller) {
+    return this->GetActorRotation();
+  }
+
+  ACesiumGeoreference* pGeoreference = this->GetGeoreference();
+  if (!pGeoreference) {
     return this->GetActorRotation();
   }
 
@@ -90,8 +100,7 @@ FRotator AGlobeAwareDefaultPawn::GetViewRotation() const {
   FVector globePosition =
       transform.InverseTransformPosition(this->GetPawnViewLocation());
   FMatrix esuAdjustmentMatrix =
-      this->GetGeoreference()->ComputeEastSouthUpToUnrealTransformation(
-          globePosition) *
+      pGeoreference->ComputeEastSouthUpToUnrealTransformation(globePosition) *
       transform.ToMatrixNoScale();
 
   return FRotator(esuAdjustmentMatrix.ToQuat() * localRotation.Quaternion());
@@ -163,6 +172,10 @@ void AGlobeAwareDefaultPawn::FlyToLocationECEF(
         Error,
         TEXT(
             "Cannot start a flight because the pawn does not have a Controller. You probably need to \"possess\" it before attempting to initiate a flight."));
+    return;
+  }
+
+  if (!IsValid(this->GetGeoreference())) {
     return;
   }
 
@@ -256,13 +269,6 @@ void AGlobeAwareDefaultPawn::FlyToLocationLongitudeLatitudeHeight(
     double PitchAtDestination,
     bool CanInterruptByMoving) {
 
-  if (!IsValid(this->GetGeoreference())) {
-    UE_LOG(
-        LogCesium,
-        Warning,
-        TEXT("GlobeAwareDefaultPawn %s does not have a valid Georeference"),
-        *this->GetName());
-  }
   FVector ecef =
       UCesiumWgs84Ellipsoid::LongitudeLatitudeHeightToEarthCenteredEarthFixed(
           VecMath::createVector(LongitudeLatitudeHeightDestination));
@@ -290,13 +296,7 @@ void AGlobeAwareDefaultPawn::FlyToLocationLongitudeLatitudeHeight(
 bool AGlobeAwareDefaultPawn::ShouldTickIfViewportsOnly() const { return true; }
 
 void AGlobeAwareDefaultPawn::_handleFlightStep(float DeltaSeconds) {
-  if (!IsValid(this->GlobeAnchor)) {
-    UE_LOG(
-        LogCesium,
-        Warning,
-        TEXT(
-            "GlobeAwareDefaultPawn %s does not have a valid GeoreferenceComponent"),
-        *this->GetName());
+  if (!IsValid(this->GetGeoreference())) {
     return;
   }
 
@@ -386,11 +386,24 @@ ACesiumGeoreference* AGlobeAwareDefaultPawn::GetGeoreference() const {
     UE_LOG(
         LogCesium,
         Error,
-        TEXT("GlobeAwareDefaultPawn %s does not have a GlobeAnchorComponent"),
+        TEXT(
+            "GlobeAwareDefaultPawn %s does not have a valid GlobeAnchorComponent."),
         *this->GetName());
     return nullptr;
   }
-  return this->GlobeAnchor->ResolveGeoreference();
+
+  ACesiumGeoreference* pGeoreference = this->GlobeAnchor->ResolveGeoreference();
+  if (!IsValid(pGeoreference)) {
+    UE_LOG(
+        LogCesium,
+        Error,
+        TEXT(
+            "GlobeAwareDefaultPawn %s does not have a valie CesiumGeoreference."),
+        *this->GetName());
+    pGeoreference = nullptr;
+  }
+
+  return pGeoreference;
 }
 
 void AGlobeAwareDefaultPawn::_moveAlongViewAxis(EAxis::Type axis, double Val) {

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -693,6 +693,11 @@ public:
    */
   void UpdateGeoreference();
 
+  const CesiumGeospatial::LocalHorizontalCoordinateSystem&
+  getCoordinateSystem() const noexcept {
+    return this->_coordinateSystem;
+  }
+
 private:
   /**
    * A tag that is assigned to Georeferences when they are created

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "CesiumGeospatial/LocalHorizontalCoordinateSystem.h"
 #include "CesiumSubLevel.h"
 #include "Containers/UnrealString.h"
 #include "CoreMinimal.h"
@@ -498,7 +499,7 @@ public:
       BlueprintPure,
       Category = "Cesium",
       meta = (ReturnDisplayName = "UnrealToEarthCenteredEarthFixedMatrix"))
-  const FMatrix& ComputeUnrealToEarthCenteredEarthFixedTransformation() const;
+  FMatrix ComputeUnrealToEarthCenteredEarthFixedTransformation() const;
 
   /**
    * Computes the transformation matrix from the Earth-Centered, Earth-Fixed
@@ -512,7 +513,7 @@ public:
       BlueprintPure,
       Category = "Cesium",
       meta = (ReturnDisplayName = "EarthCenteredEarthFixedToUnrealMatrix"))
-  const FMatrix& ComputeEarthCenteredEarthFixedToUnrealTransformation() const;
+  FMatrix ComputeEarthCenteredEarthFixedToUnrealTransformation() const;
 
   /**
    * Computes the matrix that transforms from an East-South-Up frame centered at
@@ -618,6 +619,11 @@ protected:
 
 #pragma region Obsolete
 
+public:
+  [[deprecated(
+      "Use transformation functions on ACesiumGeoreference and UCesiumWgs84Ellipsoid instead.")]] const GeoTransforms&
+  GetGeoTransforms() const noexcept;
+
 private:
   PRAGMA_DISABLE_DEPRECATION_WARNINGS
   UPROPERTY(
@@ -687,15 +693,6 @@ public:
    */
   void UpdateGeoreference();
 
-  /**
-   * Returns the GeoTransforms that offers the same conversion
-   * functions as this class, but performs the computations
-   * in double precision.
-   */
-  const GeoTransforms& GetGeoTransforms() const noexcept {
-    return _geoTransforms;
-  }
-
 private:
   /**
    * A tag that is assigned to Georeferences when they are created
@@ -703,16 +700,12 @@ private:
    */
   static FName DEFAULT_GEOREFERENCE_TAG;
 
-  GeoTransforms _geoTransforms;
+  mutable GeoTransforms _geoTransforms;
+  CesiumGeospatial::LocalHorizontalCoordinateSystem _coordinateSystem{
+      glm::dmat4(1.0)};
 
   UPROPERTY()
   UCesiumSubLevelSwitcherComponent* SubLevelSwitcher;
-
-  // TODO: add option to set georeference directly from ECEF
-  void _setGeoreferenceOrigin(
-      double targetLongitude,
-      double targetLatitude,
-      double targetHeight);
 
   /**
    * @brief Updates the load state of sub-levels.
@@ -729,7 +722,7 @@ private:
    * Updates _geoTransforms based on the current ellipsoid and center, and
    * returns the old transforms.
    */
-  void _updateGeoTransforms();
+  void _updateCoordinateSystem();
 
   /**
    * Determines if this Georeference should manage sub-level switching.

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -626,7 +626,7 @@ protected:
 
 public:
   [[deprecated(
-      "Use transformation functions on ACesiumGeoreference and UCesiumWgs84Ellipsoid instead.")]] const GeoTransforms&
+      "Use transformation functions on ACesiumGeoreference and UCesiumWgs84Ellipsoid instead.")]] GeoTransforms
   GetGeoTransforms() const noexcept;
 
 private:
@@ -709,7 +709,6 @@ private:
    */
   static FName DEFAULT_GEOREFERENCE_TAG;
 
-  mutable GeoTransforms _geoTransforms;
   CesiumGeospatial::LocalHorizontalCoordinateSystem _coordinateSystem{
       glm::dmat4(1.0)};
 


### PR DESCRIPTION
This is PR into #1179 so merge that first.
It also depends on CesiumGS/cesium-native#696 so merge that first, too.

Between Unreal itself having double-precision vector and matrix types, and new capabilities in cesium-native (like `LocalHorizontalCoordinateSystem`), the `GeoTransforms` class is no longer needed.

This PR marks it deprecated and switches all of our uses of it to an alternative. I was really happy to see that this ends up deleting more code than it adds.

I didn't switch UCesiumGlobeAnchorComponent to use cesium-native's GlobeAnchor yet, so there's a little duplication because of that at the moment. That will be a separate PR.