### PR TITLE
Fix GLTF primitive component positioning

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.cpp
@@ -63,17 +63,9 @@ void UCesium3DTilesetRoot::_updateAbsoluteLocation() {
 void UCesium3DTilesetRoot::_updateTilesetToUnrealRelativeWorldTransform() {
   ACesium3DTileset* pTileset = this->GetOwner<ACesium3DTileset>();
 
-  const FMatrix ellipsoidCenteredToUnrealWorld =
-      pTileset->ResolveGeoreference()
-          ->ComputeEarthCenteredEarthFixedToUnrealTransformation();
-
-  FVector relativeLocation = VecMath::createVector(this->_absoluteLocation);
-
-  FMatrix tilesetActorToUeLocal =
-      this->GetRelativeTransform().ToMatrixWithScale();
-
   this->_tilesetToUnrealRelativeWorld = VecMath::createMatrix4D(
-      ellipsoidCenteredToUnrealWorld * tilesetActorToUeLocal);
+      pTileset->ResolveGeoreference()
+          ->ComputeEarthCenteredEarthFixedToUnrealTransformation());
 
   pTileset->UpdateTransformFromCesium();
 }


### PR DESCRIPTION
This pull request fixes a bug in the GLTF primitive component positioning. Previously, the GLTF primitive component were using absolute coordinates to set their location:

```
Gltf->SetUsingAbsoluteLocation(true);
```

but now its using relative. 

Because the GLTF primitive component is attached to the Cesium3DTilesetRoot component, the relative transform is already applied, and it was being applied twice.