### PR TITLE
Add workaround for Linux intermediates on the UE Marketplace.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,6 +226,15 @@ jobs:
         with:
           name: CesiumForUnreal-50-windows-${{ env.CESIUM_UNREAL_VERSION}}
           path: combine
+      - name: Unreal Marketplace Workaround
+        run: |
+          # The UE Marketplace deletes our Intermediates directory and fails to produces new
+          # intermediates for the Linux platform. The Marketplace team has suggested we copy
+          # them to the LinuxIntermediate directory instead, as a workaround. Users still have
+          # to move these files to the correct place manually, though, in order for Linux builds
+          # to succeed.
+          mkdir -p combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
+          cp -r combine/CesiumForUnreal/Intermediate/Build/Linux/* combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
       - name: Publish combined package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
@@ -467,6 +476,15 @@ jobs:
         with:
           name: CesiumForUnreal-51-windows-${{ env.CESIUM_UNREAL_VERSION}}
           path: combine
+      - name: Unreal Marketplace Workaround
+        run: |
+          # The UE Marketplace deletes our Intermediates directory and fails to produces new
+          # intermediates for the Linux platform. The Marketplace team has suggested we copy
+          # them to the LinuxIntermediate directory instead, as a workaround. Users still have
+          # to move these files to the correct place manually, though, in order for Linux builds
+          # to succeed.
+          mkdir -p combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
+          cp -r combine/CesiumForUnreal/Intermediate/Build/Linux/* combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
       - name: Publish combined package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
@@ -727,6 +745,15 @@ jobs:
         with:
           name: CesiumForUnreal-52-windows-${{ env.CESIUM_UNREAL_VERSION}}
           path: combine
+      - name: Unreal Marketplace Workaround
+        run: |
+          # The UE Marketplace deletes our Intermediates directory and fails to produces new
+          # intermediates for the Linux platform. The Marketplace team has suggested we copy
+          # them to the LinuxIntermediate directory instead, as a workaround. Users still have
+          # to move these files to the correct place manually, though, in order for Linux builds
+          # to succeed.
+          mkdir -p combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
+          cp -r combine/CesiumForUnreal/Intermediate/Build/Linux/* combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
       - name: Publish combined package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3

--- a/Config/FilterPlugin.ini
+++ b/Config/FilterPlugin.ini
@@ -7,4 +7,15 @@
 /CHANGES.md
 /Shaders/*
 /Intermediate/Build/Linux/*
+/LinuxInt/*
 /Binaries/Linux/*
+/LinuxIntermediate/Build/Linux/UnrealEditor/Inc/CesiumEditor/UHT/*
+/LinuxIntermediate/Build/Linux/UnrealEditor/Inc/CesiumRuntime/UHT/*
+/LinuxIntermediate/Build/Linux/UnrealGame/Development/CesiumRuntime/*
+/LinuxIntermediate/Build/Linux/UnrealGame/Inc/CesiumRuntime/UHT/*
+/LinuxIntermediate/Build/Linux/UnrealGame/Shipping/CesiumRuntime/*
+/LinuxIntermediate/Build/Linux/x64/UnrealGame/Development/CesiumRuntime/*
+/LinuxIntermediate/Build/Linux/x64/UnrealGame/Shipping/CesiumRuntime/*
+/LinuxIntermediate/Build/Linux/B4D820EA/UnrealGame/Development/CesiumRuntime/*
+/LinuxIntermediate/Build/Linux/B4D820EA/UnrealGame/Inc/CesiumRuntime/UHT/*
+/LinuxIntermediate/Build/Linux/B4D820EA/UnrealGame/Shipping/CesiumRuntime/*

--- a/Config/FilterPlugin.ini
+++ b/Config/FilterPlugin.ini
@@ -7,7 +7,6 @@
 /CHANGES.md
 /Shaders/*
 /Intermediate/Build/Linux/*
-/LinuxInt/*
 /Binaries/Linux/*
 /LinuxIntermediate/Build/Linux/UnrealEditor/Inc/CesiumEditor/UHT/*
 /LinuxIntermediate/Build/Linux/UnrealEditor/Inc/CesiumRuntime/UHT/*


### PR DESCRIPTION
The Unreal Marketplace build process for our plugin seems to a) delete our Linux intermediate files, and b) fail to produce new ones itself. As a workaround, the Marketplace team has told us to put our Linux intermediate files into a separate directory so that they can pass through Epic's build process unscathed. 🤷 So that's what this PR does. Users will also need to manually copy the files to the correct place, though, in order for Linux builds to work.