### PR TITLE
Don't spam the log when a globe anchor does not have a world.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Fixed a bug that could cause tiles in a `Cesium3DTileset` to have an incorrect transformation.
 - Fixed a crash that occurred when a `LevelSequenceActor` in the level did not have a `LevelSequencePlayer` assigned.
+- Fixed a bug that would spam Georeference-related messages to the log when editing a globe anchor component that is not embedded in a world. For example, when editing a Blueprint asset with a globe anchor.
 
 ### v2.0.0 Preview 1 - 2023-10-02
 

--- a/Source/CesiumRuntime/Private/CesiumGlobeAnchorComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGlobeAnchorComponent.cpp
@@ -86,12 +86,16 @@ UCesiumGlobeAnchorComponent::GetResolvedGeoreference() const {
 FVector
 UCesiumGlobeAnchorComponent::GetEarthCenteredEarthFixedPosition() const {
   if (!this->_actorToECEFIsValid) {
-    UE_LOG(
-        LogCesium,
-        Warning,
-        TEXT(
-            "CesiumGlobeAnchorComponent %s globe position is invalid because the component is not yet registered."),
-        *this->GetName());
+    // Only log a warning if we're actually in a world. Otherwise we'll spam the
+    // log when editing a CDO.
+    if (this->GetWorld()) {
+      UE_LOG(
+          LogCesium,
+          Warning,
+          TEXT(
+              "CesiumGlobeAnchorComponent %s globe position is invalid because the component is not yet registered."),
+          *this->GetName());
+    }
     return FVector(0.0);
   }
 
@@ -304,12 +308,16 @@ createEastSouthUp(const CesiumGeospatial::GlobeAnchor& anchor) {
 
 FQuat UCesiumGlobeAnchorComponent::GetEastSouthUpRotation() const {
   if (!this->_actorToECEFIsValid) {
-    UE_LOG(
-        LogCesium,
-        Error,
-        TEXT(
-            "Cannot get the rotation from CesiumGlobeAnchorComponent %s because the component is not yet registered or does not have a valid CesiumGeoreference."),
-        *this->GetName());
+    // Only log a warning if we're actually in a world. Otherwise we'll spam the
+    // log when editing a CDO.
+    if (this->GetWorld()) {
+      UE_LOG(
+          LogCesium,
+          Error,
+          TEXT(
+              "Cannot get the rotation from CesiumGlobeAnchorComponent %s because the component is not yet registered or does not have a valid CesiumGeoreference."),
+          *this->GetName());
+    }
     return FQuat::Identity;
   }
 
@@ -370,12 +378,16 @@ void UCesiumGlobeAnchorComponent::SetEastSouthUpRotation(
 
 FQuat UCesiumGlobeAnchorComponent::GetEarthCenteredEarthFixedRotation() const {
   if (!this->_actorToECEFIsValid) {
-    UE_LOG(
-        LogCesium,
-        Error,
-        TEXT(
-            "Cannot get the rotation from CesiumGlobeAnchorComponent %s because the component is not yet registered or does not have a valid CesiumGeoreference."),
-        *this->GetName());
+    // Only log a warning if we're actually in a world. Otherwise we'll spam the
+    // log when editing a CDO.
+    if (this->GetWorld()) {
+      UE_LOG(
+          LogCesium,
+          Error,
+          TEXT(
+              "Cannot get the rotation from CesiumGlobeAnchorComponent %s because the component is not yet registered or does not have a valid CesiumGeoreference."),
+          *this->GetName());
+    }
     return FQuat::Identity;
   }
 


### PR DESCRIPTION
I noticed that when opening the DynamicPawn in the Blueprint Editor, Cesium for Unreal spams endless messages to the log about the pawn's GlobeAnchor not being registered:

```
LogCesium: Error: Cannot get the rotation from CesiumGlobeAnchorComponent GlobeAnchor because the component is not yet registered or does not have a valid CesiumGeoreference.
LogCesium: Warning: CesiumGlobeAnchorComponent GlobeAnchor globe position is invalid because the component is not yet registered.
LogCesium: Warning: CesiumGlobeAnchorComponent GlobeAnchor globe position is invalid because the component is not yet registered.
```

This is normal and expected in this scenario, so I changed the code to avoid the spam.

It doesn't make sense to set the globe anchor position/orientation parameters in this scenario, and the current UI implementation (both before and after this PR) hides the fields, which I guess is fine:
<img width="319" alt="image" src="https://github.com/CesiumGS/cesium-unreal/assets/924374/e448d7e1-e5d5-4d55-94b9-65f3a04af835">


