### PR TITLE
Check if Level Sequence Asset is empty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,8 @@
 
 ##### Fixes :wrench:
 
-- Fixed a bug that could cause tiles in a Cesium3DTileset to have an incorrect transformation.
-- Fixed a crash that happens when a level is played with no Level Sequence Asset assigned.
+- Fixed a bug that could cause tiles in a `Cesium3DTileset` to have an incorrect transformation.
+- Fixed a crash that occurred when a `LevelSequenceActor` in the level did not have a `LevelSequencePlayer` assigned.
 
 ### v2.0.0 Preview 1 - 2023-10-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug that could cause tiles in a Cesium3DTileset to have an incorrect transformation.
+- Fixed a crash that happens when a level is played with no Level Sequence Asset assigned.
 
 ### v2.0.0 Preview 1 - 2023-10-02
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -602,6 +602,10 @@ void ACesium3DTileset::BeginPlay() {
        ++sequenceActorIt) {
     ALevelSequenceActor* sequenceActor = *sequenceActorIt;
 
+    if (!IsValid(sequenceActor->GetSequencePlayer())) {
+      continue;
+    }
+
     FScriptDelegate playMovieSequencerDelegate;
     playMovieSequencerDelegate.BindUFunction(this, FName("PlayMovieSequencer"));
     sequenceActor->GetSequencePlayer()->OnPlay.Add(playMovieSequencerDelegate);


### PR DESCRIPTION
Fixes a crash where a level with a Level Sequence Actor has no Level Sequence Player.