### PR TITLE
Add cancel button to cancel ion login

### DIFF
--- a/Source/CesiumEditor/Private/CesiumIonSession.cpp
+++ b/Source/CesiumEditor/Private/CesiumIonSession.cpp
@@ -6,6 +6,7 @@
 #include "CesiumSourceControl.h"
 #include "HAL/PlatformProcess.h"
 #include "Misc/App.h"
+#include <CesiumUtility/Uri.h>
 
 using namespace CesiumAsync;
 using namespace CesiumIonClient;
@@ -50,6 +51,10 @@ void CesiumIonSession::connect() {
        "geocode"},
       [this](const std::string& url) {
         this->_authorizeUrl = url;
+
+        this->_redirectUrl =
+            CesiumUtility::Uri::getQueryValue(url, "redirect_uri");
+
         FPlatformProcess::LaunchURL(
             UTF8_TO_TCHAR(this->_authorizeUrl.c_str()),
             NULL,

--- a/Source/CesiumEditor/Private/CesiumIonSession.h
+++ b/Source/CesiumEditor/Private/CesiumIonSession.h
@@ -57,6 +57,7 @@ public:
   const std::vector<CesiumIonClient::Token>& getTokens();
 
   const std::string& getAuthorizeUrl() const { return this->_authorizeUrl; }
+  const std::string& getRedirectUrl() const { return this->_redirectUrl; }
 
   bool refreshProfileIfNeeded();
   bool refreshAssetsIfNeeded();
@@ -115,4 +116,5 @@ private:
   bool _loadTokensQueued;
 
   std::string _authorizeUrl;
+  std::string _redirectUrl;
 };

--- a/Source/CesiumEditor/Private/IonLoginPanel.cpp
+++ b/Source/CesiumEditor/Private/IonLoginPanel.cpp
@@ -5,6 +5,8 @@
 #include "CesiumIonClient/Connection.h"
 #include "CesiumIonClient/Token.h"
 #include "HAL/PlatformApplicationMisc.h"
+#include "HttpModule.h"
+#include "Interfaces/IHttpRequest.h"
 #include "Misc/App.h"
 #include "Styling/SlateStyle.h"
 #include "Widgets/Images/SImage.h"
@@ -81,8 +83,14 @@ void IonLoginPanel::Construct(const FArguments& InArgs) {
                             .OnClicked(
                                 this,
                                 &IonLoginPanel::CopyAuthorizeUrlToClipboard)
-                            .Text(
-                                FText::FromString(TEXT("Copy to clipboard")))]];
+                            .Text(FText::FromString(
+                                TEXT("Copy to clipboard")))]] +
+      SVerticalBox::Slot()
+          .HAlign(HAlign_Center)
+          .Padding(5)
+          .AutoHeight()[SNew(SHyperlink)
+                            .OnNavigate(this, &IonLoginPanel::CancelLogin)
+                            .Text(FText::FromString(TEXT("Cancel")))];
 
   TSharedPtr<SVerticalBox> connectionWidget =
       SNew(SVerticalBox) +
@@ -169,4 +177,12 @@ void IonLoginPanel::LaunchBrowserAgain() {
       UTF8_TO_TCHAR(FCesiumEditorModule::ion().getAuthorizeUrl().c_str()),
       NULL,
       NULL);
+}
+
+void IonLoginPanel::CancelLogin() {
+  TSharedRef<IHttpRequest, ESPMode::ThreadSafe> pRequest =
+      FHttpModule::Get().CreateRequest();
+  pRequest->SetURL(
+      UTF8_TO_TCHAR(FCesiumEditorModule::ion().getRedirectUrl().c_str()));
+  pRequest->ProcessRequest();
 }

--- a/Source/CesiumEditor/Private/IonLoginPanel.h
+++ b/Source/CesiumEditor/Private/IonLoginPanel.h
@@ -14,6 +14,7 @@ class IonLoginPanel : public SCompoundWidget {
 
 private:
   void LaunchBrowserAgain();
+  void CancelLogin();
 
   FReply SignIn();
   FReply CopyAuthorizeUrlToClipboard();


### PR DESCRIPTION
When the parameters for logging into Cesium ion are invalid, the login page does not redirect to the specified uri. This prevents the login page from resetting. Therefore, the cancel button simply navigates to the redirect uri.