### PR TITLE
Clear RF_Public flag on our Actors in PostLoad

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@
 - `ACesiumGeoreference`, `ACesiumCameraManager`, and `ACesiumCreditSystem` are now created in the Persistent Level, even if the object that triggered their automatic creation (such as `ACesium3DTileset`) exists in a sub-level. It is very rarely useful to have instances of these objects within a sub-level.
 - An instance of `ACesiumCreditSystem` in a sub-level will no longer cause overlapping and broken-looking credits. However, we still recommend deleting credit system instances from sub-levels.
 - `ACesiumCartographicPolygon` now operates on the parts of the tileset that are shown in the Editor viewport, even if it is used with a Cesium3DTileset with a non-identity transformation.
+- Fixed bug where older scenes that used Cesium UI created actors could have their `RF_Public` flag set. This could cause problems when converting an existing level to World Partition, or perhaps cause other subtle issues that we haven't realized yet.
 
 ### v1.30.1 - 2023-09-03
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -2089,7 +2089,13 @@ void ACesium3DTileset::PostLoad() {
 
   Super::PostLoad();
 
-  CesiumActors::validateActorFlags(this);
+#if WITH_EDITOR
+  // Only do this in the editor, when not in play mode
+  // We want to exclude fixing up any objects that aren't in this level
+  if (!GEditor->IsPlaySessionInProgress()) {
+    CesiumActors::validateActorFlags(this);
+  }
+#endif
 }
 
 void ACesium3DTileset::Serialize(FArchive& Ar) {

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -12,6 +12,7 @@
 #include "Cesium3DTilesSelection/TilesetOptions.h"
 #include "Cesium3DTilesetLoadFailureDetails.h"
 #include "Cesium3DTilesetRoot.h"
+#include "CesiumActors.h"
 #include "CesiumAsync/IAssetResponse.h"
 #include "CesiumBoundingVolumeComponent.h"
 #include "CesiumCamera.h"
@@ -2087,6 +2088,8 @@ void ACesium3DTileset::PostLoad() {
                                 // actor to have correct BodyInstance values.
 
   Super::PostLoad();
+
+  CesiumActors::validateActorFlags(this);
 }
 
 void ACesium3DTileset::Serialize(FArchive& Ar) {

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -2089,13 +2089,8 @@ void ACesium3DTileset::PostLoad() {
 
   Super::PostLoad();
 
-#if WITH_EDITOR
-  // Only do this in the editor, when not in play mode
-  // We want to exclude fixing up any objects that aren't in this level
-  if (!GEditor->IsPlaySessionInProgress()) {
+  if (CesiumActors::shouldValidateFlags(this))
     CesiumActors::validateActorFlags(this);
-  }
-#endif
 }
 
 void ACesium3DTileset::Serialize(FArchive& Ar) {

--- a/Source/CesiumRuntime/Private/CesiumActors.cpp
+++ b/Source/CesiumRuntime/Private/CesiumActors.cpp
@@ -23,3 +23,35 @@ glm::dvec4 CesiumActors::getWorldOrigin4D(const AActor* actor) {
   const FIntVector& originLocation = world->OriginLocation;
   return glm::dvec4(originLocation.X, originLocation.Y, originLocation.Z, 1.0);
 }
+
+void CesiumActors::validatePublicFlag(UObject* object, const FString& label) {
+  //
+  // From an Epic Engine Developer...
+  // RF_Public means that the object is an asset, so it should be only set for
+  // worlds, textures, meshes, etc. This flags essentially says it's ok to
+  // have a reference to public objects from other packages (with the
+  // exception of worlds). Actors are not assets since they are part of a
+  // level which is part of a world, etc. that's why they should not key the
+  // public flag.
+  //
+  // In earlier versions of cesium-unreal, this flag may have been set
+  //
+  if (object->HasAnyFlags(RF_Public)) {
+    UE_LOG(
+        LogCesium,
+        Display,
+        TEXT("Clearing invalid RF_Public flag on %s"),
+        *label);
+    object->ClearFlags(RF_Public);
+  }
+}
+
+void CesiumActors::validateActorFlags(AActor* actor) {
+  FString label = FString("actor: ") + *actor->GetName();
+  validatePublicFlag(actor, label);
+}
+
+void CesiumActors::validateActorComponentFlags(UActorComponent* component) {
+  FString label = FString("actor component: ") + *component->GetName();
+  validatePublicFlag(component, label);
+}

--- a/Source/CesiumRuntime/Private/CesiumActors.cpp
+++ b/Source/CesiumRuntime/Private/CesiumActors.cpp
@@ -4,6 +4,10 @@
 #include "CesiumRuntime.h"
 #include "Engine/World.h"
 
+#if WITH_EDITOR
+#include "Editor.h"
+#endif
+
 #include <glm/glm.hpp>
 
 glm::dvec4 CesiumActors::getWorldOrigin4D(const AActor* actor) {
@@ -22,6 +26,24 @@ glm::dvec4 CesiumActors::getWorldOrigin4D(const AActor* actor) {
   }
   const FIntVector& originLocation = world->OriginLocation;
   return glm::dvec4(originLocation.X, originLocation.Y, originLocation.Z, 1.0);
+}
+
+bool CesiumActors::shouldValidateFlags(UObject* object) {
+#if WITH_EDITOR
+  // Only fixup flags in the editor, when not in play mode
+  if (GEditor->IsPlaySessionInProgress())
+    return false;
+
+  // In addition, don't fix when loading from an asset file, which sets the
+  // RF_ClassDefaultObject and RF_ArchetypeObject flags.
+  if (object->HasAnyFlags(RF_ClassDefaultObject) ||
+      object->HasAnyFlags(RF_ArchetypeObject))
+    return false;
+  else
+    return true;
+#else
+  return false;
+#endif
 }
 
 void CesiumActors::validatePublicFlag(UObject* object, const FString& label) {

--- a/Source/CesiumRuntime/Private/CesiumActors.h
+++ b/Source/CesiumRuntime/Private/CesiumActors.h
@@ -29,6 +29,7 @@ public:
    */
   static glm::dvec4 getWorldOrigin4D(const AActor* actor);
 
+  static bool shouldValidateFlags(UObject* object);
   static void validateActorFlags(AActor* actor);
   static void validateActorComponentFlags(UActorComponent* component);
 

--- a/Source/CesiumRuntime/Private/CesiumActors.h
+++ b/Source/CesiumRuntime/Private/CesiumActors.h
@@ -28,4 +28,10 @@ public:
    * @return The world origin
    */
   static glm::dvec4 getWorldOrigin4D(const AActor* actor);
+
+  static void validateActorFlags(AActor* actor);
+  static void validateActorComponentFlags(UActorComponent* component);
+
+private:
+  static void validatePublicFlag(UObject* object, const FString& label);
 };

--- a/Source/CesiumRuntime/Private/CesiumCartographicPolygon.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCartographicPolygon.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 CesiumGS, Inc. and Contributors
 
 #include "CesiumCartographicPolygon.h"
+#include "CesiumActors.h"
 #include "CesiumUtility/Math.h"
 #include "Components/SceneComponent.h"
 #include "StaticMeshResources.h"
@@ -78,4 +79,10 @@ void ACesiumCartographicPolygon::MakeLinear() {
   for (size_t i = 0; i < this->Polygon->GetNumberOfSplinePoints(); ++i) {
     this->Polygon->SetSplinePointType(i, ESplinePointType::Linear);
   }
+}
+
+void ACesiumCartographicPolygon::PostLoad() {
+  Super::PostLoad();
+
+  CesiumActors::validateActorFlags(this);
 }

--- a/Source/CesiumRuntime/Private/CesiumCartographicPolygon.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCartographicPolygon.cpp
@@ -7,6 +7,10 @@
 #include "StaticMeshResources.h"
 #include <glm/glm.hpp>
 
+#if WITH_EDITOR
+#include "Editor.h"
+#endif
+
 using namespace CesiumGeospatial;
 
 ACesiumCartographicPolygon::ACesiumCartographicPolygon() : AActor() {
@@ -84,5 +88,11 @@ void ACesiumCartographicPolygon::MakeLinear() {
 void ACesiumCartographicPolygon::PostLoad() {
   Super::PostLoad();
 
-  CesiumActors::validateActorFlags(this);
+#if WITH_EDITOR
+  // Only do this in the editor, when not in play mode
+  // We want to exclude fixing up any objects that aren't in this level
+  if (!GEditor->IsPlaySessionInProgress()) {
+    CesiumActors::validateActorFlags(this);
+  }
+#endif
 }

--- a/Source/CesiumRuntime/Private/CesiumCartographicPolygon.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCartographicPolygon.cpp
@@ -7,10 +7,6 @@
 #include "StaticMeshResources.h"
 #include <glm/glm.hpp>
 
-#if WITH_EDITOR
-#include "Editor.h"
-#endif
-
 using namespace CesiumGeospatial;
 
 ACesiumCartographicPolygon::ACesiumCartographicPolygon() : AActor() {
@@ -88,11 +84,6 @@ void ACesiumCartographicPolygon::MakeLinear() {
 void ACesiumCartographicPolygon::PostLoad() {
   Super::PostLoad();
 
-#if WITH_EDITOR
-  // Only do this in the editor, when not in play mode
-  // We want to exclude fixing up any objects that aren't in this level
-  if (!GEditor->IsPlaySessionInProgress()) {
+  if (CesiumActors::shouldValidateFlags(this))
     CesiumActors::validateActorFlags(this);
-  }
-#endif
 }

--- a/Source/CesiumRuntime/Private/CesiumIonRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumIonRasterOverlay.cpp
@@ -7,10 +7,6 @@
 #include "CesiumRuntime.h"
 #include "CesiumRuntimeSettings.h"
 
-#if WITH_EDITOR
-#include "Editor.h"
-#endif
-
 void UCesiumIonRasterOverlay::TroubleshootToken() {
   OnCesiumRasterOverlayIonTroubleshooting.Broadcast(this);
 }
@@ -45,11 +41,6 @@ UCesiumIonRasterOverlay::CreateOverlay(
 void UCesiumIonRasterOverlay::PostLoad() {
   Super::PostLoad();
 
-#if WITH_EDITOR
-  // Only fixup flags in the editor, when not in play mode
-  // We want to exclude fixing up any objects that aren't in this level
-  if (!GEditor->IsPlaySessionInProgress()) {
+  if (CesiumActors::shouldValidateFlags(this))
     CesiumActors::validateActorComponentFlags(this);
-  }
-#endif
 }

--- a/Source/CesiumRuntime/Private/CesiumIonRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumIonRasterOverlay.cpp
@@ -7,6 +7,10 @@
 #include "CesiumRuntime.h"
 #include "CesiumRuntimeSettings.h"
 
+#if WITH_EDITOR
+#include "Editor.h"
+#endif
+
 void UCesiumIonRasterOverlay::TroubleshootToken() {
   OnCesiumRasterOverlayIonTroubleshooting.Broadcast(this);
 }
@@ -41,5 +45,11 @@ UCesiumIonRasterOverlay::CreateOverlay(
 void UCesiumIonRasterOverlay::PostLoad() {
   Super::PostLoad();
 
-  CesiumActors::validateActorComponentFlags(this);
+#if WITH_EDITOR
+  // Only fixup flags in the editor, when not in play mode
+  // We want to exclude fixing up any objects that aren't in this level
+  if (!GEditor->IsPlaySessionInProgress()) {
+    CesiumActors::validateActorComponentFlags(this);
+  }
+#endif
 }

--- a/Source/CesiumRuntime/Private/CesiumIonRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumIonRasterOverlay.cpp
@@ -3,6 +3,7 @@
 #include "CesiumIonRasterOverlay.h"
 #include "Cesium3DTilesSelection/IonRasterOverlay.h"
 #include "Cesium3DTilesSelection/Tileset.h"
+#include "CesiumActors.h"
 #include "CesiumRuntime.h"
 #include "CesiumRuntimeSettings.h"
 
@@ -35,4 +36,10 @@ UCesiumIonRasterOverlay::CreateOverlay(
       this->IonAssetID,
       TCHAR_TO_UTF8(*token),
       options);
+}
+
+void UCesiumIonRasterOverlay::PostLoad() {
+  Super::PostLoad();
+
+  CesiumActors::validateActorComponentFlags(this);
 }

--- a/Source/CesiumRuntime/Public/CesiumCartographicPolygon.h
+++ b/Source/CesiumRuntime/Public/CesiumCartographicPolygon.h
@@ -51,6 +51,9 @@ public:
   CesiumGeospatial::CartographicPolygon
   CreateCartographicPolygon(const FTransform& worldToTileset) const;
 
+  // AActor overrides
+  virtual void PostLoad() override;
+
 protected:
   virtual void BeginPlay() override;
 

--- a/Source/CesiumRuntime/Public/CesiumIonRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumIonRasterOverlay.h
@@ -50,6 +50,9 @@ public:
   UFUNCTION(CallInEditor, Category = "Cesium")
   void TroubleshootToken();
 
+  // UActorComponent overrides
+  virtual void PostLoad() override;
+
 protected:
   virtual std::unique_ptr<Cesium3DTilesSelection::RasterOverlay> CreateOverlay(
       const Cesium3DTilesSelection::RasterOverlayOptions& options = {})


### PR DESCRIPTION
Closes issue with same name, #1114 .

Based on the changes in #1111 , the only actors that could have previously had the `RF_Public` flag set would be `ACesium3DTileset`, `ACesiumCartographicPolygon`, and `UCesiumIonRasterOverlay` (actor component).

Hook into these classes' `PostLoad` and clear this flag if it set.

Tested using cesium-unreal-samples, 02_CesiumMelbourne and 08_CesiumClipping