### PR TITLE
Make sure editor sub-levels are hidden even when not ticking.

### DIFF
--- a/Source/CesiumEditor/Private/CesiumEditorSubLevelMutex.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditorSubLevelMutex.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020-2023 CesiumGS, Inc. and Contributors
 
 #include "CesiumEditorSubLevelMutex.h"
+#include "Async/Async.h"
 #include "CesiumGeoreference.h"
 #include "CesiumSubLevelComponent.h"
 #include "CesiumSubLevelSwitcherComponent.h"
@@ -38,9 +39,31 @@ void CesiumEditorSubLevelMutex::OnMarkRenderStateDirty(
   if (pSwitcher == nullptr)
     return;
 
+  bool needsTick = false;
+
   if (!pLevelInstance->IsTemporarilyHiddenInEditor(true)) {
     pSwitcher->SetTarget(pLevelInstance);
+    needsTick = true;
   } else if (pSwitcher->GetTarget() == pLevelInstance) {
     pSwitcher->SetTarget(nullptr);
+    needsTick = true;
+  }
+
+  UWorld* pWorld = pGeoreference->GetWorld();
+  if (needsTick && pWorld && !pWorld->IsGameWorld()) {
+    // Other sub-levels won't be deactivated until
+    // UCesiumSubLevelSwitcherComponent next ticks. Normally that's no problem,
+    // but in some unusual cases it will never happen. For example, in UE 5.3,
+    // when running tests on CI with `-nullrhi`. Or if you close all your
+    // viewports in the Editor. So here we schedule a game thread task to ensure
+    // that _updateSubLevelStateEditor is called. It won't do any harm if we are
+    // ticking and it ends up being called multiple times.
+    TWeakObjectPtr<UCesiumSubLevelSwitcherComponent> pSwitcherWeak = pSwitcher;
+    AsyncTask(ENamedThreads::GameThread, [pSwitcherWeak]() {
+      UCesiumSubLevelSwitcherComponent* pSwitcher = pSwitcherWeak.Get();
+      if (pSwitcher) {
+        pSwitcher->_updateSubLevelStateEditor();
+      }
+    });
   }
 }

--- a/Source/CesiumRuntime/Public/CesiumSubLevelSwitcherComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumSubLevelSwitcherComponent.h
@@ -97,4 +97,6 @@ private:
 
   bool _doExtraChecksOnNextTick = false;
   bool _isTransitioningSubLevels = false;
+
+  friend class CesiumEditorSubLevelMutex;
 };


### PR DESCRIPTION
Fixes the test that was disabled in #1218 because it failed in UE 5.3.

The problem is that in UE 5.3, when running headless, ActorComponents never have their TickComponent called. Why? Because there are no editor viewports, and so the engine only does a `ELevelTick::LEVELTICK_TimeOnly` type of tick, which explicitly does not tick actor or their components. Without the `UCesiumSubLevelSwitcherComponent` tick, there's nothing that disables other sub-levels when a new one is activated.

I don't know if this is a UE 5.3 bug. The closest thing I can find in the changelog is this:

> Disabled real-time viewports when the editor process is in the background and bThrottleCPUWhenNotForeground.

But in any case I've worked around it in this PR by making `CesiumEditorSubLevelMutex` now explicitly schedule the necessary operation on the game thread. This way it will still happen even if the engine doesn't tick. It's harmless and has almost no cost for it to happen multiple times.