### PR TITLE
Add support for file:/// URLs across platforms and UE versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### ? - ?
 
+##### Additions :tada:
+
+- Added support for `file:///` URLs across all platforms and Unreal Engine versions.
+
 ##### Fixes :wrench:
 
 - Fixed a bug that could cause tiles in a Cesium3DTileset to have an incorrect transformation.

--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -176,7 +176,8 @@ public class CesiumRuntime : ModuleRules
                 "GLM_FORCE_XYZW_ONLY",
                 "GLM_FORCE_EXPLICIT_CTOR",
                 "GLM_FORCE_SIZE_T_LENGTH",
-                "TIDY_STATIC"
+                "TIDY_STATIC",
+                "URI_STATIC_BUILD"
             }
         );
 

--- a/Source/CesiumRuntime/Private/Tests/UnrealAssetAccessor.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/UnrealAssetAccessor.spec.cpp
@@ -1,9 +1,10 @@
+#include "UnrealAssetAccessor.h"
 #include "CesiumAsync/IAssetResponse.h"
 #include "CesiumRuntime.h"
 #include "HAL/PlatformFileManager.h"
 #include "Misc/AutomationTest.h"
 #include "Misc/FileHelper.h"
-#include "UnrealAssetAccessor.h"
+#include "Misc/Paths.h"
 
 BEGIN_DEFINE_SPEC(
     FUnrealAssetAccessorSpec,

--- a/Source/CesiumRuntime/Private/Tests/UnrealAssetAccessor.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/UnrealAssetAccessor.spec.cpp
@@ -1,9 +1,9 @@
-#include "UnrealAssetAccessor.h"
 #include "CesiumAsync/IAssetResponse.h"
 #include "CesiumRuntime.h"
 #include "HAL/PlatformFileManager.h"
 #include "Misc/AutomationTest.h"
 #include "Misc/FileHelper.h"
+#include "UnrealAssetAccessor.h"
 
 BEGIN_DEFINE_SPEC(
     FUnrealAssetAccessorSpec,

--- a/Source/CesiumRuntime/Private/Tests/UnrealAssetAccessor.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/UnrealAssetAccessor.spec.cpp
@@ -1,3 +1,4 @@
+#include "Async/Async.h"
 #include "CesiumAsync/IAssetResponse.h"
 #include "CesiumRuntime.h"
 #include "HAL/PlatformFileManager.h"

--- a/Source/CesiumRuntime/Private/Tests/UnrealAssetAccessor.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/UnrealAssetAccessor.spec.cpp
@@ -1,0 +1,65 @@
+#include "UnrealAssetAccessor.h"
+#include "CesiumAsync/IAssetResponse.h"
+#include "CesiumRuntime.h"
+#include "HAL/PlatformFileManager.h"
+#include "Misc/AutomationTest.h"
+#include "Misc/FileHelper.h"
+
+BEGIN_DEFINE_SPEC(
+    FUnrealAssetAccessorSpec,
+    "Cesium.Unit.UnrealAssetAccessor",
+    EAutomationTestFlags::ApplicationContextMask |
+        EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FUnrealAssetAccessorSpec)
+
+void FUnrealAssetAccessorSpec::Define() {
+  It("Can access file:/// URLs", [this]() {
+    const char text[] = "Some random text.";
+
+    FString Filename = FPaths::ConvertRelativePathToFull(
+        FPaths::CreateTempFilename(*FPaths::ProjectSavedDir()));
+
+    IPlatformFile& FileManager = FPlatformFileManager::Get().GetPlatformFile();
+    FFileHelper::SaveStringToFile(
+        UTF8_TO_TCHAR(text),
+        *Filename,
+        FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
+
+    try {
+      FString Uri = TEXT("file:///") + Filename;
+      Uri.ReplaceCharInline('\\', '/');
+      Uri.ReplaceInline(TEXT(" "), TEXT("%20"));
+
+      bool done = false;
+
+      UnrealAssetAccessor accessor{};
+      accessor.get(getAsyncSystem(), TCHAR_TO_UTF8(*Uri), {})
+          .thenInMainThread(
+              [&](std::shared_ptr<CesiumAsync::IAssetRequest>&& pRequest) {
+                const CesiumAsync::IAssetResponse* Response =
+                    pRequest->response();
+                TestNotNull("Response", Response);
+                if (!Response)
+                  return;
+
+                gsl::span<const std::byte> data = Response->data();
+                TestEqual("data length", data.size(), sizeof(text) - 1);
+                std::string s(
+                    reinterpret_cast<const char*>(data.data()),
+                    data.size());
+                TestEqual("data", s, std::string(text));
+                done = true;
+              });
+
+      while (!done) {
+        accessor.tick();
+        getAsyncSystem().dispatchMainThreadTasks();
+      }
+
+      FileManager.DeleteFile(*Filename);
+    } catch (...) {
+      FileManager.DeleteFile(*Filename);
+      throw;
+    }
+  });
+}

--- a/Source/CesiumRuntime/Private/Tests/UnrealAssetAccessor.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/UnrealAssetAccessor.spec.cpp
@@ -58,34 +58,22 @@ void FUnrealAssetAccessorSpec::Define() {
         FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
   });
 
+  AfterEach([this]() { FileManager->DeleteFile(*Filename); });
+
   It("Fails with non-existant file:/// URLs", [this]() {
-    try {
-      FString Uri = TEXT("file:///") + Filename;
-      Uri.ReplaceCharInline('\\', '/');
-      Uri.ReplaceInline(TEXT(" "), TEXT("%20"));
-      Uri += ".bogusExtension";
+    FString Uri = TEXT("file:///") + Filename;
+    Uri.ReplaceCharInline('\\', '/');
+    Uri.ReplaceInline(TEXT(" "), TEXT("%20"));
+    Uri += ".bogusExtension";
 
-      TestAccessorRequest(Uri, "");
-
-      FileManager->DeleteFile(*Filename);
-    } catch (...) {
-      FileManager->DeleteFile(*Filename);
-      throw;
-    }
+    TestAccessorRequest(Uri, "");
   });
 
   It("Can access file:/// URLs", [this]() {
-    try {
-      FString Uri = TEXT("file:///") + Filename;
-      Uri.ReplaceCharInline('\\', '/');
-      Uri.ReplaceInline(TEXT(" "), TEXT("%20"));
+    FString Uri = TEXT("file:///") + Filename;
+    Uri.ReplaceCharInline('\\', '/');
+    Uri.ReplaceInline(TEXT(" "), TEXT("%20"));
 
-      TestAccessorRequest(Uri, randomText);
-
-      FileManager->DeleteFile(*Filename);
-    } catch (...) {
-      FileManager->DeleteFile(*Filename);
-      throw;
-    }
+    TestAccessorRequest(Uri, randomText);
   });
 }

--- a/Source/CesiumRuntime/Private/Tests/UnrealAssetAccessor.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/UnrealAssetAccessor.spec.cpp
@@ -1,10 +1,10 @@
-#include "UnrealAssetAccessor.h"
 #include "CesiumAsync/IAssetResponse.h"
 #include "CesiumRuntime.h"
 #include "HAL/PlatformFileManager.h"
 #include "Misc/AutomationTest.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
+#include "UnrealAssetAccessor.h"
 
 BEGIN_DEFINE_SPEC(
     FUnrealAssetAccessorSpec,

--- a/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
+++ b/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
@@ -1,6 +1,9 @@
 // Copyright 2020-2021 CesiumGS, Inc. and Contributors
 
 #include "UnrealAssetAccessor.h"
+#include "Async/Async.h"
+#include "Async/AsyncWork.h"
+
 #include "CesiumAsync/AsyncSystem.h"
 #include "CesiumAsync/IAssetRequest.h"
 #include "CesiumAsync/IAssetResponse.h"

--- a/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
+++ b/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
@@ -4,7 +4,7 @@
 #include "CesiumAsync/AsyncSystem.h"
 #include "CesiumAsync/IAssetRequest.h"
 #include "CesiumAsync/IAssetResponse.h"
-#include "HAL/PlatformFilemanager.h"
+#include "HAL/PlatformFileManager.h"
 #include "HttpManager.h"
 #include "HttpModule.h"
 #include "Interfaces/IHttpRequest.h"

--- a/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
+++ b/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 CesiumGS, Inc. and Contributors
 
 #include "UnrealAssetAccessor.h"
+#include "Async/AsyncFileHandle.h"
 #include "CesiumAsync/AsyncSystem.h"
 #include "CesiumAsync/IAssetRequest.h"
 #include "CesiumAsync/IAssetResponse.h"

--- a/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
+++ b/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
@@ -12,6 +12,7 @@
 #include "Interfaces/IPluginManager.h"
 #include "Misc/App.h"
 #include "Misc/EngineVersion.h"
+#include "Misc/Paths.h"
 #include <cstddef>
 #include <optional>
 #include <set>

--- a/Source/CesiumRuntime/Public/UnrealAssetAccessor.h
+++ b/Source/CesiumRuntime/Public/UnrealAssetAccessor.h
@@ -30,6 +30,11 @@ public:
   virtual void tick() noexcept override;
 
 private:
+  CesiumAsync::Future<std::shared_ptr<CesiumAsync::IAssetRequest>> getFromFile(
+      const CesiumAsync::AsyncSystem& asyncSystem,
+      const std::string& url,
+      const std::vector<CesiumAsync::IAssetAccessor::THeader>& headers);
+
   FString _userAgent;
   TMap<FString, FString> _cesiumRequestHeaders;
 };


### PR DESCRIPTION
Fixes #378 

I was updating the [Adding Datasets](https://cesium.com/learn/unreal/unreal-datasets/) tutorial for v2.0, and it seemed easier (or at least more rewarding) to fix file URLs rather than document all the caveats surrounding their use.