### PR TITLE
Run objcopy --compress-debug-sections on Android and Linux binaries.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,10 @@ jobs:
         run: |
           cd "C:/Program Files/Epic Games/UE_5.1/Engine/Build/BatchFiles"
           ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Android -NoHostPlatform
+      - name: Compress debug sections
+        run: |
+          dir packages/CesiumForUnreal/Intermediate/Build/Android/UnrealGame/Development/CesiumRuntime/*.o | Foreach-Object { & $ENV:ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/windows-x86_64/bin/llvm-objcopy.exe --compress-debug-sections $_.FullName }
+          dir packages/CesiumForUnreal/Intermediate/Build/Android/UnrealGame/Shipping/CesiumRuntime/*.o | Foreach-Object { & $ENV:ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/windows-x86_64/bin/llvm-objcopy.exe --compress-debug-sections $_.FullName }
       - name: Publish plugin package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
@@ -91,6 +95,10 @@ jobs:
           $ENV:LINUX_MULTIARCH_ROOT="C:/UnrealToolchains/v20_clang-13.0.1-centos7/"
           cd "C:/Program Files/Epic Games/UE_5.1/Engine/Build/BatchFiles"
           ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Linux -NoHostPlatform
+      - name: Compress debug sections
+        run: |
+          dir packages/CesiumForUnreal/Intermediate/Build/Linux/B4D820EA/UnrealGame/Development/CesiumRuntime/*.o | Foreach-Object { & $ENV:UNREAL_ENGINE_COMPILER_DIR/bin/x86_64-unknown-linux-gnu-objcopy.exe --compress-debug-sections $_.FullName }
+          dir packages/CesiumForUnreal/Intermediate/Build/Linux/B4D820EA/UnrealGame/Shipping/CesiumRuntime/*.o | Foreach-Object { & $ENV:UNREAL_ENGINE_COMPILER_DIR/bin/x86_64-unknown-linux-gnu-objcopy.exe --compress-debug-sections $_.FullName }
       - name: Publish plugin package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
@@ -300,6 +308,10 @@ jobs:
           ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.1.0"','"EngineVersion": "5.2.0"') | Set-Content -Path CesiumForUnreal.uplugin
           cd "C:/Program Files/Epic Games/UE_5.2/Engine/Build/BatchFiles"
           ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Android -NoHostPlatform
+      - name: Compress debug sections
+        run: |
+          dir packages/CesiumForUnreal/Intermediate/Build/Android/a/UnrealGame/Development/CesiumRuntime/*.o | Foreach-Object { & $ENV:ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/windows-x86_64/bin/llvm-objcopy.exe --compress-debug-sections $_.FullName }
+          dir packages/CesiumForUnreal/Intermediate/Build/Android/a/UnrealGame/Shipping/CesiumRuntime/*.o | Foreach-Object { & $ENV:ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/windows-x86_64/bin/llvm-objcopy.exe --compress-debug-sections $_.FullName }
       - name: Publish plugin package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
@@ -352,6 +364,12 @@ jobs:
           patchelf --print-rpath libUnrealEditor-CesiumRuntime.so
           export UPDATED_RPATH=`patchelf --print-rpath libUnrealEditor-CesiumRuntime.so | sed 's/${ORIGIN}[^:]*\/SunPosition\/Binaries\/Linux/${ORIGIN}\/..\/..\/..\/..\/Runtime\/SunPosition\/Binaries\/Linux/'`
           patchelf --force-rpath --set-rpath "$UPDATED_RPATH" libUnrealEditor-CesiumRuntime.so
+      - name: Compress debug sections
+        run: |
+          for f in packages/CesiumForUnreal/Binaries/Linux/*.so; do objcopy --compress-debug-sections $f; done
+          for f in packages/CesiumForUnreal/Binaries/Linux/*.debug; do objcopy --compress-debug-sections $f; done
+          for f in packages/CesiumForUnreal/Intermediate/Build/Linux/x64/UnrealGame/Development/CesiumRuntime/*.o; do objcopy --compress-debug-sections $f; done
+          for f in packages/CesiumForUnreal/Intermediate/Build/Linux/x64/UnrealGame/Shipping/CesiumRuntime/*.o; do objcopy --compress-debug-sections $f; done
       - name: Publish plugin package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
@@ -569,6 +587,10 @@ jobs:
           ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.1.0"','"EngineVersion": "5.3.0"') | Set-Content -Path CesiumForUnreal.uplugin
           cd "C:/Program Files/Epic Games/UE_5.3/Engine/Build/BatchFiles"
           ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Android -NoHostPlatform
+      - name: Compress debug sections
+        run: |
+          dir packages/CesiumForUnreal/Intermediate/Build/Android/a/UnrealGame/Development/CesiumRuntime/*.o | Foreach-Object { & $ENV:ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/windows-x86_64/bin/llvm-objcopy.exe --compress-debug-sections $_.FullName }
+          dir packages/CesiumForUnreal/Intermediate/Build/Android/a/UnrealGame/Shipping/CesiumRuntime/*.o | Foreach-Object { & $ENV:ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/windows-x86_64/bin/llvm-objcopy.exe --compress-debug-sections $_.FullName }
       - name: Publish plugin package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
@@ -621,6 +643,12 @@ jobs:
           patchelf --print-rpath libUnrealEditor-CesiumRuntime.so
           export UPDATED_RPATH=`patchelf --print-rpath libUnrealEditor-CesiumRuntime.so | sed 's/${ORIGIN}[^:]*\/SunPosition\/Binaries\/Linux/${ORIGIN}\/..\/..\/..\/..\/Runtime\/SunPosition\/Binaries\/Linux/'`
           patchelf --force-rpath --set-rpath "$UPDATED_RPATH" libUnrealEditor-CesiumRuntime.so
+      - name: Compress debug sections
+        run: |
+          for f in packages/CesiumForUnreal/Binaries/Linux/*.so; do objcopy --compress-debug-sections $f; done
+          for f in packages/CesiumForUnreal/Binaries/Linux/*.debug; do objcopy --compress-debug-sections $f; done
+          for f in packages/CesiumForUnreal/Intermediate/Build/Linux/x64/UnrealGame/Development/CesiumRuntime/*.o; do objcopy --compress-debug-sections $f; done
+          for f in packages/CesiumForUnreal/Intermediate/Build/Linux/x64/UnrealGame/Shipping/CesiumRuntime/*.o; do objcopy --compress-debug-sections $f; done
       - name: Publish plugin package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,8 @@ jobs:
           ./RunUAT.bat BuildPlugin -Plugin="$ENV:GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$ENV:GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Linux -NoHostPlatform
       - name: Compress debug sections
         run: |
+          $ENV:LINUX_MULTIARCH_ROOT="C:/UnrealToolchains/v20_clang-13.0.1-centos7/"
+          $ENV:UNREAL_ENGINE_COMPILER_DIR="${ENV:LINUX_MULTIARCH_ROOT}x86_64-unknown-linux-gnu"
           dir packages/CesiumForUnreal/Intermediate/Build/Linux/B4D820EA/UnrealGame/Development/CesiumRuntime/*.o | Foreach-Object { & $ENV:UNREAL_ENGINE_COMPILER_DIR/bin/x86_64-unknown-linux-gnu-objcopy.exe --compress-debug-sections $_.FullName }
           dir packages/CesiumForUnreal/Intermediate/Build/Linux/B4D820EA/UnrealGame/Shipping/CesiumRuntime/*.o | Foreach-Object { & $ENV:UNREAL_ENGINE_COMPILER_DIR/bin/x86_64-unknown-linux-gnu-objcopy.exe --compress-debug-sections $_.FullName }
       - name: Publish plugin package artifact


### PR DESCRIPTION
This should greatly reduce the size of the .o files we ship on these platforms.