### PR TITLE
Fix crash when a selected tile leaves the viewport 

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumLifetime.cpp
+++ b/Source/CesiumRuntime/Private/CesiumLifetime.cpp
@@ -2,6 +2,9 @@
 
 #include "CesiumLifetime.h"
 #include "CesiumRuntime.h"
+#include "Editor.h"
+#include "Editor/EditorEngine.h"
+#include "Engine/Selection.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/Texture2D.h"
 #include "PhysicsEngine/BodySetup.h"
@@ -37,6 +40,15 @@ CesiumLifetime::destroyComponentRecursively(USceneComponent* pComponent) {
   for (USceneComponent* pChild : children) {
     destroyComponentRecursively(pChild);
   }
+
+#if WITH_EDITOR
+  // If the editor is currently selecting this, remove the reference
+  if (GEditor) {
+    USelection* editorSelection = GEditor->GetSelectedComponents();
+    if (editorSelection && editorSelection->IsSelected(pComponent))
+      editorSelection->Deselect(pComponent);
+  }
+#endif
 
   pComponent->DestroyPhysicsState();
   pComponent->DestroyComponent();


### PR DESCRIPTION
Closes #1220 

Add code to `CesiumLifetime::destroyComponentRecursively` to deselect a component from the editor if we're about to destroy it.

One would think that the Unreal Editor would automatically update its selection if a component gets destroyed, but that's not the case here. For reference, I deleted some actors + components through the editor UI, traced though some engine code, and found that these delete actions have editor specific code that handles the deletion and deselection logic. 

Our tiling code is unique in comparison. When moving the view around, tiles can stream in and out, creating / destroying objects without going through editor code at all (`CesiumLifetime::destroyComponentRecursively`). The is mostly ok, except in corner cases like this, where we've selected a component in the viewport, and it gets destroyed.

If there's a more optimal solution, I'm open to ideas.

