### PR TITLE
Remove Unreal Engine 5.0 support from CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,247 +11,6 @@ jobs:
         run: |
           npm install
           npm run format -- --dry-run -Werror
-  Windows50:
-    uses: ./.github/workflows/buildWindows.yml
-    with:
-      unreal-engine-version: "5.0.0"
-      unreal-runner-label: "unreal-50"
-      unreal-batch-files-path: "C:/Program Files/Epic Games/UE_5.0/Engine/Build/BatchFiles"
-      upload-package-base-name: "CesiumForUnreal-50-windows"
-    secrets: inherit
-  TestWindows50:
-    needs: [Windows50]
-    uses: ./.github/workflows/testWindows.yml
-    with:
-      unreal-runner-label: "unreal-50"
-      unreal-binaries-path: "C:/Program Files/Epic Games/UE_5.0/Engine/Binaries/Win64"
-      unreal-plugins-path: "C:/Program Files/Epic Games/UE_5.0/Engine/Plugins"
-      test-package-base-name: "CesiumForUnreal-50-windows"
-    secrets: inherit
-  Android50:
-    runs-on: ["self-hosted","windows","x64","unreal-50"]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0 # so that `git describe` works.
-      - name: Set environment variables
-        run: |
-          $ENV:CESIUM_UNREAL_VERSION=$(git describe)
-          $ENV:BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-50-android-${ENV:CESIUM_UNREAL_VERSION}"
-          # Make these available to subsequent steps
-          echo "CESIUM_UNREAL_VERSION=${ENV:CESIUM_UNREAL_VERSION}" >> $ENV:GITHUB_ENV
-          echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=${ENV:BUILD_CESIUM_UNREAL_PACKAGE_NAME}" >> $ENV:GITHUB_ENV
-      - name: Install nasm
-        uses: ilammy/setup-nasm@v1.4.0
-      - name: Build cesium-native
-        run: |
-          cd extern
-          cmake -B build-android -S . -G Ninja -DCMAKE_TOOLCHAIN_FILE="unreal-android-toolchain.cmake" -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release
-          cmake --build build-android --config Release --target install -j8
-      - name: Build plugin
-        run: |
-          cd "C:/Program Files/Epic Games/UE_5.0/Engine/Build/BatchFiles"
-          ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Android -NoHostPlatform
-      - name: Publish plugin package artifact
-        if: ${{ success() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}
-          path: packages
-  Linux50:
-    runs-on: ["self-hosted","windows","x64","unreal-50"]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0 # so that `git describe` works.
-      - name: Set environment variables
-        run: |
-          $ENV:CESIUM_UNREAL_VERSION=$(git describe)
-          $ENV:BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-50-linux-${ENV:CESIUM_UNREAL_VERSION}"
-          # Make these available to subsequent steps
-          echo "CESIUM_UNREAL_VERSION=${ENV:CESIUM_UNREAL_VERSION}" >> $ENV:GITHUB_ENV
-          echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=${ENV:BUILD_CESIUM_UNREAL_PACKAGE_NAME}" >> $ENV:GITHUB_ENV
-      - name: Install nasm
-        uses: ilammy/setup-nasm@v1.4.0
-      - name: Build cesium-native
-        run: |
-          $ENV:UNREAL_ENGINE_DIR="C:/Program Files/Epic Games/UE_5.0"
-          $ENV:LINUX_MULTIARCH_ROOT="C:/UnrealToolchains/v19_clang-11.0.1-centos7/"
-          $ENV:UNREAL_ENGINE_COMPILER_DIR="${ENV:LINUX_MULTIARCH_ROOT}x86_64-unknown-linux-gnu"
-          $ENV:UNREAL_ENGINE_LIBCXX_DIR="${ENV:UNREAL_ENGINE_DIR}/Engine/Source/ThirdParty/Unix/LibCxx"
-          cd extern
-          cmake -B build -S . -G Ninja -DCMAKE_TOOLCHAIN_FILE="unreal-linux-from-windows-toolchain.cmake" -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release
-          cmake --build build --config Release --target install -j8
-      - name: Build plugin
-        run: |
-          cd "C:/Program Files/Epic Games/UE_5.0/Engine/Build/BatchFiles"
-          ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Linux -NoHostPlatform
-      - name: Publish plugin package artifact
-        if: ${{ success() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}
-          path: packages
-  macOS50:
-    runs-on: macos-11
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: us-east-1
-    steps:
-      - name: Get Unreal Engine
-        run: |
-          aws s3 cp s3://cesium-unreal-engine/5.0.1/macOS/UE501.zip .
-          unzip -q UE501.zip -d $HOME
-          rm UE501.zip
-      - name: Check out repository code
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0 # so that `git describe` works.
-      - name: Set environment variables
-        run: |
-          export CESIUM_UNREAL_VERSION=$(git describe)
-          export BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-50-macos-${CESIUM_UNREAL_VERSION}"
-          # Make these available to subsequent steps
-          echo "CESIUM_UNREAL_VERSION=${CESIUM_UNREAL_VERSION}" >> $GITHUB_ENV
-          echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=${BUILD_CESIUM_UNREAL_PACKAGE_NAME}" >> $GITHUB_ENV
-      - name: Install nasm
-        uses: ilammy/setup-nasm@v1.4.0
-      - name: Build cesium-native
-        run: |
-          mkdir -p extern/build
-          cd extern/build
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
-          cmake --build . -j4 --target install
-          cd ../..
-          rm -rf extern
-      - name: Build plugin
-        run: |
-          export UNREAL_ENGINE_DIR=$HOME/UE_5.0
-          cd $UNREAL_ENGINE_DIR/Engine/Build/BatchFiles
-          ./RunUAT.sh BuildPlugin -Plugin="$GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Mac
-      - name: Publish plugin package artifact
-        if: ${{ success() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}
-          path: packages
-  iOS50:
-    runs-on: macos-11
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: us-east-1
-    steps:
-      - name: Get Unreal Engine
-        run: |
-          aws s3 cp s3://cesium-unreal-engine/5.0.1/macOS/UE501.zip .
-          unzip -q UE501.zip -d $HOME
-          rm UE501.zip
-      - name: Check out repository code
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0 # so that `git describe` works.
-      - name: Set environment variables
-        run: |
-          export CESIUM_UNREAL_VERSION=$(git describe)
-          export BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-50-ios-${CESIUM_UNREAL_VERSION}"
-          # Make these available to subsequent steps
-          echo "CESIUM_UNREAL_VERSION=${CESIUM_UNREAL_VERSION}" >> $GITHUB_ENV
-          echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=${BUILD_CESIUM_UNREAL_PACKAGE_NAME}" >> $GITHUB_ENV
-      - name: Install nasm
-        uses: ilammy/setup-nasm@v1.4.0
-      - name: Build cesium-native
-        run: |
-          mkdir -p extern/build-ios
-          cd extern
-          cmake -B build-ios -S . -GXcode -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-fembed-bitcode" -DCMAKE_C_FLAGS="-fembed-bitcode"
-          cmake --build build-ios -j 4 --target install --config Release -- -quiet # XCode output maxes out Travis log - Need to make it quiet
-          cd ..
-          rm -rf extern
-      - name: Build plugin
-        run: |
-          export UNREAL_ENGINE_DIR=$HOME/UE_5.0
-          cd $UNREAL_ENGINE_DIR/Engine/Build/BatchFiles
-          ./RunUAT.sh BuildPlugin -Plugin="$GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=iOS -NoHostPlatform
-      - name: Publish plugin package artifact
-        if: ${{ success() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}
-          path: packages
-  Combine50:
-    runs-on: ubuntu-latest
-    needs: [Windows50, Android50, Linux50, macOS50, iOS50]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # so that `git describe` works.
-      - name: Set environment variables
-        run: |
-          export CESIUM_UNREAL_VERSION=$(git describe)
-          export BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-50-${CESIUM_UNREAL_VERSION}"
-          # Make these available to subsequent steps
-          echo "CESIUM_UNREAL_VERSION=$CESIUM_UNREAL_VERSION" >> $GITHUB_ENV
-          echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=$BUILD_CESIUM_UNREAL_PACKAGE_NAME" >> $GITHUB_ENV
-      - name: Download iOS build
-        uses: actions/download-artifact@v3
-        with:
-          name: CesiumForUnreal-50-ios-${{ env.CESIUM_UNREAL_VERSION}}
-          path: combine
-      - name: Download macOS build
-        uses: actions/download-artifact@v3
-        with:
-          name: CesiumForUnreal-50-macos-${{ env.CESIUM_UNREAL_VERSION}}
-          path: combine
-      - name: Download Android build
-        uses: actions/download-artifact@v3
-        with:
-          name: CesiumForUnreal-50-android-${{ env.CESIUM_UNREAL_VERSION}}
-          path: combine
-      - name: Download Linux build
-        uses: actions/download-artifact@v3
-        with:
-          name: CesiumForUnreal-50-linux-${{ env.CESIUM_UNREAL_VERSION}}
-          path: combine
-      - name: Download Windows build
-        uses: actions/download-artifact@v3
-        with:
-          name: CesiumForUnreal-50-windows-${{ env.CESIUM_UNREAL_VERSION}}
-          path: combine
-      - name: Unreal Marketplace Workaround
-        run: |
-          # The UE Marketplace deletes our Intermediates directory and fails to produces new
-          # intermediates for the Linux platform. The Marketplace team has suggested we copy
-          # them to the LinuxIntermediate directory instead, as a workaround. Users still have
-          # to move these files to the correct place manually, though, in order for Linux builds
-          # to succeed.
-          mkdir -p combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
-          cp -r combine/CesiumForUnreal/Intermediate/Build/Linux/* combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
-      - name: Publish combined package artifact
-        if: ${{ success() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}
-          path: combine
-  TestPackage50:
-    needs: [Combine50]
-    uses: ./.github/workflows/testPackageOnWindows.yml
-    with:
-      unreal-engine-association: "5.0"
-      unreal-runner-label: "unreal-50"
-      unreal-binaries-path: "C:/Program Files/Epic Games/UE_5.0/Engine/Binaries/Win64"
-      unreal-batch-files-path: "C:/Program Files/Epic Games/UE_5.0/Engine/Build/BatchFiles"
-      unreal-plugins-path: "C:/Program Files/Epic Games/UE_5.0/Engine/Plugins"
-      test-package-base-name: "CesiumForUnreal-50"
-    secrets: inherit
   Windows51:
     uses: ./.github/workflows/buildWindows.yml
     with:
@@ -293,7 +52,6 @@ jobs:
           cmake --build build-android --config Release --target install -j8
       - name: Build plugin
         run: |
-          ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.0.0"','"EngineVersion": "5.1.0"') | Set-Content -Path CesiumForUnreal.uplugin
           cd "C:/Program Files/Epic Games/UE_5.1/Engine/Build/BatchFiles"
           ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Android -NoHostPlatform
       - name: Publish plugin package artifact
@@ -330,7 +88,6 @@ jobs:
           cmake --build build --config Release --target install -j8
       - name: Build plugin
         run: |
-          ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.0.0"','"EngineVersion": "5.1.0"') | Set-Content -Path CesiumForUnreal.uplugin
           $ENV:LINUX_MULTIARCH_ROOT="C:/UnrealToolchains/v20_clang-13.0.1-centos7/"
           cd "C:/Program Files/Epic Games/UE_5.1/Engine/Build/BatchFiles"
           ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Linux -NoHostPlatform
@@ -376,7 +133,6 @@ jobs:
           rm -rf extern
       - name: Build plugin
         run: |
-          sed -i '' 's/\"EngineVersion\": \"5.0.0\"/\"EngineVersion\": \"5.1.0\"/g' CesiumForUnreal.uplugin
           export UNREAL_ENGINE_DIR=$HOME/UE_5.1
           cd $UNREAL_ENGINE_DIR/Engine/Build/BatchFiles
           ./RunUAT.sh BuildPlugin -Plugin="$GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Mac
@@ -426,7 +182,6 @@ jobs:
           rm -rf extern
       - name: Build plugin
         run: |
-          sed -i '' 's/\"EngineVersion\": \"5.0.0\"/\"EngineVersion\": \"5.1.0\"/g' CesiumForUnreal.uplugin
           export UNREAL_ENGINE_DIR=$HOME/UE_5.1
           cd $UNREAL_ENGINE_DIR/Engine/Build/BatchFiles
           ./RunUAT.sh BuildPlugin -Plugin="$GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=iOS -NoHostPlatform
@@ -542,7 +297,7 @@ jobs:
           cmake --build build-android --config Release --target install -j8
       - name: Build plugin
         run: |
-          ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.0.0"','"EngineVersion": "5.2.0"') | Set-Content -Path CesiumForUnreal.uplugin
+          ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.1.0"','"EngineVersion": "5.2.0"') | Set-Content -Path CesiumForUnreal.uplugin
           cd "C:/Program Files/Epic Games/UE_5.2/Engine/Build/BatchFiles"
           ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Android -NoHostPlatform
       - name: Publish plugin package artifact
@@ -583,7 +338,7 @@ jobs:
           rm -rf extern
       - name: Build plugin
         run: |
-          sed -i 's/\"EngineVersion\": \"5.0.0\"/\"EngineVersion\": \"5.2.0\"/g' CesiumForUnreal.uplugin
+          sed -i 's/\"EngineVersion\": \"5.1.0\"/\"EngineVersion\": \"5.2.0\"/g' CesiumForUnreal.uplugin
           export LINUX_MULTIARCH_ROOT="/opt/ue52/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v21_clang-15.0.1-centos7/"
           cd /opt/ue52/Engine/Build/BatchFiles
           # UnrealBuildTool writes to write to ~/.config and loses its mind if it doesn't exist. So create it.
@@ -649,7 +404,7 @@ jobs:
           rm -rf extern
       - name: Build plugin
         run: |
-          sed -i '' 's/\"EngineVersion\": \"5.0.0\"/\"EngineVersion\": \"5.2.0\"/g' CesiumForUnreal.uplugin
+          sed -i '' 's/\"EngineVersion\": \"5.1.0\"/\"EngineVersion\": \"5.2.0\"/g' CesiumForUnreal.uplugin
           export UNREAL_ENGINE_DIR=$HOME/UE_5.2
           cd $UNREAL_ENGINE_DIR/Engine/Build/BatchFiles
           ./RunUAT.sh BuildPlugin -Plugin="$GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Mac
@@ -695,7 +450,7 @@ jobs:
           rm -rf extern
       - name: Build plugin
         run: |
-          sed -i '' 's/\"EngineVersion\": \"5.0.0\"/\"EngineVersion\": \"5.2.0\"/g' CesiumForUnreal.uplugin
+          sed -i '' 's/\"EngineVersion\": \"5.1.0\"/\"EngineVersion\": \"5.2.0\"/g' CesiumForUnreal.uplugin
           export UNREAL_ENGINE_DIR=$HOME/UE_5.2
           cd $UNREAL_ENGINE_DIR/Engine/Build/BatchFiles
           ./RunUAT.sh BuildPlugin -Plugin="$GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=iOS -NoHostPlatform
@@ -811,7 +566,7 @@ jobs:
           cmake --build build-android --config Release --target install -j8
       - name: Build plugin
         run: |
-          ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.0.0"','"EngineVersion": "5.3.0"') | Set-Content -Path CesiumForUnreal.uplugin
+          ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.1.0"','"EngineVersion": "5.3.0"') | Set-Content -Path CesiumForUnreal.uplugin
           cd "C:/Program Files/Epic Games/UE_5.3/Engine/Build/BatchFiles"
           ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Android -NoHostPlatform
       - name: Publish plugin package artifact
@@ -852,7 +607,7 @@ jobs:
           rm -rf extern
       - name: Build plugin
         run: |
-          sed -i 's/\"EngineVersion\": \"5.0.0\"/\"EngineVersion\": \"5.3.0\"/g' CesiumForUnreal.uplugin
+          sed -i 's/\"EngineVersion\": \"5.1.0\"/\"EngineVersion\": \"5.3.0\"/g' CesiumForUnreal.uplugin
           export LINUX_MULTIARCH_ROOT="/opt/ue53/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/v22_clang-16.0.6-centos7/"
           cd /opt/ue53/Engine/Build/BatchFiles
           # UnrealBuildTool writes to write to ~/.config and loses its mind if it doesn't exist. So create it.
@@ -918,7 +673,7 @@ jobs:
           rm -rf extern
       - name: Build plugin
         run: |
-          sed -i '' 's/\"EngineVersion\": \"5.0.0\"/\"EngineVersion\": \"5.3.0\"/g' CesiumForUnreal.uplugin
+          sed -i '' 's/\"EngineVersion\": \"5.1.0\"/\"EngineVersion\": \"5.3.0\"/g' CesiumForUnreal.uplugin
           export UNREAL_ENGINE_DIR=$HOME/UE_5.3
           cd $UNREAL_ENGINE_DIR/Engine/Build/BatchFiles
           ./RunUAT.sh BuildPlugin -Plugin="$GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Mac
@@ -964,7 +719,7 @@ jobs:
           rm -rf extern
       - name: Build plugin
         run: |
-          sed -i '' 's/\"EngineVersion\": \"5.0.0\"/\"EngineVersion\": \"5.3.0\"/g' CesiumForUnreal.uplugin
+          sed -i '' 's/\"EngineVersion\": \"5.1.0\"/\"EngineVersion\": \"5.3.0\"/g' CesiumForUnreal.uplugin
           export UNREAL_ENGINE_DIR=$HOME/UE_5.3
           cd $UNREAL_ENGINE_DIR/Engine/Build/BatchFiles
           ./RunUAT.sh BuildPlugin -Plugin="$GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=iOS -NoHostPlatform

--- a/CesiumForUnreal.uplugin
+++ b/CesiumForUnreal.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "https://cesium.com/learn/unreal/",
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/87b0d05800a545d49bf858ef3458c4f7",
 	"SupportURL": "https://community.cesium.com",
-	"EngineVersion": "5.0.0",
+	"EngineVersion": "5.1.0",
 	"CanContainContent": true,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,


### PR DESCRIPTION
We now require UE 5.1+. I haven't done all the potential code cleanup that we could do after removing 5.0; I've just removed it from CI.