### PR TITLE
Improve build error handling on Continuous Integration (CI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     with:
       unreal-engine-version: "5.1.0"
       unreal-runner-label: "unreal-51"
-      unreal-batch-files-path: "C:/Program Files/Epic Games/UE_5.1/Engine/Build/BatchFiles"
+      unreal-program-name: "UE_5.1"
       upload-package-base-name: "CesiumForUnreal-51-windows"
     secrets: inherit
   TestWindows51:
@@ -262,7 +262,7 @@ jobs:
     with:
       unreal-engine-version: "5.2.0"
       unreal-runner-label: "unreal-52"
-      unreal-batch-files-path: "C:/Program Files/Epic Games/UE_5.2/Engine/Build/BatchFiles"
+      unreal-program-name: "UE_5.2"
       upload-package-base-name: "CesiumForUnreal-52-windows"
   TestWindows52:
     needs: [Windows52]
@@ -531,7 +531,7 @@ jobs:
     with:
       unreal-engine-version: "5.3.0"
       unreal-runner-label: "unreal-53"
-      unreal-batch-files-path: "C:/Program Files/Epic Games/UE_5.3/Engine/Build/BatchFiles"
+      unreal-program-name: "UE_5.3"
       upload-package-base-name: "CesiumForUnreal-53-windows"
   TestWindows53:
     needs: [Windows53]

--- a/.github/workflows/buildWindows.yml
+++ b/.github/workflows/buildWindows.yml
@@ -73,9 +73,9 @@ jobs:
         run: |
           echo "Temp directory: $env:TEMP"
           cd "$env:UNREAL_BATCH_FILES_PATH"
-          $exitCode = ./RunUAT.bat BuildPlugin -Plugin="$env:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$env:BUILD_CESIUM_UNREAL_PACKAGE_PATH" -CreateSubFolder -TargetPlatforms=Win64
-          echo ExitCode=$exitCode
-          if ($exitCode -eq 0) {
+          $consoleLog = ./RunUAT.bat BuildPlugin -Plugin="$env:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$env:BUILD_CESIUM_UNREAL_PACKAGE_PATH" -CreateSubFolder -TargetPlatforms=Win64
+          echo LastExitCode=$LASTEXITCODE
+          if ($LASTEXITCODE -eq 0) {
             exit 0
           }
           else {

--- a/.github/workflows/buildWindows.yml
+++ b/.github/workflows/buildWindows.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           echo "Temp directory: $env:TEMP"
           cd "$env:UNREAL_BATCH_FILES_PATH"
-          $consoleLog = ./RunUAT.bat BuildPlugin -Plugin="$env:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$env:BUILD_CESIUM_UNREAL_PACKAGE_PATH" -CreateSubFolder -TargetPlatforms=Win64
+          ./RunUAT.bat BuildPlugin -Plugin="$env:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$env:BUILD_CESIUM_UNREAL_PACKAGE_PATH" -CreateSubFolder -TargetPlatforms=Win64
           echo LastExitCode=$LASTEXITCODE
           if ($LASTEXITCODE -eq 0) {
             exit 0
@@ -81,12 +81,6 @@ jobs:
           else {
             exit -1
           }
-      - name: Display build log 
-        if: always()
-        run: |
-          cd "$env:UNREAL_BUILD_LOG_PATH"  
-          dir 
-          Get-Content Log.txt
       - name: Upload plugin artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/buildWindows.yml
+++ b/.github/workflows/buildWindows.yml
@@ -74,6 +74,7 @@ jobs:
           echo "Temp directory: $env:TEMP"
           cd "$env:UNREAL_BATCH_FILES_PATH"
           $exitCode = ./RunUAT.bat BuildPlugin -Plugin="$env:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$env:BUILD_CESIUM_UNREAL_PACKAGE_PATH" -CreateSubFolder -TargetPlatforms=Win64
+          echo ExitCode=$exitCode
           if ($exitCode -eq 0) {
             exit 0
           }

--- a/.github/workflows/buildWindows.yml
+++ b/.github/workflows/buildWindows.yml
@@ -80,7 +80,7 @@ jobs:
           else {
             exit -1
           }
-       - name: Display build log 
+      - name: Display build log 
         if: always()
         run: |
           cd "$env:UNREAL_BUILD_LOG_PATH"  

--- a/.github/workflows/buildWindows.yml
+++ b/.github/workflows/buildWindows.yml
@@ -9,7 +9,7 @@ on:
       unreal-runner-label:
         required: true
         type: string
-      unreal-batch-files-path:
+      unreal-program-name:
         required: true
         type: string
       upload-package-base-name:
@@ -37,7 +37,8 @@ jobs:
           $env:CESIUM_UNREAL_VERSION=$(git describe)
           $env:BUILD_CESIUM_UNREAL_PACKAGE_NAME="${{ inputs.upload-package-base-name }}-${env:CESIUM_UNREAL_VERSION}"
           $env:BUILD_CESIUM_UNREAL_PACKAGE_PATH="$env:GITHUB_WORKSPACE/packages/CesiumForUnreal"
-          $env:UNREAL_BATCH_FILES_PATH="${{ inputs.unreal-batch-files-path }}"
+          $env:UNREAL_BATCH_FILES_PATH="C:/Program Files/Epic Games/${{ inputs.unreal-program-name }}/Engine/Build/BatchFiles"
+          $env:UNREAL_BUILD_LOG_PATH="C:/Users/ec2-user/AppData/Roaming/Unreal Engine/AutomationTool/Logs\C+Program+Files+Epic+Games+${{ inputs.unreal-program-name }}"
 
           # Store temp files on the D drive, which is much faster than the EBS-backed C drive.
           mkdir -p d:\cesium\temp
@@ -47,6 +48,7 @@ jobs:
           echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=${env:BUILD_CESIUM_UNREAL_PACKAGE_NAME}" >> $env:GITHUB_ENV
           echo "BUILD_CESIUM_UNREAL_PACKAGE_PATH=${env:BUILD_CESIUM_UNREAL_PACKAGE_PATH}" >> $env:GITHUB_ENV
           echo "UNREAL_BATCH_FILES_PATH=${env:UNREAL_BATCH_FILES_PATH}" >> $env:GITHUB_ENV
+          echo "UNREAL_BUILD_LOG_PATH=${env:UNREAL_BUILD_LOG_PATH}" >> $env:GITHUB_ENV
           echo "TEMP=${env:TEMP}" >> $env:GITHUB_ENV
 
           # Confirm vars to the console
@@ -54,6 +56,7 @@ jobs:
           echo BUILD_CESIUM_UNREAL_PACKAGE_NAME=$env:BUILD_CESIUM_UNREAL_PACKAGE_NAME
           echo BUILD_CESIUM_UNREAL_PACKAGE_PATH=$env:BUILD_CESIUM_UNREAL_PACKAGE_PATH
           echo UNREAL_BATCH_FILES_PATH=$env:UNREAL_BATCH_FILES_PATH
+          echo UNREAL_BUILD_LOG_PATH=$env:UNREAL_BUILD_LOG_PATH
           echo TEMP=$env:TEMP
       - name: Install nasm
         uses: ilammy/setup-nasm@v1.4.0
@@ -70,7 +73,19 @@ jobs:
         run: |
           echo "Temp directory: $env:TEMP"
           cd "$env:UNREAL_BATCH_FILES_PATH"
-          ./RunUAT.bat BuildPlugin -Plugin="$env:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$env:BUILD_CESIUM_UNREAL_PACKAGE_PATH" -CreateSubFolder -TargetPlatforms=Win64
+          $exitCode = ./RunUAT.bat BuildPlugin -Plugin="$env:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$env:BUILD_CESIUM_UNREAL_PACKAGE_PATH" -CreateSubFolder -TargetPlatforms=Win64
+          if ($exitCode -eq 0) {
+            exit 0
+          }
+          else {
+            exit -1
+          }
+       - name: Display build log 
+        if: always()
+        run: |
+          cd "$env:UNREAL_BUILD_LOG_PATH"  
+          dir 
+          Get-Content Log.txt
       - name: Upload plugin artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/buildWindows.yml
+++ b/.github/workflows/buildWindows.yml
@@ -38,7 +38,7 @@ jobs:
           $env:BUILD_CESIUM_UNREAL_PACKAGE_NAME="${{ inputs.upload-package-base-name }}-${env:CESIUM_UNREAL_VERSION}"
           $env:BUILD_CESIUM_UNREAL_PACKAGE_PATH="$env:GITHUB_WORKSPACE/packages/CesiumForUnreal"
           $env:UNREAL_BATCH_FILES_PATH="C:/Program Files/Epic Games/${{ inputs.unreal-program-name }}/Engine/Build/BatchFiles"
-          $env:UNREAL_BUILD_LOG_PATH="C:/Users/ec2-user/AppData/Roaming/Unreal Engine/AutomationTool/Logs\C+Program+Files+Epic+Games+${{ inputs.unreal-program-name }}"
+          $env:UNREAL_BUILD_LOG_PATH="C:/Users/ec2-user/AppData/Roaming/Unreal Engine/AutomationTool/Logs/C+Program+Files+Epic+Games+${{ inputs.unreal-program-name }}"
 
           # Store temp files on the D drive, which is much faster than the EBS-backed C drive.
           mkdir -p d:\cesium\temp

--- a/.github/workflows/buildWindows.yml
+++ b/.github/workflows/buildWindows.yml
@@ -38,7 +38,6 @@ jobs:
           $env:BUILD_CESIUM_UNREAL_PACKAGE_NAME="${{ inputs.upload-package-base-name }}-${env:CESIUM_UNREAL_VERSION}"
           $env:BUILD_CESIUM_UNREAL_PACKAGE_PATH="$env:GITHUB_WORKSPACE/packages/CesiumForUnreal"
           $env:UNREAL_BATCH_FILES_PATH="C:/Program Files/Epic Games/${{ inputs.unreal-program-name }}/Engine/Build/BatchFiles"
-          $env:UNREAL_BUILD_LOG_PATH="C:/Users/ec2-user/AppData/Roaming/Unreal Engine/AutomationTool/Logs/C+Program+Files+Epic+Games+${{ inputs.unreal-program-name }}"
 
           # Store temp files on the D drive, which is much faster than the EBS-backed C drive.
           mkdir -p d:\cesium\temp
@@ -48,7 +47,6 @@ jobs:
           echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=${env:BUILD_CESIUM_UNREAL_PACKAGE_NAME}" >> $env:GITHUB_ENV
           echo "BUILD_CESIUM_UNREAL_PACKAGE_PATH=${env:BUILD_CESIUM_UNREAL_PACKAGE_PATH}" >> $env:GITHUB_ENV
           echo "UNREAL_BATCH_FILES_PATH=${env:UNREAL_BATCH_FILES_PATH}" >> $env:GITHUB_ENV
-          echo "UNREAL_BUILD_LOG_PATH=${env:UNREAL_BUILD_LOG_PATH}" >> $env:GITHUB_ENV
           echo "TEMP=${env:TEMP}" >> $env:GITHUB_ENV
 
           # Confirm vars to the console
@@ -56,7 +54,6 @@ jobs:
           echo BUILD_CESIUM_UNREAL_PACKAGE_NAME=$env:BUILD_CESIUM_UNREAL_PACKAGE_NAME
           echo BUILD_CESIUM_UNREAL_PACKAGE_PATH=$env:BUILD_CESIUM_UNREAL_PACKAGE_PATH
           echo UNREAL_BATCH_FILES_PATH=$env:UNREAL_BATCH_FILES_PATH
-          echo UNREAL_BUILD_LOG_PATH=$env:UNREAL_BUILD_LOG_PATH
           echo TEMP=$env:TEMP
       - name: Install nasm
         uses: ilammy/setup-nasm@v1.4.0

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -81,6 +81,8 @@ public:
   ACesium3DTileset();
   virtual ~ACesium3DTileset();
 
+  This is an error
+  
 private:
   UPROPERTY(VisibleAnywhere, Category = "Cesium")
   USceneComponent* Root;

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -81,8 +81,6 @@ public:
   ACesium3DTileset();
   virtual ~ACesium3DTileset();
 
-  This is an error
-  
 private:
   UPROPERTY(VisibleAnywhere, Category = "Cesium")
   USceneComponent* Root;

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -33,6 +33,8 @@ class UCesiumBoundingVolumePoolComponent;
 class CesiumViewExtension;
 struct FCesiumCamera;
 
+Here is an error
+
 namespace Cesium3DTilesSelection {
 class Tileset;
 class TilesetView;

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -33,8 +33,6 @@ class UCesiumBoundingVolumePoolComponent;
 class CesiumViewExtension;
 struct FCesiumCamera;
 
-Here is an error
-
 namespace Cesium3DTilesSelection {
 class Tileset;
 class TilesetView;


### PR DESCRIPTION
Fix bug where CI wouldn't show an error on the build step. 

This would not only lead to a false positive, but would also upload artifacts even when the build wasn't valid.

Applies to Windows builds only.

Closes #1235 