### PR TITLE
Fix ios52 CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -660,7 +660,7 @@ jobs:
           name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}
           path: packages
   iOS52:
-    runs-on: macos-13
+    runs-on: macos-12
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
We suspect that the macOS 13 image was recently updated and caused our ios52 builds to break. Revert to macOS 12, which seems to work fine.

Latest [broken builds](https://github.com/CesiumGS/cesium-unreal/actions/runs/6099938454/job/16553187907) show this
```
Operating System
  macOS
  13.5.1
  22G90
```

Previous [good builds](https://github.com/CesiumGS/cesium-unreal/actions/runs/6069027505/job/16462820024) show
```
Operating System
  macOS
  13.5
  22G74
```
