### PR TITLE
Add missing headers.

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumSubLevelSwitcherComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSubLevelSwitcherComponent.cpp
@@ -1,4 +1,5 @@
 #include "CesiumSubLevelSwitcherComponent.h"
+#include "CesiumRuntime.h"
 #include "CesiumSubLevelComponent.h"
 #include "Engine/LevelStreaming.h"
 #include "Engine/World.h"

--- a/Source/CesiumRuntime/Private/Tests/CesiumTestHelpers.h
+++ b/Source/CesiumRuntime/Private/Tests/CesiumTestHelpers.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "CesiumRuntime.h"
 #include "EngineUtils.h"
 #include "Kismet/GameplayStatics.h"
 #include "Misc/AutomationTest.h"
@@ -15,7 +16,7 @@ class UWorld;
 
 namespace CesiumTestHelpers {
 
-static UWorld* getGlobalWorldContext();
+UWorld* getGlobalWorldContext();
 
 template <typename T>
 void waitForImpl(


### PR DESCRIPTION
These show up as compiler errors when building in non-unity mode.