### PR TITLE
Add performance tests for investigating MaximumSimultaneousTileLoads

### DIFF
--- a/Source/CesiumRuntime/Private/Tests/CesiumLoadTestCore.h
+++ b/Source/CesiumRuntime/Private/Tests/CesiumLoadTestCore.h
@@ -24,14 +24,19 @@ struct TestPass {
   double startMark = 0;
   double endMark = 0;
   double elapsedTime = 0;
+
+  bool isFastest = false;
 };
+
+typedef std::function<void(const std::vector<TestPass>&)> ReportCallback;
 
 bool RunLoadTest(
     const FString& testName,
     std::function<void(SceneGenerationContext&)> locationSetup,
     const std::vector<TestPass>& testPasses,
     int viewportWidth,
-    int viewportHeight);
+    int viewportHeight,
+    ReportCallback optionalReportStep = nullptr);
 
 }; // namespace Cesium
 

--- a/Source/CesiumRuntime/Private/Tests/CesiumLoadTestCore.h
+++ b/Source/CesiumRuntime/Private/Tests/CesiumLoadTestCore.h
@@ -11,9 +11,19 @@
 namespace Cesium {
 
 struct TestPass {
+  typedef std::variant<int, float> TestingParameter;
+  typedef std::function<void(SceneGenerationContext&, TestingParameter)>
+      PassCallback;
+
   FString name;
-  std::function<void(SceneGenerationContext&)> setupStep;
-  std::function<void(SceneGenerationContext&)> verifyStep;
+  PassCallback setupStep;
+  PassCallback verifyStep;
+  TestingParameter optionalParameter;
+
+  bool testInProgress = false;
+  double startMark = 0;
+  double endMark = 0;
+  double elapsedTime = 0;
 };
 
 bool RunLoadTest(

--- a/Source/CesiumRuntime/Private/Tests/CesiumLoadTestSamples.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumLoadTestSamples.cpp
@@ -22,7 +22,9 @@ IMPLEMENT_SIMPLE_AUTOMATION_TEST(
     "Cesium.Performance.SampleLoadMontrealPointCloud",
     EAutomationTestFlags::EditorContext | EAutomationTestFlags::PerfFilter)
 
-void refreshSampleTilesets(SceneGenerationContext& context) {
+void refreshSampleTilesets(
+    SceneGenerationContext& context,
+    TestPass::TestingParameter parameter) {
   context.refreshTilesets();
 }
 
@@ -97,7 +99,9 @@ bool FCesiumSampleLoadDenver::RunTest(const FString& Parameters) {
 }
 
 bool FCesiumSampleLoadMontrealPointCloud::RunTest(const FString& Parameters) {
-  auto adjustCamera = [this](SceneGenerationContext& context) {
+  auto adjustCamera = [this](
+                          SceneGenerationContext& context,
+                          TestPass::TestingParameter parameter) {
     // Zoom way out
     context.startPosition = FVector(0, 0, 7240000.0);
     context.startRotation = FRotator(-90.0, 0.0, 0.0);
@@ -106,7 +110,9 @@ bool FCesiumSampleLoadMontrealPointCloud::RunTest(const FString& Parameters) {
     context.pawn->SetActorLocation(context.startPosition);
   };
 
-  auto verifyVisibleTiles = [this](SceneGenerationContext& context) {
+  auto verifyVisibleTiles = [this](
+                                SceneGenerationContext& context,
+                                TestPass::TestingParameter parameter) {
     Cesium3DTilesSelection::Tileset* pTileset =
         context.tilesets[0]->GetTileset();
     if (TestNotNull("Tileset", pTileset)) {

--- a/Source/CesiumRuntime/Private/Tests/CesiumLoadTestSamples.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumLoadTestSamples.cpp
@@ -231,6 +231,25 @@ bool FSampleMaxTileLoads::RunTest(const FString& Parameters) {
     context.refreshTilesets();
   };
 
+  auto reportStep = [this](const std::vector<TestPass>& testPasses) {
+    FString reportStr;
+    reportStr += "\n\nTest Results\n";
+    reportStr += "------------------------------------------------------\n";
+    reportStr += "(measured time) - (MaximumSimultaneousTileLoads value)\n";
+    reportStr += "------------------------------------------------------\n";
+    std::vector<TestPass>::const_iterator it;
+    for (it = testPasses.begin(); it != testPasses.end(); ++it) {
+      const TestPass& pass = *it;
+      reportStr +=
+          FString::Printf(TEXT("%.2f secs - %s"), pass.elapsedTime, *pass.name);
+      if (pass.isFastest)
+        reportStr += " <-- fastest";
+      reportStr += "\n";
+    }
+    reportStr += "------------------------------------------------------\n";
+    UE_LOG(LogCesium, Display, TEXT("%s"), *reportStr);
+  };
+
   std::vector<TestPass> testPasses;
   testPasses.push_back(TestPass{"Default", NULL, NULL});
   testPasses.push_back(TestPass{"12", setupPass, NULL, 12});
@@ -244,6 +263,7 @@ bool FSampleMaxTileLoads::RunTest(const FString& Parameters) {
       setupForMelbourne,
       testPasses,
       1024,
-      768);
+      768,
+      reportStep);
 }
 #endif

--- a/Source/CesiumRuntime/Private/Tests/CesiumSceneGeneration.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumSceneGeneration.cpp
@@ -53,6 +53,12 @@ void SceneGenerationContext::setSuspendUpdate(bool suspend) {
     (*it)->SuspendUpdate = suspend;
 }
 
+void SceneGenerationContext::setMaximumSimultaneousTileLoads(int value) {
+  std::vector<ACesium3DTileset*>::iterator it;
+  for (it = tilesets.begin(); it != tilesets.end(); ++it)
+    (*it)->MaximumSimultaneousTileLoads = value;
+}
+
 bool SceneGenerationContext::areTilesetsDoneLoading() {
   if (tilesets.empty())
     return false;

--- a/Source/CesiumRuntime/Private/Tests/CesiumSceneGeneration.h
+++ b/Source/CesiumRuntime/Private/Tests/CesiumSceneGeneration.h
@@ -34,6 +34,7 @@ struct SceneGenerationContext {
 
   void refreshTilesets();
   void setSuspendUpdate(bool suspend);
+  void setMaximumSimultaneousTileLoads(int32 value);
   bool areTilesetsDoneLoading();
 
   void trackForPlay();

--- a/Source/CesiumRuntime/Private/Tests/Google3dTilesLoadTest.cpp
+++ b/Source/CesiumRuntime/Private/Tests/Google3dTilesLoadTest.cpp
@@ -240,33 +240,28 @@ bool FGoogleTilesGoogleplex::RunTest(const FString& Parameters) {
       TEST_SCREEN_HEIGHT);
 }
 
-void setupMaxTileLoads(
-    SceneGenerationContext& context,
-    TestPass::TestingParameter parameter) {
-  std::shared_ptr<CesiumAsync::ICacheDatabase> pCacheDatabase =
-      getCacheDatabase();
-  pCacheDatabase->clearAll();
-
-  int maxLoadsTarget = std::get<int>(parameter);
-  context.tilesets[0]->MaximumSimultaneousTileLoads = maxLoadsTarget;
-
-  UE_LOG(
-      LogCesium,
-      Display,
-      TEXT("Set tileset MaximumSimultaneousTileLoads to %d"),
-      maxLoadsTarget);
-
-  context.refreshTilesets();
-}
-
 bool FGoogleTilesMaxTileLoads::RunTest(const FString& Parameters) {
+
+  auto setupPass = [this](
+                       SceneGenerationContext& context,
+                       TestPass::TestingParameter parameter) {
+    std::shared_ptr<CesiumAsync::ICacheDatabase> pCacheDatabase =
+        getCacheDatabase();
+    pCacheDatabase->clearAll();
+
+    int maxLoadsTarget = std::get<int>(parameter);
+    context.setMaximumSimultaneousTileLoads(maxLoadsTarget);
+
+    context.refreshTilesets();
+  };
+
   std::vector<TestPass> testPasses;
   testPasses.push_back(TestPass{"Default", NULL, NULL});
-  testPasses.push_back(TestPass{"12", setupMaxTileLoads, NULL, 12});
-  testPasses.push_back(TestPass{"16", setupMaxTileLoads, NULL, 16});
-  testPasses.push_back(TestPass{"20", setupMaxTileLoads, NULL, 20});
-  testPasses.push_back(TestPass{"24", setupMaxTileLoads, NULL, 24});
-  testPasses.push_back(TestPass{"28", setupMaxTileLoads, NULL, 28});
+  testPasses.push_back(TestPass{"12", setupPass, NULL, 12});
+  testPasses.push_back(TestPass{"16", setupPass, NULL, 16});
+  testPasses.push_back(TestPass{"20", setupPass, NULL, 20});
+  testPasses.push_back(TestPass{"24", setupPass, NULL, 24});
+  testPasses.push_back(TestPass{"28", setupPass, NULL, 28});
 
   return RunLoadTest(
       GetBeautifiedTestName(),

--- a/Source/CesiumRuntime/Private/Tests/Google3dTilesLoadTest.cpp
+++ b/Source/CesiumRuntime/Private/Tests/Google3dTilesLoadTest.cpp
@@ -13,11 +13,6 @@
 
 using namespace Cesium;
 
-namespace Cesium {
-FString testGoogleUrl(
-    "https://tile.googleapis.com/v1/3dtiles/root.json?key=AIzaSyCaIL-JEK2Tw9MMBVKSTIu8dPkwfzfqAbU");
-}
-
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(
     FGoogleTilesPompidou,
     "Cesium.Performance.GoogleTiles.LocalePompidou",
@@ -73,8 +68,9 @@ void setupForPompidou(SceneGenerationContext& context) {
   context.sunSky->UpdateSun();
 
   ACesium3DTileset* tileset = context.world->SpawnActor<ACesium3DTileset>();
-  tileset->SetUrl(Cesium::testGoogleUrl);
-  tileset->SetTilesetSource(ETilesetSource::FromUrl);
+  tileset->SetTilesetSource(ETilesetSource::FromCesiumIon);
+  tileset->SetIonAssetID(2275207);
+  tileset->SetIonAccessToken(SceneGenerationContext::testIonToken);
   tileset->SetActorLabel(TEXT("Center Pompidou, Paris, France"));
   context.tilesets.push_back(tileset);
 }
@@ -90,8 +86,9 @@ void setupForChrysler(SceneGenerationContext& context) {
   context.sunSky->UpdateSun();
 
   ACesium3DTileset* tileset = context.world->SpawnActor<ACesium3DTileset>();
-  tileset->SetUrl(Cesium::testGoogleUrl);
-  tileset->SetTilesetSource(ETilesetSource::FromUrl);
+  tileset->SetTilesetSource(ETilesetSource::FromCesiumIon);
+  tileset->SetIonAssetID(2275207);
+  tileset->SetIonAccessToken(SceneGenerationContext::testIonToken);
   tileset->SetActorLabel(TEXT("Chrysler Building, NYC"));
   context.tilesets.push_back(tileset);
 }
@@ -107,8 +104,9 @@ void setupForGuggenheim(SceneGenerationContext& context) {
   context.sunSky->UpdateSun();
 
   ACesium3DTileset* tileset = context.world->SpawnActor<ACesium3DTileset>();
-  tileset->SetUrl(Cesium::testGoogleUrl);
-  tileset->SetTilesetSource(ETilesetSource::FromUrl);
+  tileset->SetTilesetSource(ETilesetSource::FromCesiumIon);
+  tileset->SetIonAssetID(2275207);
+  tileset->SetIonAccessToken(SceneGenerationContext::testIonToken);
   tileset->SetActorLabel(TEXT("Guggenheim Museum, Bilbao, Spain"));
   context.tilesets.push_back(tileset);
 }
@@ -124,8 +122,9 @@ void setupForDeathValley(SceneGenerationContext& context) {
   context.sunSky->UpdateSun();
 
   ACesium3DTileset* tileset = context.world->SpawnActor<ACesium3DTileset>();
-  tileset->SetUrl(Cesium::testGoogleUrl);
-  tileset->SetTilesetSource(ETilesetSource::FromUrl);
+  tileset->SetTilesetSource(ETilesetSource::FromCesiumIon);
+  tileset->SetIonAssetID(2275207);
+  tileset->SetIonAccessToken(SceneGenerationContext::testIonToken);
   tileset->SetActorLabel(
       TEXT("Zabriskie Point, Death Valley National Park, California"));
   context.tilesets.push_back(tileset);
@@ -142,8 +141,9 @@ void setupForTokyo(SceneGenerationContext& context) {
   context.sunSky->UpdateSun();
 
   ACesium3DTileset* tileset = context.world->SpawnActor<ACesium3DTileset>();
-  tileset->SetUrl(Cesium::testGoogleUrl);
-  tileset->SetTilesetSource(ETilesetSource::FromUrl);
+  tileset->SetTilesetSource(ETilesetSource::FromCesiumIon);
+  tileset->SetIonAssetID(2275207);
+  tileset->SetIonAccessToken(SceneGenerationContext::testIonToken);
   tileset->SetActorLabel(TEXT("Tokyo Tower, Tokyo, Japan"));
   context.tilesets.push_back(tileset);
 }
@@ -156,8 +156,9 @@ void setupForGoogleplex(SceneGenerationContext& context) {
       90.0f);
 
   ACesium3DTileset* tileset = context.world->SpawnActor<ACesium3DTileset>();
-  tileset->SetUrl(Cesium::testGoogleUrl);
-  tileset->SetTilesetSource(ETilesetSource::FromUrl);
+  tileset->SetTilesetSource(ETilesetSource::FromCesiumIon);
+  tileset->SetIonAssetID(2275207);
+  tileset->SetIonAccessToken(SceneGenerationContext::testIonToken);
   tileset->SetActorLabel(TEXT("Google Photorealistic 3D Tiles"));
 
   context.tilesets.push_back(tileset);


### PR DESCRIPTION
New tests to show loading time changes when tweaking a tileset's `MaximumSimultaneousTileLoads` property.

Also, update tests to fetch Google 3D Tiles through Cesium Ion.

This defaults to 20, but may benefit from being tweaked based on your physical location and network connectivity.

* Added new `VaryMaxTileLoads` test to sample tests
* Added new `VaryMaxTileLoads` test to Google 3D Tiles tests
* Added new Melbourne locale to sample tests
* Add report step at end of tests to summarize all passes at a glance

(animation sped up for convenience)
![MaxTileLoads](https://github.com/CesiumGS/cesium-unreal/assets/130494071/f2f75c0a-ec26-4baa-8aa3-18738cfc7452)

