### PR TITLE
Don't use `std::variant` in `FCesiumPropertyTableProperty`

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumPropertyTableProperty.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPropertyTableProperty.cpp
@@ -3,26 +3,823 @@
 #include "CesiumPropertyTableProperty.h"
 #include "CesiumGltf/PropertyTypeTraits.h"
 #include "CesiumMetadataConversions.h"
+#include <utility>
 
 using namespace CesiumGltf;
 
 namespace {
-template <typename T, typename Callback>
-T callback(
-    const std::variant<
-        PropertyTablePropertyViewType,
-        NormalizedPropertyTablePropertyViewType>& property,
-    Callback&& callback) {
-  if (std::holds_alternative<CesiumGltf::PropertyTablePropertyViewType>(
-          property)) {
-    return std::visit(
-        callback,
-        std::get<CesiumGltf::PropertyTablePropertyViewType>(property));
+/**
+ * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
+ * of the given type and normalization. If the std::any is not of the specified
+ * type, the callback is performed on an invalid PropertyTablePropertyView
+ * instead.
+ *
+ * @param property The std::any containing the property.
+ * @param callback The callback function.
+ *
+ * @tparam TProperty The type of the PropertyTablePropertyView.
+ * @tparam Normalized Whether the PropertyTablePropertyView is normalized.
+ * @tparam TResult The type of the output from the callback function.
+ * @tparam Callback The callback function type.
+ */
+template <
+    typename TProperty,
+    bool Normalized,
+    typename TResult,
+    typename Callback>
+TResult propertyTablePropertyCallback(std::any property, Callback&& callback) {
+  if (property.type() ==
+      typeid(PropertyTablePropertyView<TProperty, Normalized>)) {
+    return callback(
+        std::any_cast<PropertyTablePropertyView<TProperty, Normalized>>(
+            property));
   }
 
-  return std::visit(
-      callback,
-      std::get<CesiumGltf::NormalizedPropertyTablePropertyViewType>(property));
+  return callback(PropertyTablePropertyView<uint8>());
+}
+
+/**
+ * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
+ * on a scalar type. This restricts the number of typeid checks done on the
+ * std::any. If the valueType does not have a valid component type, the callback
+ * is performed on an invalid PropertyTablePropertyView instead.
+ *
+ * @param property The std::any containing the property.
+ * @param valueType The FCesiumMetadataValueType of the property.
+ * @param callback The callback function.
+ *
+ * @tparam Normalized Whether the PropertyTablePropertyView is normalized.
+ * @tparam TResult The type of the output from the callback function.
+ * @tparam Callback The callback function type.
+ */
+template <bool Normalized, typename TResult, typename Callback>
+TResult scalarPropertyTablePropertyCallback(
+    std::any property,
+    FCesiumMetadataValueType valueType,
+    Callback&& callback) {
+  switch (valueType.ComponentType) {
+  case ECesiumMetadataComponentType::Int8:
+    return propertyTablePropertyCallback<int8, Normalized, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint8:
+    return propertyTablePropertyCallback<uint8, Normalized, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int16:
+    return propertyTablePropertyCallback<int16, Normalized, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint16:
+    return propertyTablePropertyCallback<uint16, Normalized, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int32:
+    return propertyTablePropertyCallback<int32, Normalized, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint32:
+    return propertyTablePropertyCallback<uint32, Normalized, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int64:
+    return propertyTablePropertyCallback<int64, Normalized, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint64:
+    return propertyTablePropertyCallback<uint64, Normalized, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Float32:
+    return propertyTablePropertyCallback<float, false, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Float64:
+    return propertyTablePropertyCallback<double, false, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
+  default:
+    return callback(PropertyTablePropertyView<uint8>());
+  }
+}
+
+/**
+ * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
+ * on a scalar array type. This restricts the number of typeid checks done on
+ * the std::any. If the valueType does not have a valid component type, the
+ * callback is performed on an invalid PropertyTablePropertyView instead.
+ *
+ * @param property The std::any containing the property.
+ * @param valueType The FCesiumMetadataValueType of the property.
+ * @param callback The callback function.
+ *
+ * @tparam Normalized Whether the PropertyTablePropertyView is normalized.
+ * @tparam TResult The type of the output from the callback function.
+ * @tparam Callback The callback function type.
+ */
+template <bool Normalized, typename TResult, typename Callback>
+TResult scalarArrayPropertyTablePropertyCallback(
+    std::any property,
+    FCesiumMetadataValueType valueType,
+    Callback&& callback) {
+  switch (valueType.ComponentType) {
+  case ECesiumMetadataComponentType::Int8:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<int8>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint8:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<uint8>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int16:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<int16>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint16:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<uint16>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int32:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<int32>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint32:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<uint32>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int64:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<int64>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint64:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<uint64>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Float32:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<float>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Float64:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<double>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  default:
+    return callback(PropertyTablePropertyView<uint8>());
+  }
+}
+
+/**
+ * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
+ * on a glm::vecN type. This restricts the number of typeid checks done on the
+ * std::any. If the valueType does not have a valid component type, the callback
+ * is performed on an invalid PropertyTablePropertyView instead.
+ *
+ * @param property The std::any containing the property.
+ * @param valueType The FCesiumMetadataValueType of the property.
+ * @param callback The callback function.
+ *
+ * @tparam N The dimensions of the glm::vecN
+ * @tparam Normalized Whether the PropertyTablePropertyView is normalized.
+ * @tparam TResult The type of the output from the callback function.
+ * @tparam Callback The callback function type.
+ */
+template <glm::length_t N, bool Normalized, typename TResult, typename Callback>
+TResult vecNPropertyTablePropertyCallback(
+    std::any property,
+    FCesiumMetadataValueType valueType,
+    Callback&& callback) {
+  switch (valueType.ComponentType) {
+  case ECesiumMetadataComponentType::Int8:
+    return propertyTablePropertyCallback<
+        glm::vec<N, int8>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint8:
+    return propertyTablePropertyCallback<
+        glm::vec<N, uint8>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int16:
+    return propertyTablePropertyCallback<
+        glm::vec<N, int16>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint16:
+    return propertyTablePropertyCallback<
+        glm::vec<N, uint16>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int32:
+    return propertyTablePropertyCallback<
+        glm::vec<N, int32>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint32:
+    return propertyTablePropertyCallback<
+        glm::vec<N, uint32>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int64:
+    return propertyTablePropertyCallback<
+        glm::vec<N, int64>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint64:
+    return propertyTablePropertyCallback<
+        glm::vec<N, uint64>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Float32:
+    return propertyTablePropertyCallback<
+        glm::vec<N, float>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Float64:
+    return propertyTablePropertyCallback<
+        glm::vec<N, double>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  default:
+    return callback(PropertyTablePropertyView<uint8>());
+  }
+}
+
+/**
+ * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
+ * on a glm::vecN type. This restricts the number of typeid checks done on the
+ * std::any. If the valueType does not have a valid component type, the callback
+ * is performed on an invalid PropertyTablePropertyView instead.
+ *
+ * @param property The std::any containing the property.
+ * @param valueType The FCesiumMetadataValueType of the property.
+ * @param callback The callback function.
+ *
+ * @tparam Normalized Whether the PropertyTablePropertyView is normalized.
+ * @tparam TResult The type of the output from the callback function.
+ * @tparam Callback The callback function type.
+ */
+template <bool Normalized, typename TResult, typename Callback>
+TResult vecNPropertyTablePropertyCallback(
+    std::any property,
+    FCesiumMetadataValueType valueType,
+    Callback&& callback) {
+  if (valueType.Type == ECesiumMetadataType::Vec2) {
+    return vecNPropertyTablePropertyCallback<2, Normalized, TResult, Callback>(
+        property,
+        valueType,
+        std::forward<Callback>(callback));
+  }
+
+  if (valueType.Type == ECesiumMetadataType::Vec3) {
+    return vecNPropertyTablePropertyCallback<3, Normalized, TResult, Callback>(
+        property,
+        valueType,
+        std::forward<Callback>(callback));
+  }
+
+  if (valueType.Type == ECesiumMetadataType::Vec4) {
+    return vecNPropertyTablePropertyCallback<4, Normalized, TResult, Callback>(
+        property,
+        valueType,
+        std::forward<Callback>(callback));
+  }
+
+  return callback(PropertyTablePropertyView<uint8>());
+}
+
+/**
+ * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
+ * on a glm::vecN array type. This restricts the number of typeid checks done on
+ * the std::any. If the valueType does not have a valid component type, the
+ * callback is performed on an invalid PropertyTablePropertyView instead.
+ *
+ * @param property The std::any containing the property.
+ * @param valueType The FCesiumMetadataValueType of the property.
+ * @param callback The callback function.
+ *
+ * @tparam N The dimensions of the glm::vecN
+ * @tparam Normalized Whether the PropertyTablePropertyView is normalized.
+ * @tparam TResult The type of the output from the callback function.
+ * @tparam Callback The callback function type.
+ */
+template <glm::length_t N, bool Normalized, typename TResult, typename Callback>
+TResult vecNArrayPropertyTablePropertyCallback(
+    std::any property,
+    FCesiumMetadataValueType valueType,
+    Callback&& callback) {
+  switch (valueType.ComponentType) {
+  case ECesiumMetadataComponentType::Int8:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, int8>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint8:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, uint8>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int16:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, int16>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint16:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, uint16>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int32:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, int32>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint32:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, uint32>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int64:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, int64>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint64:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, uint64>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Float32:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, float>>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Float64:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, double>>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  default:
+    return callback(PropertyTablePropertyView<uint8>());
+  }
+}
+
+/**
+ * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
+ * on a glm::vecN array type. This restricts the number of typeid checks done on
+ * the std::any. If the valueType does not have a valid component type, the
+ * callback is performed on an invalid PropertyTablePropertyView instead.
+ *
+ * @param property The std::any containing the property.
+ * @param valueType The FCesiumMetadataValueType of the property.
+ * @param callback The callback function.
+ *
+ * @tparam Normalized Whether the PropertyTablePropertyView is normalized.
+ * @tparam TResult The type of the output from the callback function.
+ * @tparam Callback The callback function type.
+ */
+template <bool Normalized, typename TResult, typename Callback>
+TResult vecNArrayPropertyTablePropertyCallback(
+    std::any property,
+    FCesiumMetadataValueType valueType,
+    Callback&& callback) {
+  if (valueType.Type == ECesiumMetadataType::Vec2) {
+    return vecNArrayPropertyTablePropertyCallback<
+        2,
+        Normalized,
+        TResult,
+        Callback>(property, valueType, std::forward<Callback>(callback));
+  }
+
+  if (valueType.Type == ECesiumMetadataType::Vec3) {
+    return vecNArrayPropertyTablePropertyCallback<
+        3,
+        Normalized,
+        TResult,
+        Callback>(property, valueType, std::forward<Callback>(callback));
+  }
+
+  if (valueType.Type == ECesiumMetadataType::Vec4) {
+    return vecNArrayPropertyTablePropertyCallback<
+        4,
+        Normalized,
+        TResult,
+        Callback>(property, valueType, std::forward<Callback>(callback));
+  }
+
+  return callback(PropertyTablePropertyView<uint8>());
+}
+
+/**
+ * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
+ * on a glm::matN type. This restricts the number of typeid checks done on the
+ * std::any. If the valueType does not have a valid component type, the callback
+ * is performed on an invalid PropertyTablePropertyView instead.
+ *
+ * @param property The std::any containing the property.
+ * @param valueType The FCesiumMetadataValueType of the property.
+ * @param callback The callback function.
+ *
+ * @tparam N The dimensions of the glm::matN
+ * @tparam TNormalized Whether the PropertyTablePropertyView is normalized.
+ * @tparam TResult The type of the output from the callback function.
+ * @tparam Callback The callback function type.
+ */
+template <glm::length_t N, bool Normalized, typename TResult, typename Callback>
+TResult matNPropertyTablePropertyCallback(
+    std::any property,
+    FCesiumMetadataValueType valueType,
+    Callback&& callback) {
+  switch (valueType.ComponentType) {
+  case ECesiumMetadataComponentType::Int8:
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, int8>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint8:
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, uint8>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int16:
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, int16>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint16:
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, uint16>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int32:
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, int32>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint32:
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, uint32>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int64:
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, int64>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint64:
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, uint64>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Float32:
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, float>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Float64:
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, double>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  default:
+    return callback(PropertyTablePropertyView<uint8>());
+  }
+}
+
+/**
+ * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
+ * on a glm::matN type. This restricts the number of typeid checks done on the
+ * std::any. If the valueType does not have a valid component type, the callback
+ * is performed on an invalid PropertyTablePropertyView instead.
+ *
+ * @param property The std::any containing the property.
+ * @param valueType The FCesiumMetadataValueType of the property.
+ * @param callback The callback function.
+ *
+ * @tparam Normalized Whether the PropertyTablePropertyView is normalized.
+ * @tparam TResult The type of the output from the callback function.
+ * @tparam Callback The callback function type.
+ */
+template <bool Normalized, typename TResult, typename Callback>
+TResult matNPropertyTablePropertyCallback(
+    std::any property,
+    FCesiumMetadataValueType valueType,
+    Callback&& callback) {
+  if (valueType.Type == ECesiumMetadataType::Mat2) {
+    return matNPropertyTablePropertyCallback<2, Normalized, TResult, Callback>(
+        property,
+        valueType,
+        std::forward<Callback>(callback));
+  }
+
+  if (valueType.Type == ECesiumMetadataType::Mat3) {
+    return matNPropertyTablePropertyCallback<3, Normalized, TResult, Callback>(
+        property,
+        valueType,
+        std::forward<Callback>(callback));
+  }
+
+  if (valueType.Type == ECesiumMetadataType::Mat4) {
+    return matNPropertyTablePropertyCallback<4, Normalized, TResult, Callback>(
+        property,
+        valueType,
+        std::forward<Callback>(callback));
+  }
+
+  return callback(PropertyTablePropertyView<uint8>());
+}
+
+/**
+ * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
+ * on a glm::matN array type. This restricts the number of typeid checks done on
+ * the std::any. If the valueType does not have a valid component type, the
+ * callback is performed on an invalid PropertyTablePropertyView instead.
+ *
+ * @param property The std::any containing the property.
+ * @param valueType The FCesiumMetadataValueType of the property.
+ * @param callback The callback function.
+ *
+ * @tparam N The dimensions of the glm::matN
+ * @tparam TNormalized Whether the PropertyTablePropertyView is normalized.
+ * @tparam TResult The type of the output from the callback function.
+ * @tparam Callback The callback function type.
+ */
+template <glm::length_t N, bool Normalized, typename TResult, typename Callback>
+TResult matNArrayPropertyTablePropertyCallback(
+    std::any property,
+    FCesiumMetadataValueType valueType,
+    Callback&& callback) {
+  switch (valueType.ComponentType) {
+  case ECesiumMetadataComponentType::Int8:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, int8>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint8:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, uint8>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int16:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, int16>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint16:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, uint16>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int32:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, int32>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint32:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, uint32>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Int64:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, int64>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Uint64:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, uint64>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Float32:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, float>>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataComponentType::Float64:
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, double>>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  default:
+    return callback(PropertyTablePropertyView<uint8>());
+  }
+}
+
+/**
+ * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
+ * on a glm::matN array type. This restricts the number of typeid checks done on
+ * the std::any. If the valueType does not have a valid component type, the
+ * callback is performed on an invalid PropertyTablePropertyView instead.
+ *
+ * @param property The std::any containing the property.
+ * @param valueType The FCesiumMetadataValueType of the property.
+ * @param callback The callback function.
+ *
+ * @tparam Normalized Whether the PropertyTablePropertyView is normalized.
+ * @tparam TResult The type of the output from the callback function.
+ * @tparam Callback The callback function type.
+ */
+template <bool Normalized, typename TResult, typename Callback>
+TResult matNArrayPropertyTablePropertyCallback(
+    std::any property,
+    FCesiumMetadataValueType valueType,
+    Callback&& callback) {
+  if (valueType.Type == ECesiumMetadataType::Mat2) {
+    return matNArrayPropertyTablePropertyCallback<
+        2,
+        Normalized,
+        TResult,
+        Callback>(property, valueType, std::forward<Callback>(callback));
+  }
+
+  if (valueType.Type == ECesiumMetadataType::Mat3) {
+    return matNArrayPropertyTablePropertyCallback<
+        3,
+        Normalized,
+        TResult,
+        Callback>(property, valueType, std::forward<Callback>(callback));
+  }
+
+  if (valueType.Type == ECesiumMetadataType::Mat4) {
+    return matNArrayPropertyTablePropertyCallback<
+        4,
+        Normalized,
+        TResult,
+        Callback>(property, valueType, std::forward<Callback>(callback));
+  }
+
+  return callback(PropertyTablePropertyView<uint8>());
+}
+
+template <bool Normalized, typename TResult, typename Callback>
+TResult arrayPropertyTablePropertyCallback(
+    std::any property,
+    FCesiumMetadataValueType valueType,
+    Callback&& callback) {
+  switch (valueType.Type) {
+  case ECesiumMetadataType::Scalar:
+    return scalarArrayPropertyTablePropertyCallback<
+        Normalized,
+        TResult,
+        Callback>(property, valueType, std::forward<Callback>(callback));
+  case ECesiumMetadataType::Vec2:
+  case ECesiumMetadataType::Vec3:
+  case ECesiumMetadataType::Vec4:
+    return vecNArrayPropertyTablePropertyCallback<
+        Normalized,
+        TResult,
+        Callback>(property, valueType, std::forward<Callback>(callback));
+  case ECesiumMetadataType::Mat2:
+  case ECesiumMetadataType::Mat3:
+  case ECesiumMetadataType::Mat4:
+    return matNArrayPropertyTablePropertyCallback<
+        Normalized,
+        TResult,
+        Callback>(property, valueType, std::forward<Callback>(callback));
+  case ECesiumMetadataType::Boolean:
+    if (property.type() ==
+        typeid(PropertyTablePropertyView<PropertyArrayView<bool>>))
+      return callback(
+          std::any_cast<PropertyTablePropertyView<PropertyArrayView<bool>>>(
+              property));
+    [[fallthrough]];
+  case ECesiumMetadataType::String:
+    if (property.type() ==
+        typeid(PropertyTablePropertyView<PropertyArrayView<std::string_view>>))
+      return callback(
+          std::any_cast<
+              PropertyTablePropertyView<PropertyArrayView<std::string_view>>>(
+              property));
+    [[fallthrough]];
+  default:
+    return callback(PropertyTablePropertyView<uint8>());
+  }
+}
+
+template <typename TResult, typename Callback>
+TResult propertyTablePropertyCallback(
+    std::any property,
+    FCesiumMetadataValueType valueType,
+    bool normalized,
+    Callback&& callback) {
+  if (valueType.bIsArray) {
+    return normalized
+               ? arrayPropertyTablePropertyCallback<true, TResult, Callback>(
+                     property,
+                     valueType,
+                     std::forward<Callback>(callback))
+               : arrayPropertyTablePropertyCallback<false, TResult, Callback>(
+                     property,
+                     valueType,
+                     std::forward<Callback>(callback));
+  }
+
+  switch (valueType.Type) {
+  case ECesiumMetadataType::Scalar:
+    return normalized
+               ? scalarPropertyTablePropertyCallback<true, TResult, Callback>(
+                     property,
+                     valueType,
+                     std::forward<Callback>(callback))
+               : scalarPropertyTablePropertyCallback<false, TResult, Callback>(
+                     property,
+                     valueType,
+                     std::forward<Callback>(callback));
+  case ECesiumMetadataType::Vec2:
+  case ECesiumMetadataType::Vec3:
+  case ECesiumMetadataType::Vec4:
+    return normalized
+               ? vecNPropertyTablePropertyCallback<true, TResult, Callback>(
+                     property,
+                     valueType,
+                     std::forward<Callback>(callback))
+               : vecNPropertyTablePropertyCallback<false, TResult, Callback>(
+                     property,
+                     valueType,
+                     std::forward<Callback>(callback));
+  case ECesiumMetadataType::Mat2:
+  case ECesiumMetadataType::Mat3:
+  case ECesiumMetadataType::Mat4:
+    return normalized
+               ? matNPropertyTablePropertyCallback<true, TResult, Callback>(
+                     property,
+                     valueType,
+                     std::forward<Callback>(callback))
+               : matNPropertyTablePropertyCallback<false, TResult, Callback>(
+                     property,
+                     valueType,
+                     std::forward<Callback>(callback));
+  case ECesiumMetadataType::Boolean:
+    if (property.type() == typeid(PropertyTablePropertyView<bool>))
+      return callback(std::any_cast<PropertyTablePropertyView<bool>>(property));
+    [[fallthrough]];
+  case ECesiumMetadataType::String:
+    if (property.type() == typeid(PropertyTablePropertyView<std::string_view>))
+      return callback(
+          std::any_cast<PropertyTablePropertyView<std::string_view>>(property));
+    [[fallthrough]];
+  default:
+    return callback(PropertyTablePropertyView<uint8>());
+  }
 }
 
 } // namespace
@@ -60,24 +857,30 @@ UCesiumPropertyTablePropertyBlueprintLibrary::GetValueType(
 
 int64 UCesiumPropertyTablePropertyBlueprintLibrary::GetPropertySize(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property) {
-  return callback<int64>(Property._property, [](const auto& view) -> int64 {
-    return view.size();
-  });
+  return propertyTablePropertyCallback<int64>(
+      Property._property,
+      Property._valueType,
+      Property._normalized,
+      [](const auto& view) -> int64 { return view.size(); });
 }
 
 int64 UCesiumPropertyTablePropertyBlueprintLibrary::GetArraySize(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property) {
-  return callback<int64>(Property._property, [](const auto& view) -> int64 {
-    return view.arrayCount();
-  });
+  return propertyTablePropertyCallback<int64>(
+      Property._property,
+      Property._valueType,
+      Property._normalized,
+      [](const auto& view) -> int64 { return view.arrayCount(); });
 }
 
 bool UCesiumPropertyTablePropertyBlueprintLibrary::GetBoolean(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     bool DefaultValue) {
-  return callback<bool>(
+  return propertyTablePropertyCallback<bool>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> bool {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -98,8 +901,10 @@ uint8 UCesiumPropertyTablePropertyBlueprintLibrary::GetByte(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     uint8 DefaultValue) {
-  return callback<uint8>(
+  return propertyTablePropertyCallback<uint8>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> uint8 {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -120,8 +925,10 @@ int32 UCesiumPropertyTablePropertyBlueprintLibrary::GetInteger(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     int32 DefaultValue) {
-  return callback<int32>(
+  return propertyTablePropertyCallback<int32>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> int32 {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -142,8 +949,10 @@ int64 UCesiumPropertyTablePropertyBlueprintLibrary::GetInteger64(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     int64 DefaultValue) {
-  return callback<int64>(
+  return propertyTablePropertyCallback<int64>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> int64 {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -164,8 +973,10 @@ float UCesiumPropertyTablePropertyBlueprintLibrary::GetFloat(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     float DefaultValue) {
-  return callback<float>(
+  return propertyTablePropertyCallback<float>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> float {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -186,8 +997,10 @@ double UCesiumPropertyTablePropertyBlueprintLibrary::GetFloat64(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     double DefaultValue) {
-  return callback<double>(
+  return propertyTablePropertyCallback<double>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> double {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -208,8 +1021,10 @@ FIntPoint UCesiumPropertyTablePropertyBlueprintLibrary::GetIntPoint(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     const FIntPoint& DefaultValue) {
-  return callback<FIntPoint>(
+  return propertyTablePropertyCallback<FIntPoint>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> FIntPoint {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -230,8 +1045,10 @@ FVector2D UCesiumPropertyTablePropertyBlueprintLibrary::GetVector2D(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     const FVector2D& DefaultValue) {
-  return callback<FVector2D>(
+  return propertyTablePropertyCallback<FVector2D>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> FVector2D {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -252,8 +1069,10 @@ FIntVector UCesiumPropertyTablePropertyBlueprintLibrary::GetIntVector(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     const FIntVector& DefaultValue) {
-  return callback<FIntVector>(
+  return propertyTablePropertyCallback<FIntVector>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> FIntVector {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -273,8 +1092,10 @@ FVector3f UCesiumPropertyTablePropertyBlueprintLibrary::GetVector3f(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     const FVector3f& DefaultValue) {
-  return callback<FVector3f>(
+  return propertyTablePropertyCallback<FVector3f>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> FVector3f {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -295,8 +1116,10 @@ FVector UCesiumPropertyTablePropertyBlueprintLibrary::GetVector(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     const FVector& DefaultValue) {
-  return callback<FVector>(
+  return propertyTablePropertyCallback<FVector>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> FVector {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -317,8 +1140,10 @@ FVector4 UCesiumPropertyTablePropertyBlueprintLibrary::GetVector4(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     const FVector4& DefaultValue) {
-  return callback<FVector4>(
+  return propertyTablePropertyCallback<FVector4>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> FVector4 {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -339,8 +1164,10 @@ FMatrix UCesiumPropertyTablePropertyBlueprintLibrary::GetMatrix(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     const FMatrix& DefaultValue) {
-  return callback<FMatrix>(
+  return propertyTablePropertyCallback<FMatrix>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, DefaultValue](const auto& v) -> FMatrix {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -361,8 +1188,10 @@ FString UCesiumPropertyTablePropertyBlueprintLibrary::GetString(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     const FString& DefaultValue) {
-  return callback<FString>(
+  return propertyTablePropertyCallback<FString>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID, &DefaultValue](const auto& v) -> FString {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -382,8 +1211,10 @@ FString UCesiumPropertyTablePropertyBlueprintLibrary::GetString(
 FCesiumPropertyArray UCesiumPropertyTablePropertyBlueprintLibrary::GetArray(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID) {
-  return callback<FCesiumPropertyArray>(
+  return propertyTablePropertyCallback<FCesiumPropertyArray>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID](const auto& v) -> FCesiumPropertyArray {
         // size() returns zero if the view is invalid.
         if (FeatureID < 0 || FeatureID >= v.size()) {
@@ -403,8 +1234,10 @@ FCesiumPropertyArray UCesiumPropertyTablePropertyBlueprintLibrary::GetArray(
 FCesiumMetadataValue UCesiumPropertyTablePropertyBlueprintLibrary::GetValue(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID) {
-  return callback<FCesiumMetadataValue>(
+  return propertyTablePropertyCallback<FCesiumMetadataValue>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID](const auto& view) -> FCesiumMetadataValue {
         // size() returns zero if the view is invalid.
         if (FeatureID >= 0 && FeatureID < view.size()) {
@@ -417,8 +1250,10 @@ FCesiumMetadataValue UCesiumPropertyTablePropertyBlueprintLibrary::GetValue(
 FCesiumMetadataValue UCesiumPropertyTablePropertyBlueprintLibrary::GetRawValue(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID) {
-  return callback<FCesiumMetadataValue>(
+  return propertyTablePropertyCallback<FCesiumMetadataValue>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [FeatureID](const auto& view) -> FCesiumMetadataValue {
         // Return an empty value if the property is empty.
         if (view.status() ==
@@ -442,8 +1277,10 @@ bool UCesiumPropertyTablePropertyBlueprintLibrary::IsNormalized(
 
 FCesiumMetadataValue UCesiumPropertyTablePropertyBlueprintLibrary::GetOffset(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property) {
-  return callback<FCesiumMetadataValue>(
+  return propertyTablePropertyCallback<FCesiumMetadataValue>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [](const auto& view) -> FCesiumMetadataValue {
         // Returns an empty value if no offset is specified.
         return FCesiumMetadataValue(view.offset());
@@ -452,8 +1289,10 @@ FCesiumMetadataValue UCesiumPropertyTablePropertyBlueprintLibrary::GetOffset(
 
 FCesiumMetadataValue UCesiumPropertyTablePropertyBlueprintLibrary::GetScale(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property) {
-  return callback<FCesiumMetadataValue>(
+  return propertyTablePropertyCallback<FCesiumMetadataValue>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [](const auto& view) -> FCesiumMetadataValue {
         // Returns an empty value if no scale is specified.
         return FCesiumMetadataValue(view.scale());
@@ -463,8 +1302,10 @@ FCesiumMetadataValue UCesiumPropertyTablePropertyBlueprintLibrary::GetScale(
 FCesiumMetadataValue
 UCesiumPropertyTablePropertyBlueprintLibrary::GetMinimumValue(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property) {
-  return callback<FCesiumMetadataValue>(
+  return propertyTablePropertyCallback<FCesiumMetadataValue>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [](const auto& view) -> FCesiumMetadataValue {
         // Returns an empty value if no min is specified.
         return FCesiumMetadataValue(view.min());
@@ -474,8 +1315,10 @@ UCesiumPropertyTablePropertyBlueprintLibrary::GetMinimumValue(
 FCesiumMetadataValue
 UCesiumPropertyTablePropertyBlueprintLibrary::GetMaximumValue(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property) {
-  return callback<FCesiumMetadataValue>(
+  return propertyTablePropertyCallback<FCesiumMetadataValue>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [](const auto& view) -> FCesiumMetadataValue {
         // Returns an empty value if no max is specified.
         return FCesiumMetadataValue(view.max());
@@ -485,8 +1328,10 @@ UCesiumPropertyTablePropertyBlueprintLibrary::GetMaximumValue(
 FCesiumMetadataValue
 UCesiumPropertyTablePropertyBlueprintLibrary::GetNoDataValue(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property) {
-  return callback<FCesiumMetadataValue>(
+  return propertyTablePropertyCallback<FCesiumMetadataValue>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [](const auto& view) -> FCesiumMetadataValue {
         // Returns an empty value if no "no data" value is specified.
         return FCesiumMetadataValue(view.noData());
@@ -496,8 +1341,10 @@ UCesiumPropertyTablePropertyBlueprintLibrary::GetNoDataValue(
 FCesiumMetadataValue
 UCesiumPropertyTablePropertyBlueprintLibrary::GetDefaultValue(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property) {
-  return callback<FCesiumMetadataValue>(
+  return propertyTablePropertyCallback<FCesiumMetadataValue>(
       Property._property,
+      Property._valueType,
+      Property._normalized,
       [](const auto& view) -> FCesiumMetadataValue {
         // Returns an empty value if no default value is specified.
         return FCesiumMetadataValue(view.defaultValue());

--- a/Source/CesiumRuntime/Private/CesiumPropertyTableProperty.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPropertyTableProperty.cpp
@@ -10,39 +10,8 @@ using namespace CesiumGltf;
 namespace {
 /**
  * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
- * of the given type and normalization. If the std::any is not of the specified
- * type, the callback is performed on an invalid PropertyTablePropertyView
- * instead.
- *
- * @param property The std::any containing the property.
- * @param callback The callback function.
- *
- * @tparam TProperty The type of the PropertyTablePropertyView.
- * @tparam Normalized Whether the PropertyTablePropertyView is normalized.
- * @tparam TResult The type of the output from the callback function.
- * @tparam Callback The callback function type.
- */
-template <
-    typename TProperty,
-    bool Normalized,
-    typename TResult,
-    typename Callback>
-TResult propertyTablePropertyCallback(std::any property, Callback&& callback) {
-  if (property.type() ==
-      typeid(PropertyTablePropertyView<TProperty, Normalized>)) {
-    return callback(
-        std::any_cast<PropertyTablePropertyView<TProperty, Normalized>>(
-            property));
-  }
-
-  return callback(PropertyTablePropertyView<uint8>());
-}
-
-/**
- * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
- * on a scalar type. This restricts the number of typeid checks done on the
- * std::any. If the valueType does not have a valid component type, the callback
- * is performed on an invalid PropertyTablePropertyView instead.
+ * on a scalar type. If the valueType does not have a valid component type, the
+ * callback is performed on an invalid PropertyTablePropertyView instead.
  *
  * @param property The std::any containing the property.
  * @param valueType The FCesiumMetadataValueType of the property.
@@ -59,45 +28,33 @@ TResult scalarPropertyTablePropertyCallback(
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
-    return propertyTablePropertyCallback<int8, Normalized, TResult, Callback>(
-        property,
-        std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<int8, Normalized>>(property));
   case ECesiumMetadataComponentType::Uint8:
-    return propertyTablePropertyCallback<uint8, Normalized, TResult, Callback>(
-        property,
-        std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<uint8, Normalized>>(property));
   case ECesiumMetadataComponentType::Int16:
-    return propertyTablePropertyCallback<int16, Normalized, TResult, Callback>(
-        property,
-        std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<int16, Normalized>>(property));
   case ECesiumMetadataComponentType::Uint16:
-    return propertyTablePropertyCallback<uint16, Normalized, TResult, Callback>(
-        property,
-        std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<uint16, Normalized>>(property));
   case ECesiumMetadataComponentType::Int32:
-    return propertyTablePropertyCallback<int32, Normalized, TResult, Callback>(
-        property,
-        std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<int32, Normalized>>(property));
   case ECesiumMetadataComponentType::Uint32:
-    return propertyTablePropertyCallback<uint32, Normalized, TResult, Callback>(
-        property,
-        std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<uint32, Normalized>>(property));
   case ECesiumMetadataComponentType::Int64:
-    return propertyTablePropertyCallback<int64, Normalized, TResult, Callback>(
-        property,
-        std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<int64, Normalized>>(property));
   case ECesiumMetadataComponentType::Uint64:
-    return propertyTablePropertyCallback<uint64, Normalized, TResult, Callback>(
-        property,
-        std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<uint64, Normalized>>(property));
   case ECesiumMetadataComponentType::Float32:
-    return propertyTablePropertyCallback<float, false, TResult, Callback>(
-        property,
-        std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<float>>(property));
   case ECesiumMetadataComponentType::Float64:
-    return propertyTablePropertyCallback<double, false, TResult, Callback>(
-        property,
-        std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<double>>(property));
   default:
     return callback(PropertyTablePropertyView<uint8>());
   }
@@ -105,9 +62,9 @@ TResult scalarPropertyTablePropertyCallback(
 
 /**
  * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
- * on a scalar array type. This restricts the number of typeid checks done on
- * the std::any. If the valueType does not have a valid component type, the
- * callback is performed on an invalid PropertyTablePropertyView instead.
+ * on a scalar array type. If the valueType does not have a valid component
+ * type, the callback is performed on an invalid PropertyTablePropertyView
+ * instead.
  *
  * @param property The std::any containing the property.
  * @param valueType The FCesiumMetadataValueType of the property.
@@ -124,65 +81,53 @@ TResult scalarArrayPropertyTablePropertyCallback(
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<int8>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<PropertyArrayView<int8>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Uint8:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<uint8>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<PropertyArrayView<uint8>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Int16:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<int16>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<PropertyArrayView<int16>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Uint16:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<uint16>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<PropertyArrayView<uint16>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Int32:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<int32>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<PropertyArrayView<int32>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Uint32:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<uint32>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<PropertyArrayView<uint32>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Int64:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<int64>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<PropertyArrayView<int64>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Uint64:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<uint64>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<PropertyArrayView<uint64>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Float32:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<float>,
-        false,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<PropertyArrayView<float>>>(
+            property));
   case ECesiumMetadataComponentType::Float64:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<double>,
-        false,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<PropertyArrayView<double>>>(
+            property));
   default:
     return callback(PropertyTablePropertyView<uint8>());
   }
@@ -190,9 +135,8 @@ TResult scalarArrayPropertyTablePropertyCallback(
 
 /**
  * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
- * on a glm::vecN type. This restricts the number of typeid checks done on the
- * std::any. If the valueType does not have a valid component type, the callback
- * is performed on an invalid PropertyTablePropertyView instead.
+ * on a glm::vecN type. If the valueType does not have a valid component type,
+ * the callback is performed on an invalid PropertyTablePropertyView instead.
  *
  * @param property The std::any containing the property.
  * @param valueType The FCesiumMetadataValueType of the property.
@@ -210,65 +154,44 @@ TResult vecNPropertyTablePropertyCallback(
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
-    return propertyTablePropertyCallback<
-        glm::vec<N, int8>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<glm::vec<N, int8>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Uint8:
-    return propertyTablePropertyCallback<
-        glm::vec<N, uint8>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<
+                    PropertyTablePropertyView<glm::vec<N, uint8>, Normalized>>(
+        property));
   case ECesiumMetadataComponentType::Int16:
-    return propertyTablePropertyCallback<
-        glm::vec<N, int16>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<
+                    PropertyTablePropertyView<glm::vec<N, int16>, Normalized>>(
+        property));
   case ECesiumMetadataComponentType::Uint16:
-    return propertyTablePropertyCallback<
-        glm::vec<N, uint16>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<
+                    PropertyTablePropertyView<glm::vec<N, uint16>, Normalized>>(
+        property));
   case ECesiumMetadataComponentType::Int32:
-    return propertyTablePropertyCallback<
-        glm::vec<N, int32>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<
+                    PropertyTablePropertyView<glm::vec<N, int32>, Normalized>>(
+        property));
   case ECesiumMetadataComponentType::Uint32:
-    return propertyTablePropertyCallback<
-        glm::vec<N, uint32>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<
+                    PropertyTablePropertyView<glm::vec<N, uint32>, Normalized>>(
+        property));
   case ECesiumMetadataComponentType::Int64:
-    return propertyTablePropertyCallback<
-        glm::vec<N, int64>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<
+                    PropertyTablePropertyView<glm::vec<N, int64>, Normalized>>(
+        property));
   case ECesiumMetadataComponentType::Uint64:
-    return propertyTablePropertyCallback<
-        glm::vec<N, uint64>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<
+                    PropertyTablePropertyView<glm::vec<N, uint64>, Normalized>>(
+        property));
   case ECesiumMetadataComponentType::Float32:
-    return propertyTablePropertyCallback<
-        glm::vec<N, float>,
-        false,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<glm::vec<N, float>>>(property));
   case ECesiumMetadataComponentType::Float64:
-    return propertyTablePropertyCallback<
-        glm::vec<N, double>,
-        false,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<glm::vec<N, double>>>(
+            property));
   default:
     return callback(PropertyTablePropertyView<uint8>());
   }
@@ -276,9 +199,8 @@ TResult vecNPropertyTablePropertyCallback(
 
 /**
  * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
- * on a glm::vecN type. This restricts the number of typeid checks done on the
- * std::any. If the valueType does not have a valid component type, the callback
- * is performed on an invalid PropertyTablePropertyView instead.
+ * on a glm::vecN type. If the valueType does not have a valid component type,
+ * the callback is performed on an invalid PropertyTablePropertyView instead.
  *
  * @param property The std::any containing the property.
  * @param valueType The FCesiumMetadataValueType of the property.
@@ -319,9 +241,9 @@ TResult vecNPropertyTablePropertyCallback(
 
 /**
  * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
- * on a glm::vecN array type. This restricts the number of typeid checks done on
- * the std::any. If the valueType does not have a valid component type, the
- * callback is performed on an invalid PropertyTablePropertyView instead.
+ * on a glm::vecN array type. If the valueType does not have a valid component
+ * type, the callback is performed on an invalid PropertyTablePropertyView
+ * instead.
  *
  * @param property The std::any containing the property.
  * @param valueType The FCesiumMetadataValueType of the property.
@@ -339,65 +261,47 @@ TResult vecNArrayPropertyTablePropertyCallback(
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::vec<N, int8>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::vec<N, int8>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Uint8:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::vec<N, uint8>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::vec<N, uint8>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Int16:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::vec<N, int16>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::vec<N, int16>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Uint16:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::vec<N, uint16>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::vec<N, uint16>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Int32:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::vec<N, int32>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::vec<N, int32>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Uint32:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::vec<N, uint32>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::vec<N, uint32>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Int64:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::vec<N, int64>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::vec<N, int64>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Uint64:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::vec<N, uint64>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::vec<N, uint64>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Float32:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::vec<N, float>>,
-        false,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<PropertyArrayView<glm::vec<N, float>>>>(
+            property));
   case ECesiumMetadataComponentType::Float64:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::vec<N, double>>,
-        false,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<PropertyArrayView<glm::vec<N, double>>>>(
+            property));
   default:
     return callback(PropertyTablePropertyView<uint8>());
   }
@@ -405,9 +309,9 @@ TResult vecNArrayPropertyTablePropertyCallback(
 
 /**
  * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
- * on a glm::vecN array type. This restricts the number of typeid checks done on
- * the std::any. If the valueType does not have a valid component type, the
- * callback is performed on an invalid PropertyTablePropertyView instead.
+ * on a glm::vecN array type. If the valueType does not have a valid component
+ * type, the callback is performed on an invalid PropertyTablePropertyView
+ * instead.
  *
  * @param property The std::any containing the property.
  * @param valueType The FCesiumMetadataValueType of the property.
@@ -451,9 +355,8 @@ TResult vecNArrayPropertyTablePropertyCallback(
 
 /**
  * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
- * on a glm::matN type. This restricts the number of typeid checks done on the
- * std::any. If the valueType does not have a valid component type, the callback
- * is performed on an invalid PropertyTablePropertyView instead.
+ * on a glm::matN type. If the valueType does not have a valid component type,
+ * the callback is performed on an invalid PropertyTablePropertyView instead.
  *
  * @param property The std::any containing the property.
  * @param valueType The FCesiumMetadataValueType of the property.
@@ -471,65 +374,53 @@ TResult matNPropertyTablePropertyCallback(
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
-    return propertyTablePropertyCallback<
-        glm::mat<N, N, int8>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<glm::mat<N, N, int8>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Uint8:
-    return propertyTablePropertyCallback<
-        glm::mat<N, N, uint8>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<glm::mat<N, N, uint8>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Int16:
-    return propertyTablePropertyCallback<
-        glm::mat<N, N, int16>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<glm::mat<N, N, int16>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Uint16:
-    return propertyTablePropertyCallback<
-        glm::mat<N, N, uint16>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<glm::mat<N, N, uint16>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Int32:
-    return propertyTablePropertyCallback<
-        glm::mat<N, N, int32>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<glm::mat<N, N, int32>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Uint32:
-    return propertyTablePropertyCallback<
-        glm::mat<N, N, uint32>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<glm::mat<N, N, uint32>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Int64:
-    return propertyTablePropertyCallback<
-        glm::mat<N, N, int64>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<glm::mat<N, N, int64>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Uint64:
-    return propertyTablePropertyCallback<
-        glm::mat<N, N, uint64>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<
+            PropertyTablePropertyView<glm::mat<N, N, uint64>, Normalized>>(
+            property));
   case ECesiumMetadataComponentType::Float32:
-    return propertyTablePropertyCallback<
-        glm::mat<N, N, float>,
-        false,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<glm::mat<N, N, float>>>(
+            property));
   case ECesiumMetadataComponentType::Float64:
-    return propertyTablePropertyCallback<
-        glm::mat<N, N, double>,
-        false,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(
+        std::any_cast<PropertyTablePropertyView<glm::mat<N, N, double>>>(
+            property));
   default:
     return callback(PropertyTablePropertyView<uint8>());
   }
@@ -600,65 +491,43 @@ TResult matNArrayPropertyTablePropertyCallback(
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::mat<N, N, int8>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::mat<N, N, int8>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Uint8:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::mat<N, N, uint8>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::mat<N, N, uint8>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Int16:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::mat<N, N, int16>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::mat<N, N, int16>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Uint16:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::mat<N, N, uint16>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::mat<N, N, uint16>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Int32:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::mat<N, N, int32>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::mat<N, N, int32>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Uint32:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::mat<N, N, uint32>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::mat<N, N, uint32>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Int64:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::mat<N, N, int64>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::mat<N, N, int64>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Uint64:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::mat<N, N, uint64>>,
-        Normalized,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::mat<N, N, uint64>>,
+                        Normalized>>(property));
   case ECesiumMetadataComponentType::Float32:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::mat<N, N, float>>,
-        false,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::mat<N, N, float>>>>(property));
   case ECesiumMetadataComponentType::Float64:
-    return propertyTablePropertyCallback<
-        PropertyArrayView<glm::mat<N, N, double>>,
-        false,
-        TResult,
-        Callback>(property, std::forward<Callback>(callback));
+    return callback(std::any_cast<PropertyTablePropertyView<
+                        PropertyArrayView<glm::mat<N, N, double>>>>(property));
   default:
     return callback(PropertyTablePropertyView<uint8>());
   }

--- a/Source/CesiumRuntime/Private/CesiumPropertyTableProperty.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPropertyTableProperty.cpp
@@ -10,6 +10,36 @@ using namespace CesiumGltf;
 namespace {
 /**
  * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
+ * of the specified type. If the type does not match, the callback is performed
+ * on an invalid PropertyTablePropertyView instead.
+ *
+ * @param property The std::any containing the property.
+ * @param callback The callback function.
+ *
+ * @tparam TProperty The property type.
+ * @tparam Normalized Whether the PropertyTablePropertyView is normalized.
+ * @tparam TResult The type of the output from the callback function.
+ * @tparam Callback The callback function type.
+ */
+template <
+    typename TProperty,
+    bool Normalized,
+    typename TResult,
+    typename Callback>
+TResult
+propertyTablePropertyCallback(const std::any& property, Callback&& callback) {
+  const PropertyTablePropertyView<TProperty, Normalized>* pProperty =
+      std::any_cast<PropertyTablePropertyView<TProperty, Normalized>>(
+          &property);
+  if (pProperty) {
+    return callback(*pProperty);
+  }
+
+  return callback(PropertyTablePropertyView<uint8_t>());
+}
+
+/**
+ * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
  * on a scalar type. If the valueType does not have a valid component type, the
  * callback is performed on an invalid PropertyTablePropertyView instead.
  *
@@ -23,40 +53,66 @@ namespace {
  */
 template <bool Normalized, typename TResult, typename Callback>
 TResult scalarPropertyTablePropertyCallback(
-    std::any property,
+    const std::any& property,
     FCesiumMetadataValueType valueType,
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<int8, Normalized>>(property));
+    return propertyTablePropertyCallback<int8_t, Normalized, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint8:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<uint8, Normalized>>(property));
+    return propertyTablePropertyCallback<
+        uint8_t,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int16:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<int16, Normalized>>(property));
+    return propertyTablePropertyCallback<
+        int16_t,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint16:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<uint16, Normalized>>(property));
+    return propertyTablePropertyCallback<
+        uint16_t,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int32:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<int32, Normalized>>(property));
+    return propertyTablePropertyCallback<
+        int32_t,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint32:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<uint32, Normalized>>(property));
+    return propertyTablePropertyCallback<
+        uint32_t,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int64:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<int64, Normalized>>(property));
+    return propertyTablePropertyCallback<
+        int64_t,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint64:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<uint64, Normalized>>(property));
+    return propertyTablePropertyCallback<
+        uint64_t,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Float32:
-    return callback(std::any_cast<PropertyTablePropertyView<float>>(property));
+    return propertyTablePropertyCallback<float, false, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Float64:
-    return callback(std::any_cast<PropertyTablePropertyView<double>>(property));
+    return propertyTablePropertyCallback<double, false, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
   default:
-    return callback(PropertyTablePropertyView<uint8>());
+    return callback(PropertyTablePropertyView<uint8_t>());
   }
 }
 
@@ -76,60 +132,72 @@ TResult scalarPropertyTablePropertyCallback(
  */
 template <bool Normalized, typename TResult, typename Callback>
 TResult scalarArrayPropertyTablePropertyCallback(
-    std::any property,
+    const std::any& property,
     FCesiumMetadataValueType valueType,
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<PropertyArrayView<int8>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<int8_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint8:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<PropertyArrayView<uint8>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<uint8_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int16:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<PropertyArrayView<int16>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<int16_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint16:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<PropertyArrayView<uint16>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<uint16_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int32:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<PropertyArrayView<int32>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<int32_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint32:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<PropertyArrayView<uint32>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<uint32_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int64:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<PropertyArrayView<int64>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<int64_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint64:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<PropertyArrayView<uint64>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<uint64_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Float32:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<PropertyArrayView<float>>>(
-            property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<float>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Float64:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<PropertyArrayView<double>>>(
-            property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<double>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   default:
-    return callback(PropertyTablePropertyView<uint8>());
+    return callback(PropertyTablePropertyView<uint8_t>());
   }
 }
 
@@ -149,51 +217,72 @@ TResult scalarArrayPropertyTablePropertyCallback(
  */
 template <glm::length_t N, bool Normalized, typename TResult, typename Callback>
 TResult vecNPropertyTablePropertyCallback(
-    std::any property,
+    const std::any& property,
     FCesiumMetadataValueType valueType,
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<glm::vec<N, int8>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        glm::vec<N, int8_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint8:
-    return callback(std::any_cast<
-                    PropertyTablePropertyView<glm::vec<N, uint8>, Normalized>>(
-        property));
+    return propertyTablePropertyCallback<
+        glm::vec<N, uint8_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int16:
-    return callback(std::any_cast<
-                    PropertyTablePropertyView<glm::vec<N, int16>, Normalized>>(
-        property));
+    return propertyTablePropertyCallback<
+        glm::vec<N, int16_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint16:
-    return callback(std::any_cast<
-                    PropertyTablePropertyView<glm::vec<N, uint16>, Normalized>>(
-        property));
+    return propertyTablePropertyCallback<
+        glm::vec<N, uint16_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int32:
-    return callback(std::any_cast<
-                    PropertyTablePropertyView<glm::vec<N, int32>, Normalized>>(
-        property));
+    return propertyTablePropertyCallback<
+        glm::vec<N, int32_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint32:
-    return callback(std::any_cast<
-                    PropertyTablePropertyView<glm::vec<N, uint32>, Normalized>>(
-        property));
+    return propertyTablePropertyCallback<
+        glm::vec<N, uint32_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int64:
-    return callback(std::any_cast<
-                    PropertyTablePropertyView<glm::vec<N, int64>, Normalized>>(
-        property));
+    return propertyTablePropertyCallback<
+        glm::vec<N, int64_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint64:
-    return callback(std::any_cast<
-                    PropertyTablePropertyView<glm::vec<N, uint64>, Normalized>>(
-        property));
+    return propertyTablePropertyCallback<
+        glm::vec<N, uint64_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Float32:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<glm::vec<N, float>>>(property));
+    return propertyTablePropertyCallback<
+        glm::vec<N, float>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Float64:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<glm::vec<N, double>>>(
-            property));
+    return propertyTablePropertyCallback<
+        glm::vec<N, double>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   default:
-    return callback(PropertyTablePropertyView<uint8>());
+    return callback(PropertyTablePropertyView<uint8_t>());
   }
 }
 
@@ -212,7 +301,7 @@ TResult vecNPropertyTablePropertyCallback(
  */
 template <bool Normalized, typename TResult, typename Callback>
 TResult vecNPropertyTablePropertyCallback(
-    std::any property,
+    const std::any& property,
     FCesiumMetadataValueType valueType,
     Callback&& callback) {
   if (valueType.Type == ECesiumMetadataType::Vec2) {
@@ -236,7 +325,7 @@ TResult vecNPropertyTablePropertyCallback(
         std::forward<Callback>(callback));
   }
 
-  return callback(PropertyTablePropertyView<uint8>());
+  return callback(PropertyTablePropertyView<uint8_t>());
 }
 
 /**
@@ -256,54 +345,72 @@ TResult vecNPropertyTablePropertyCallback(
  */
 template <glm::length_t N, bool Normalized, typename TResult, typename Callback>
 TResult vecNArrayPropertyTablePropertyCallback(
-    std::any property,
+    const std::any& property,
     FCesiumMetadataValueType valueType,
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::vec<N, int8>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, int8_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint8:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::vec<N, uint8>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, uint8_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int16:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::vec<N, int16>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, int16_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint16:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::vec<N, uint16>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, uint16_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int32:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::vec<N, int32>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, int32_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint32:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::vec<N, uint32>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, uint32_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int64:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::vec<N, int64>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, int64_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint64:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::vec<N, uint64>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, uint64_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Float32:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<PropertyArrayView<glm::vec<N, float>>>>(
-            property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, float>>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Float64:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<PropertyArrayView<glm::vec<N, double>>>>(
-            property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::vec<N, double>>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   default:
-    return callback(PropertyTablePropertyView<uint8>());
+    return callback(PropertyTablePropertyView<uint8_t>());
   }
 }
 
@@ -323,7 +430,7 @@ TResult vecNArrayPropertyTablePropertyCallback(
  */
 template <bool Normalized, typename TResult, typename Callback>
 TResult vecNArrayPropertyTablePropertyCallback(
-    std::any property,
+    const std::any& property,
     FCesiumMetadataValueType valueType,
     Callback&& callback) {
   if (valueType.Type == ECesiumMetadataType::Vec2) {
@@ -350,7 +457,7 @@ TResult vecNArrayPropertyTablePropertyCallback(
         Callback>(property, valueType, std::forward<Callback>(callback));
   }
 
-  return callback(PropertyTablePropertyView<uint8>());
+  return callback(PropertyTablePropertyView<uint8_t>());
 }
 
 /**
@@ -369,68 +476,79 @@ TResult vecNArrayPropertyTablePropertyCallback(
  */
 template <glm::length_t N, bool Normalized, typename TResult, typename Callback>
 TResult matNPropertyTablePropertyCallback(
-    std::any property,
+    const std::any& property,
     FCesiumMetadataValueType valueType,
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<glm::mat<N, N, int8>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, int8_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint8:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<glm::mat<N, N, uint8>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, uint8_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int16:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<glm::mat<N, N, int16>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, int16_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint16:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<glm::mat<N, N, uint16>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, uint16_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int32:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<glm::mat<N, N, int32>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, int32_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint32:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<glm::mat<N, N, uint32>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, uint32_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int64:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<glm::mat<N, N, int64>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, int64_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint64:
-    return callback(
-        std::any_cast<
-            PropertyTablePropertyView<glm::mat<N, N, uint64>, Normalized>>(
-            property));
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, uint64_t>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Float32:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<glm::mat<N, N, float>>>(
-            property));
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, float>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Float64:
-    return callback(
-        std::any_cast<PropertyTablePropertyView<glm::mat<N, N, double>>>(
-            property));
+    return propertyTablePropertyCallback<
+        glm::mat<N, N, double>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   default:
-    return callback(PropertyTablePropertyView<uint8>());
+    return callback(PropertyTablePropertyView<uint8_t>());
   }
 }
 
 /**
  * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
- * on a glm::matN type. This restricts the number of typeid checks done on the
- * std::any. If the valueType does not have a valid component type, the callback
- * is performed on an invalid PropertyTablePropertyView instead.
+ * on a glm::matN type. If the valueType does not have a valid component type,
+ * the callback is performed on an invalid PropertyTablePropertyView instead.
  *
  * @param property The std::any containing the property.
  * @param valueType The FCesiumMetadataValueType of the property.
@@ -442,7 +560,7 @@ TResult matNPropertyTablePropertyCallback(
  */
 template <bool Normalized, typename TResult, typename Callback>
 TResult matNPropertyTablePropertyCallback(
-    std::any property,
+    const std::any& property,
     FCesiumMetadataValueType valueType,
     Callback&& callback) {
   if (valueType.Type == ECesiumMetadataType::Mat2) {
@@ -471,9 +589,9 @@ TResult matNPropertyTablePropertyCallback(
 
 /**
  * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
- * on a glm::matN array type. This restricts the number of typeid checks done on
- * the std::any. If the valueType does not have a valid component type, the
- * callback is performed on an invalid PropertyTablePropertyView instead.
+ * on a glm::matN array type. If the valueType does not have a valid component
+ * type, the callback is performed on an invalid PropertyTablePropertyView
+ * instead.
  *
  * @param property The std::any containing the property.
  * @param valueType The FCesiumMetadataValueType of the property.
@@ -486,58 +604,80 @@ TResult matNPropertyTablePropertyCallback(
  */
 template <glm::length_t N, bool Normalized, typename TResult, typename Callback>
 TResult matNArrayPropertyTablePropertyCallback(
-    std::any property,
+    const std::any& property,
     FCesiumMetadataValueType valueType,
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::mat<N, N, int8>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, int8_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint8:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::mat<N, N, uint8>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, uint8_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int16:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::mat<N, N, int16>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, int16_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint16:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::mat<N, N, uint16>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, uint16_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int32:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::mat<N, N, int32>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, int32_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint32:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::mat<N, N, uint32>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, uint32_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Int64:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::mat<N, N, int64>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, int64_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Uint64:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::mat<N, N, uint64>>,
-                        Normalized>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, uint64_t>>,
+        Normalized,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Float32:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::mat<N, N, float>>>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, float>>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataComponentType::Float64:
-    return callback(std::any_cast<PropertyTablePropertyView<
-                        PropertyArrayView<glm::mat<N, N, double>>>>(property));
+    return propertyTablePropertyCallback<
+        PropertyArrayView<glm::mat<N, N, double>>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   default:
-    return callback(PropertyTablePropertyView<uint8>());
+    return callback(PropertyTablePropertyView<uint8_t>());
   }
 }
 
 /**
  * Callback on a std::any, assuming that it contains a PropertyTablePropertyView
- * on a glm::matN array type. This restricts the number of typeid checks done on
- * the std::any. If the valueType does not have a valid component type, the
- * callback is performed on an invalid PropertyTablePropertyView instead.
+ * on a glm::matN array type. If the valueType does not have a valid component
+ * type, the callback is performed on an invalid PropertyTablePropertyView
+ * instead.
  *
  * @param property The std::any containing the property.
  * @param valueType The FCesiumMetadataValueType of the property.
@@ -549,7 +689,7 @@ TResult matNArrayPropertyTablePropertyCallback(
  */
 template <bool Normalized, typename TResult, typename Callback>
 TResult matNArrayPropertyTablePropertyCallback(
-    std::any property,
+    const std::any& property,
     FCesiumMetadataValueType valueType,
     Callback&& callback) {
   if (valueType.Type == ECesiumMetadataType::Mat2) {
@@ -576,7 +716,7 @@ TResult matNArrayPropertyTablePropertyCallback(
         Callback>(property, valueType, std::forward<Callback>(callback));
   }
 
-  return callback(PropertyTablePropertyView<uint8>());
+  return callback(PropertyTablePropertyView<uint8_t>());
 }
 
 template <bool Normalized, typename TResult, typename Callback>
@@ -605,22 +745,19 @@ TResult arrayPropertyTablePropertyCallback(
         TResult,
         Callback>(property, valueType, std::forward<Callback>(callback));
   case ECesiumMetadataType::Boolean:
-    if (property.type() ==
-        typeid(PropertyTablePropertyView<PropertyArrayView<bool>>))
-      return callback(
-          std::any_cast<PropertyTablePropertyView<PropertyArrayView<bool>>>(
-              property));
-    [[fallthrough]];
+    return propertyTablePropertyCallback<
+        PropertyArrayView<bool>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   case ECesiumMetadataType::String:
-    if (property.type() ==
-        typeid(PropertyTablePropertyView<PropertyArrayView<std::string_view>>))
-      return callback(
-          std::any_cast<
-              PropertyTablePropertyView<PropertyArrayView<std::string_view>>>(
-              property));
-    [[fallthrough]];
+    return propertyTablePropertyCallback<
+        PropertyArrayView<std::string_view>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   default:
-    return callback(PropertyTablePropertyView<uint8>());
+    return callback(PropertyTablePropertyView<uint8_t>());
   }
 }
 
@@ -678,16 +815,17 @@ TResult propertyTablePropertyCallback(
                      valueType,
                      std::forward<Callback>(callback));
   case ECesiumMetadataType::Boolean:
-    if (property.type() == typeid(PropertyTablePropertyView<bool>))
-      return callback(std::any_cast<PropertyTablePropertyView<bool>>(property));
-    [[fallthrough]];
+    return propertyTablePropertyCallback<bool, false, TResult, Callback>(
+        property,
+        std::forward<Callback>(callback));
   case ECesiumMetadataType::String:
-    if (property.type() == typeid(PropertyTablePropertyView<std::string_view>))
-      return callback(
-          std::any_cast<PropertyTablePropertyView<std::string_view>>(property));
-    [[fallthrough]];
+    return propertyTablePropertyCallback<
+        std::string_view,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   default:
-    return callback(PropertyTablePropertyView<uint8>());
+    return callback(PropertyTablePropertyView<uint8_t>());
   }
 }
 
@@ -770,7 +908,7 @@ uint8 UCesiumPropertyTablePropertyBlueprintLibrary::GetByte(
     UPARAM(ref) const FCesiumPropertyTableProperty& Property,
     int64 FeatureID,
     uint8 DefaultValue) {
-  return propertyTablePropertyCallback<uint8>(
+  return propertyTablePropertyCallback<uint8_t>(
       Property._property,
       Property._valueType,
       Property._normalized,
@@ -1093,7 +1231,7 @@ FCesiumPropertyArray UCesiumPropertyTablePropertyBlueprintLibrary::GetArray(
         if (maybeValue) {
           auto value = *maybeValue;
           if constexpr (CesiumGltf::IsMetadataArray<decltype(value)>::value) {
-            return FCesiumPropertyArray(value);
+            return FCesiumPropertyArray(std::move(value));
           }
         }
         return FCesiumPropertyArray();

--- a/Source/CesiumRuntime/Private/CesiumPropertyTableProperty.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPropertyTableProperty.cpp
@@ -54,7 +54,7 @@ propertyTablePropertyCallback(const std::any& property, Callback&& callback) {
 template <bool Normalized, typename TResult, typename Callback>
 TResult scalarPropertyTablePropertyCallback(
     const std::any& property,
-    FCesiumMetadataValueType valueType,
+    const FCesiumMetadataValueType& valueType,
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
@@ -133,7 +133,7 @@ TResult scalarPropertyTablePropertyCallback(
 template <bool Normalized, typename TResult, typename Callback>
 TResult scalarArrayPropertyTablePropertyCallback(
     const std::any& property,
-    FCesiumMetadataValueType valueType,
+    const FCesiumMetadataValueType& valueType,
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
@@ -218,7 +218,7 @@ TResult scalarArrayPropertyTablePropertyCallback(
 template <glm::length_t N, bool Normalized, typename TResult, typename Callback>
 TResult vecNPropertyTablePropertyCallback(
     const std::any& property,
-    FCesiumMetadataValueType valueType,
+    const FCesiumMetadataValueType& valueType,
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
@@ -302,7 +302,7 @@ TResult vecNPropertyTablePropertyCallback(
 template <bool Normalized, typename TResult, typename Callback>
 TResult vecNPropertyTablePropertyCallback(
     const std::any& property,
-    FCesiumMetadataValueType valueType,
+    const FCesiumMetadataValueType& valueType,
     Callback&& callback) {
   if (valueType.Type == ECesiumMetadataType::Vec2) {
     return vecNPropertyTablePropertyCallback<2, Normalized, TResult, Callback>(
@@ -346,7 +346,7 @@ TResult vecNPropertyTablePropertyCallback(
 template <glm::length_t N, bool Normalized, typename TResult, typename Callback>
 TResult vecNArrayPropertyTablePropertyCallback(
     const std::any& property,
-    FCesiumMetadataValueType valueType,
+    const FCesiumMetadataValueType& valueType,
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
@@ -431,7 +431,7 @@ TResult vecNArrayPropertyTablePropertyCallback(
 template <bool Normalized, typename TResult, typename Callback>
 TResult vecNArrayPropertyTablePropertyCallback(
     const std::any& property,
-    FCesiumMetadataValueType valueType,
+    const FCesiumMetadataValueType& valueType,
     Callback&& callback) {
   if (valueType.Type == ECesiumMetadataType::Vec2) {
     return vecNArrayPropertyTablePropertyCallback<
@@ -477,7 +477,7 @@ TResult vecNArrayPropertyTablePropertyCallback(
 template <glm::length_t N, bool Normalized, typename TResult, typename Callback>
 TResult matNPropertyTablePropertyCallback(
     const std::any& property,
-    FCesiumMetadataValueType valueType,
+    const FCesiumMetadataValueType& valueType,
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
@@ -561,7 +561,7 @@ TResult matNPropertyTablePropertyCallback(
 template <bool Normalized, typename TResult, typename Callback>
 TResult matNPropertyTablePropertyCallback(
     const std::any& property,
-    FCesiumMetadataValueType valueType,
+    const FCesiumMetadataValueType& valueType,
     Callback&& callback) {
   if (valueType.Type == ECesiumMetadataType::Mat2) {
     return matNPropertyTablePropertyCallback<2, Normalized, TResult, Callback>(
@@ -605,7 +605,7 @@ TResult matNPropertyTablePropertyCallback(
 template <glm::length_t N, bool Normalized, typename TResult, typename Callback>
 TResult matNArrayPropertyTablePropertyCallback(
     const std::any& property,
-    FCesiumMetadataValueType valueType,
+    const FCesiumMetadataValueType& valueType,
     Callback&& callback) {
   switch (valueType.ComponentType) {
   case ECesiumMetadataComponentType::Int8:
@@ -690,7 +690,7 @@ TResult matNArrayPropertyTablePropertyCallback(
 template <bool Normalized, typename TResult, typename Callback>
 TResult matNArrayPropertyTablePropertyCallback(
     const std::any& property,
-    FCesiumMetadataValueType valueType,
+    const FCesiumMetadataValueType& valueType,
     Callback&& callback) {
   if (valueType.Type == ECesiumMetadataType::Mat2) {
     return matNArrayPropertyTablePropertyCallback<
@@ -721,8 +721,8 @@ TResult matNArrayPropertyTablePropertyCallback(
 
 template <bool Normalized, typename TResult, typename Callback>
 TResult arrayPropertyTablePropertyCallback(
-    std::any property,
-    FCesiumMetadataValueType valueType,
+    const std::any& property,
+    const FCesiumMetadataValueType& valueType,
     Callback&& callback) {
   switch (valueType.Type) {
   case ECesiumMetadataType::Scalar:
@@ -763,8 +763,8 @@ TResult arrayPropertyTablePropertyCallback(
 
 template <typename TResult, typename Callback>
 TResult propertyTablePropertyCallback(
-    std::any property,
-    FCesiumMetadataValueType valueType,
+    const std::any& property,
+    const FCesiumMetadataValueType& valueType,
     bool normalized,
     Callback&& callback) {
   if (valueType.bIsArray) {

--- a/Source/CesiumRuntime/Private/Tests/CesiumPropertyTableProperty.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumPropertyTableProperty.spec.cpp
@@ -540,7 +540,7 @@ void FCesiumPropertyTablePropertySpec::Define() {
           UCesiumMetadataValueBlueprintLibrary::GetArray(value);
 
       TestEqual(
-          "Size",
+          TEXT("Size"),
           UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
           static_cast<int64_t>(*classProperty.count));
       TestEqual(
@@ -560,7 +560,7 @@ void FCesiumPropertyTablePropertySpec::Define() {
       array = UCesiumMetadataValueBlueprintLibrary::GetArray(value);
 
       TestEqual(
-          "Size",
+          TEXT("Size"),
           UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
           static_cast<int64_t>(*classProperty.count));
       TestEqual(
@@ -581,7 +581,7 @@ void FCesiumPropertyTablePropertySpec::Define() {
       array = UCesiumMetadataValueBlueprintLibrary::GetArray(value);
 
       TestEqual(
-          "Size",
+          TEXT("Size"),
           UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
           static_cast<int64_t>(*classProperty.count));
       TestEqual(
@@ -602,7 +602,7 @@ void FCesiumPropertyTablePropertySpec::Define() {
       array = UCesiumMetadataValueBlueprintLibrary::GetArray(value);
 
       TestEqual(
-          "Size",
+          TEXT("Size"),
           UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
           static_cast<int64_t>(*classProperty.count));
       TestEqual(
@@ -623,7 +623,7 @@ void FCesiumPropertyTablePropertySpec::Define() {
       array = UCesiumMetadataValueBlueprintLibrary::GetArray(value);
 
       TestEqual(
-          "Size",
+          TEXT("Size"),
           UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
           static_cast<int64_t>(*classProperty.count));
       TestEqual(
@@ -644,7 +644,7 @@ void FCesiumPropertyTablePropertySpec::Define() {
       array = UCesiumMetadataValueBlueprintLibrary::GetArray(value);
 
       TestEqual(
-          "Size",
+          TEXT("Size"),
           UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
           static_cast<int64_t>(*classProperty.count));
       TestEqual(

--- a/Source/CesiumRuntime/Private/Tests/CesiumPropertyTableProperty.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumPropertyTableProperty.spec.cpp
@@ -462,6 +462,204 @@ void FCesiumPropertyTablePropertySpec::Define() {
           UCesiumMetadataValueBlueprintLibrary::GetFloat64(value, 0.0),
           defaultValue);
     });
+
+    It("constructs valid array instance with additional properties", [this]() {
+      PropertyTableProperty propertyTableProperty;
+      ClassProperty classProperty;
+      classProperty.type = ClassProperty::Type::SCALAR;
+      classProperty.componentType = ClassProperty::ComponentType::INT32;
+      classProperty.normalized = true;
+      classProperty.array = true;
+      classProperty.count = 2;
+
+      std::vector<double> offset = {1.0, 2.0};
+      std::vector<double> scale = {2.0, -1.0};
+      std::vector<double> min = {1.0, 1.0};
+      std::vector<double> max = {3.0, 2.0};
+      std::vector<int32_t> noData = {-1, -1};
+      std::vector<double> defaultValue = {12.3, 4.5};
+
+      classProperty.offset = {offset[0], offset[1]};
+      classProperty.scale = {scale[0], scale[1]};
+      classProperty.min = {min[0], min[1]};
+      classProperty.max = {max[0], max[1]};
+      classProperty.noData = {noData[0], noData[1]};
+      classProperty.defaultProperty = {defaultValue[0], defaultValue[1]};
+
+      std::vector<int32_t> values{1, 2, 3, 4, 5, 6, -1, -1};
+      std::vector<std::byte> data = GetValuesAsBytes(values);
+      PropertyTablePropertyView<PropertyArrayView<int32_t>, true> propertyView(
+          propertyTableProperty,
+          classProperty,
+          static_cast<int64_t>(values.size()),
+          gsl::span<const std::byte>(data.data(), data.size()));
+
+      FCesiumPropertyTableProperty property(propertyView);
+      TestEqual(
+          "PropertyTablePropertyStatus",
+          UCesiumPropertyTablePropertyBlueprintLibrary::
+              GetPropertyTablePropertyStatus(property),
+          ECesiumPropertyTablePropertyStatus::Valid);
+      TestEqual<int64>(
+          "Size",
+          UCesiumPropertyTablePropertyBlueprintLibrary::GetPropertySize(
+              property),
+          static_cast<int64_t>(values.size()));
+
+      FCesiumMetadataValueType expectedType(
+          ECesiumMetadataType::Scalar,
+          ECesiumMetadataComponentType::Int32,
+          true);
+      TestTrue(
+          "ValueType",
+          UCesiumPropertyTablePropertyBlueprintLibrary::GetValueType(
+              property) == expectedType);
+      TestEqual(
+          "BlueprintType",
+          UCesiumPropertyTablePropertyBlueprintLibrary::GetBlueprintType(
+              property),
+          ECesiumMetadataBlueprintType::Array);
+
+      TestTrue(
+          "IsNormalized",
+          UCesiumPropertyTablePropertyBlueprintLibrary::IsNormalized(property));
+
+      TestEqual<int64>(
+          "ArraySize",
+          UCesiumPropertyTablePropertyBlueprintLibrary::GetArraySize(property),
+          static_cast<int64_t>(*classProperty.count));
+      TestEqual(
+          "ArrayElementBlueprintType",
+          UCesiumPropertyTablePropertyBlueprintLibrary::
+              GetArrayElementBlueprintType(property),
+          ECesiumMetadataBlueprintType::Integer);
+
+      FCesiumMetadataValue value =
+          UCesiumPropertyTablePropertyBlueprintLibrary::GetOffset(property);
+      FCesiumPropertyArray array =
+          UCesiumMetadataValueBlueprintLibrary::GetArray(value);
+
+      TestEqual(
+          "Size",
+          UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
+          static_cast<int64_t>(*classProperty.count));
+      TestEqual(
+          "Offset0",
+          UCesiumMetadataValueBlueprintLibrary::GetFloat64(
+              UCesiumPropertyArrayBlueprintLibrary::GetValue(array, 0),
+              0.0),
+          offset[0]);
+      TestEqual(
+          "Offset1",
+          UCesiumMetadataValueBlueprintLibrary::GetFloat64(
+              UCesiumPropertyArrayBlueprintLibrary::GetValue(array, 1),
+              0.0),
+          offset[1]);
+
+      value = UCesiumPropertyTablePropertyBlueprintLibrary::GetScale(property);
+      array = UCesiumMetadataValueBlueprintLibrary::GetArray(value);
+
+      TestEqual(
+          "Size",
+          UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
+          static_cast<int64_t>(*classProperty.count));
+      TestEqual(
+          "Scale0",
+          UCesiumMetadataValueBlueprintLibrary::GetFloat64(
+              UCesiumPropertyArrayBlueprintLibrary::GetValue(array, 0),
+              0.0),
+          scale[0]);
+      TestEqual(
+          "Scale1",
+          UCesiumMetadataValueBlueprintLibrary::GetFloat64(
+              UCesiumPropertyArrayBlueprintLibrary::GetValue(array, 1),
+              0.0),
+          scale[1]);
+
+      value = UCesiumPropertyTablePropertyBlueprintLibrary::GetMaximumValue(
+          property);
+      array = UCesiumMetadataValueBlueprintLibrary::GetArray(value);
+
+      TestEqual(
+          "Size",
+          UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
+          static_cast<int64_t>(*classProperty.count));
+      TestEqual(
+          "Max0",
+          UCesiumMetadataValueBlueprintLibrary::GetFloat64(
+              UCesiumPropertyArrayBlueprintLibrary::GetValue(array, 0),
+              0.0),
+          max[0]);
+      TestEqual(
+          "Max1",
+          UCesiumMetadataValueBlueprintLibrary::GetFloat64(
+              UCesiumPropertyArrayBlueprintLibrary::GetValue(array, 1),
+              0.0),
+          max[1]);
+
+      value = UCesiumPropertyTablePropertyBlueprintLibrary::GetMinimumValue(
+          property);
+      array = UCesiumMetadataValueBlueprintLibrary::GetArray(value);
+
+      TestEqual(
+          "Size",
+          UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
+          static_cast<int64_t>(*classProperty.count));
+      TestEqual(
+          "Min0",
+          UCesiumMetadataValueBlueprintLibrary::GetFloat64(
+              UCesiumPropertyArrayBlueprintLibrary::GetValue(array, 0),
+              0.0),
+          min[0]);
+      TestEqual(
+          "Min1",
+          UCesiumMetadataValueBlueprintLibrary::GetFloat64(
+              UCesiumPropertyArrayBlueprintLibrary::GetValue(array, 1),
+              0.0),
+          min[1]);
+
+      value = UCesiumPropertyTablePropertyBlueprintLibrary::GetNoDataValue(
+          property);
+      array = UCesiumMetadataValueBlueprintLibrary::GetArray(value);
+
+      TestEqual(
+          "Size",
+          UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
+          static_cast<int64_t>(*classProperty.count));
+      TestEqual(
+          "NoData0",
+          UCesiumMetadataValueBlueprintLibrary::GetInteger(
+              UCesiumPropertyArrayBlueprintLibrary::GetValue(array, 0),
+              0),
+          noData[0]);
+      TestEqual(
+          "NoData1",
+          UCesiumMetadataValueBlueprintLibrary::GetInteger(
+              UCesiumPropertyArrayBlueprintLibrary::GetValue(array, 1),
+              0),
+          noData[1]);
+
+      value = UCesiumPropertyTablePropertyBlueprintLibrary::GetDefaultValue(
+          property);
+      array = UCesiumMetadataValueBlueprintLibrary::GetArray(value);
+
+      TestEqual(
+          "Size",
+          UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
+          static_cast<int64_t>(*classProperty.count));
+      TestEqual(
+          "DefaultValue0",
+          UCesiumMetadataValueBlueprintLibrary::GetFloat64(
+              UCesiumPropertyArrayBlueprintLibrary::GetValue(array, 0),
+              0.0),
+          defaultValue[0]);
+      TestEqual(
+          "DefaultValue1",
+          UCesiumMetadataValueBlueprintLibrary::GetFloat64(
+              UCesiumPropertyArrayBlueprintLibrary::GetValue(array, 1),
+              0.0),
+          defaultValue[1]);
+    });
   });
 
   Describe("GetBoolean", [this]() {

--- a/Source/CesiumRuntime/Public/CesiumPropertyTableProperty.h
+++ b/Source/CesiumRuntime/Public/CesiumPropertyTableProperty.h
@@ -2,13 +2,14 @@
 
 #pragma once
 
+#include "CesiumGltf/PropertyTablePropertyView.h"
 #include "CesiumGltf/PropertyTypeTraits.h"
-#include "CesiumGltf/PropertyViewTypes.h"
 #include "CesiumMetadataValue.h"
 #include "CesiumMetadataValueType.h"
 #include "CesiumPropertyArray.h"
 #include "Kismet/BlueprintFunctionLibrary.h"
 #include "UObject/ObjectMacros.h"
+#include <any>
 #include <glm/glm.hpp>
 #include <string_view>
 #include <variant>
@@ -62,15 +63,9 @@ public:
   FCesiumPropertyTableProperty(
       const CesiumGltf::PropertyTablePropertyView<T, Normalized>& Property)
       : _status(ECesiumPropertyTablePropertyStatus::ErrorInvalidProperty),
-        _property(),
+        _property(Property),
         _valueType(),
         _normalized(Normalized) {
-    if constexpr (Normalized) {
-      _property = CesiumGltf::NormalizedPropertyTablePropertyViewType(Property);
-    } else {
-      _property = CesiumGltf::PropertyTablePropertyViewType(Property);
-    }
-
     switch (Property.status()) {
     case CesiumGltf::PropertyTablePropertyViewStatus::Valid:
       _status = ECesiumPropertyTablePropertyStatus::Valid;
@@ -107,10 +102,7 @@ public:
 private:
   ECesiumPropertyTablePropertyStatus _status;
 
-  using PropertyType = std::variant<
-      CesiumGltf::PropertyTablePropertyViewType,
-      CesiumGltf::NormalizedPropertyTablePropertyViewType>;
-  PropertyType _property;
+  std::any _property;
 
   FCesiumMetadataValueType _valueType;
   bool _normalized;


### PR DESCRIPTION
`PropertyTablePropertyViewType` was a `typedef` for a large `std::variant` defined in Cesium Native. It was so large that all of the normalized property versions had to be put in their own `std::variant`, and the two were then grouped under their own `std::variant` in Cesium for Unreal. While Visual Studio's compiler was able to handle this well, Clang would experience incredibly slow compilation times and often would not be able to complete CI.

This replaces the `std::variant` with a `std::any`. The original property type is stored in the `FCesiumMetadataValueType`, and the struct can be used to re-find the C++ type to `std::any_cast` to. This allows Clang + CI to finally compile successfully, and to _somewhat_ reduce the size of our object files.