### PR TITLE
Cesium sub-level improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,12 +5,15 @@
 ##### Additions :tada:
 
 - Added support for `file:///` URLs across all platforms and Unreal Engine versions.
+- Added "Create Sub Level Here" button on `CesiumGeoreference`.
+- Added "Please Georeference Origin Here" button to `CesiumSubLevelComponent`.
 
 ##### Fixes :wrench:
 
 - Fixed a bug that could cause tiles in a `Cesium3DTileset` to have an incorrect transformation.
 - Fixed a crash that occurred when a `LevelSequenceActor` in the level did not have a `LevelSequencePlayer` assigned.
 - Fixed a bug that would spam Georeference-related messages to the log when editing a globe anchor component that is not embedded in a world. For example, when editing a Blueprint asset with a globe anchor.
+- Fixed several problems that could cause tilesets in sub-levels to be misaligned with the rest of the globe.
 
 ### v2.0.0 Preview 1 - 2023-10-02
 

--- a/Source/CesiumEditor/Private/CesiumEditor.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditor.cpp
@@ -54,6 +54,9 @@ TSharedPtr<FSlateStyleSet> FCesiumEditorModule::StyleSet = nullptr;
 FCesiumEditorModule* FCesiumEditorModule::_pModule = nullptr;
 
 namespace {
+
+AActor* SpawnActorWithClass(UClass* actorClass);
+
 /**
  * Register an icon in the StyleSet, using the given property
  * name and relative resource path.
@@ -518,31 +521,13 @@ FCesiumEditorModule::FindFirstTilesetWithAssetID(int64_t assetID) {
 
 ACesium3DTileset*
 FCesiumEditorModule::CreateTileset(const std::string& name, int64_t assetID) {
-  UWorld* pCurrentWorld = GEditor->GetEditorWorldContext().World();
-  ULevel* pCurrentLevel = pCurrentWorld->GetCurrentLevel();
-
-  ACesiumGeoreference* Georeference =
-      ACesiumGeoreference::GetDefaultGeoreference(pCurrentWorld);
-
-  AActor* pNewActor = GEditor->AddActor(
-      pCurrentLevel,
-      ACesium3DTileset::StaticClass(),
-      FTransform(),
-      false,
-      RF_Transactional);
-
-  // Make the new Tileset a child of the CesiumGeoreference. Unless they're in
-  // different levels.
-  if (Georeference->GetLevel() == pCurrentLevel) {
-    pNewActor->AttachToActor(
-        Georeference,
-        FAttachmentTransformRules::KeepRelativeTransform);
-  }
-
+  AActor* pNewActor = SpawnActorWithClass(ACesium3DTileset::StaticClass());
   ACesium3DTileset* pTilesetActor = Cast<ACesium3DTileset>(pNewActor);
-  pTilesetActor->SetActorLabel(UTF8_TO_TCHAR(name.c_str()));
-  if (assetID != -1) {
-    pTilesetActor->SetIonAssetID(assetID);
+  if (pTilesetActor) {
+    pTilesetActor->SetActorLabel(UTF8_TO_TCHAR(name.c_str()));
+    if (assetID != -1) {
+      pTilesetActor->SetIonAssetID(assetID);
+    }
   }
   return pTilesetActor;
 }
@@ -673,10 +658,21 @@ AActor* SpawnActorWithClass(UClass* actorClass) {
   ACesiumGeoreference* Georeference =
       ACesiumGeoreference::GetDefaultGeoreference(pCurrentWorld);
 
+  // Spawn the new Actor with the same world transform as the
+  // CesiumGeoreference. This way it will match the existing globe. The user may
+  // transform it from there (e.g., to offset one tileset from another).
+
+  // When we're spawning this Actor in a sub-level, the transform specified here
+  // is a world transform relative to the _persistent level_. It's not relative
+  // to the sub-level's origin. Strange but true! But it's helpful in this case
+  // because we're able to correctly spawn things like tilesets into sub-levels
+  // where the sub-level origin and the persistent-level origin don't coincide
+  // due to a LevelTransform.
+
   AActor* NewActor = GEditor->AddActor(
       pCurrentLevel,
       actorClass,
-      FTransform(),
+      Georeference->GetActorTransform(),
       false,
       RF_Transactional);
 
@@ -685,7 +681,7 @@ AActor* SpawnActorWithClass(UClass* actorClass) {
   if (Georeference->GetLevel() == pCurrentLevel) {
     NewActor->AttachToActor(
         Georeference,
-        FAttachmentTransformRules::KeepRelativeTransform);
+        FAttachmentTransformRules::KeepWorldTransform);
   }
 
   return NewActor;

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceCustomization.cpp
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceCustomization.cpp
@@ -39,6 +39,10 @@ void FCesiumGeoreferenceCustomization::CustomizeDetails(
               ACesiumGeoreference,
               PlaceGeoreferenceOriginHere)));
 
+  pButtons->AddButtonForUFunction(
+      ACesiumGeoreference::StaticClass()->FindFunctionByName(
+          GET_FUNCTION_NAME_CHECKED(ACesiumGeoreference, CreateSubLevelHere)));
+
   pButtons->Finish(DetailBuilder, CesiumCategory);
 
   CesiumCategory.AddProperty(

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -421,6 +421,11 @@ void ACesiumGeoreference::CreateSubLevelHere() {
     return;
   }
 
+  // Deactivate any previous sub-levels, so that setting the georeference origin
+  // doesn't change their origin, too.
+  this->SubLevelSwitcher->SetTargetSubLevel(nullptr);
+
+  // Update the georeference origin so that the new sub-level inherits it.
   this->PlaceGeoreferenceOriginHere();
 
   // Create a dummy Actor to add to the new sub-level, because
@@ -453,6 +458,12 @@ void ACesiumGeoreference::CreateSubLevelHere() {
       Cast<AActor>(LevelInstanceSubsystem->CreateLevelInstanceFrom(
           SubLevelActors,
           LevelInstanceParams));
+  if (!IsValid(LevelInstance)) {
+    // User canceled creation of the sub-level, so delete the placeholder we
+    // created.
+    PlaceholderActor->Destroy();
+    return;
+  }
 
   UCesiumSubLevelComponent* LevelComponent =
       Cast<UCesiumSubLevelComponent>(LevelInstance->AddComponentByClass(

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -37,8 +37,10 @@
 #if WITH_EDITOR
 #include "DrawDebugHelpers.h"
 #include "Editor.h"
+#include "EditorLevelUtils.h"
 #include "EditorViewportClient.h"
 #include "GameFramework/Pawn.h"
+#include "LevelInstance/LevelInstanceEditorLevelStreaming.h"
 #include "Slate/SceneViewport.h"
 #endif
 
@@ -364,7 +366,7 @@ FMatrix ACesiumGeoreference::ComputeUnrealToEastSouthUpTransformation(
 void ACesiumGeoreference::PlaceGeoreferenceOriginHere() {
   // If this is PIE mode, ignore
   UWorld* pWorld = this->GetWorld();
-  if (!GEditor || pWorld->IsGameWorld()) {
+  if (!pWorld || !GEditor || pWorld->IsGameWorld()) {
     return;
   }
 
@@ -375,22 +377,32 @@ void ACesiumGeoreference::PlaceGeoreferenceOriginHere() {
   FEditorViewportClient* pEditorViewportClient =
       static_cast<FEditorViewportClient*>(pViewportClient);
 
-  FRotator newViewRotation = this->TransformUnrealRotatorToEastSouthUp(
-      pEditorViewportClient->GetViewRotation(),
-      pEditorViewportClient->GetViewLocation());
+  // The viewport location / rotation is Unreal world coordinates. Transform
+  // into the georeference's reference frame. This way we'll compute the correct
+  // globe position even if the globe is transformed into the Unreal world.
+  FVector ViewLocation = pEditorViewportClient->GetViewLocation();
+  FQuat ViewRotation = pEditorViewportClient->GetViewRotation().Quaternion();
+
+  ViewLocation =
+      this->GetActorTransform().InverseTransformPosition(ViewLocation);
+  ViewRotation =
+      this->GetActorTransform().InverseTransformRotation(ViewRotation);
+
+  FRotator NewViewRotation = this->TransformUnrealRotatorToEastSouthUp(
+      ViewRotation.Rotator(),
+      ViewLocation);
 
   // camera local space to ECEF
-  FVector cameraEcefPosition =
-      this->TransformUnrealPositionToEarthCenteredEarthFixed(
-          pEditorViewportClient->GetViewLocation());
+  FVector CameraEcefPosition =
+      this->TransformUnrealPositionToEarthCenteredEarthFixed(ViewLocation);
 
   // Long/Lat/Height camera location, in degrees/meters (also our new target
   // georeference origin) When the location is too close to the center of the
   // earth, the result will be (0,0,0)
-  this->SetOriginEarthCenteredEarthFixed(cameraEcefPosition);
+  this->SetOriginEarthCenteredEarthFixed(CameraEcefPosition);
 
   // TODO: check for degeneracy ?
-  FVector cameraFront = newViewRotation.RotateVector(FVector::XAxisVector);
+  FVector cameraFront = NewViewRotation.RotateVector(FVector::XAxisVector);
   FVector cameraRight =
       FVector::CrossProduct(FVector::ZAxisVector, cameraFront).GetSafeNormal();
   FVector cameraUp =
@@ -399,7 +411,64 @@ void ACesiumGeoreference::PlaceGeoreferenceOriginHere() {
   pEditorViewportClient->SetViewRotation(
       FMatrix(cameraFront, cameraRight, cameraUp, FVector::ZeroVector)
           .Rotator());
-  pEditorViewportClient->SetViewLocation(FVector::ZeroVector);
+  pEditorViewportClient->SetViewLocation(
+      this->GetActorTransform().TransformPosition(FVector::ZeroVector));
+}
+
+void ACesiumGeoreference::CreateSubLevelHere() {
+  UWorld* World = GetWorld();
+  if (!World || !GEditor || World->IsGameWorld()) {
+    return;
+  }
+
+  this->PlaceGeoreferenceOriginHere();
+
+  // Create a dummy Actor to add to the new sub-level, because
+  // CreateLevelInstanceFrom forbids an empty array for some reason.
+  TArray<AActor*> SubLevelActors;
+
+  FActorSpawnParameters SpawnParameters{};
+  SpawnParameters.NameMode =
+      FActorSpawnParameters::ESpawnActorNameMode::Requested;
+  SpawnParameters.Name = TEXT("Placeholder");
+  SpawnParameters.ObjectFlags = RF_Transactional;
+
+  AActor* PlaceholderActor = World->SpawnActor<AActor>(
+      FVector::ZeroVector,
+      FRotator::ZeroRotator,
+      SpawnParameters);
+  PlaceholderActor->SetActorLabel(TEXT("Placeholder"));
+
+  SubLevelActors.Add(PlaceholderActor);
+
+  // Create the new Level Instance Actor and corresponding streaming level.
+  FNewLevelInstanceParams LevelInstanceParams{};
+  LevelInstanceParams.PivotType = ELevelInstancePivotType::WorldOrigin;
+  LevelInstanceParams.Type = ELevelInstanceCreationType::LevelInstance;
+  LevelInstanceParams.SetExternalActors(false);
+
+  ULevelInstanceSubsystem* LevelInstanceSubsystem =
+      World->GetSubsystem<ULevelInstanceSubsystem>();
+  AActor* LevelInstance =
+      Cast<AActor>(LevelInstanceSubsystem->CreateLevelInstanceFrom(
+          SubLevelActors,
+          LevelInstanceParams));
+
+  UCesiumSubLevelComponent* LevelComponent =
+      Cast<UCesiumSubLevelComponent>(LevelInstance->AddComponentByClass(
+          UCesiumSubLevelComponent::StaticClass(),
+          false,
+          FTransform::Identity,
+          false));
+  LevelComponent->SetFlags(RF_Transactional);
+  LevelInstance->AddInstanceComponent(LevelComponent);
+
+  // Move the new level instance under the CesiumGeoreference.
+  LevelInstance->GetRootComponent()->SetMobility(
+      this->GetRootComponent()->Mobility);
+  LevelInstance->AttachToActor(
+      this,
+      FAttachmentTransformRules::KeepRelativeTransform);
 }
 
 void ACesiumGeoreference::_showSubLevelLoadRadii() const {
@@ -661,6 +730,8 @@ void ACesiumGeoreference::_createSubLevelsFromWorldComposition() {
 
     FActorSpawnParameters spawnParameters{};
     spawnParameters.Name = FName(pFound->LevelName);
+    spawnParameters.NameMode =
+        FActorSpawnParameters::ESpawnActorNameMode::Requested;
     spawnParameters.ObjectFlags = RF_Transactional;
 
     ALevelInstance* pLevelInstance = pWorld->SpawnActor<ALevelInstance>(

--- a/Source/CesiumRuntime/Private/CesiumSubLevelComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSubLevelComponent.cpp
@@ -223,6 +223,15 @@ void UCesiumSubLevelComponent::PlaceOriginAtEcef(const FVector& NewOriginEcef) {
     return;
   }
 
+  if (pOwner->IsEditing()) {
+    UE_LOG(
+        LogCesium,
+        Error,
+        TEXT(
+            "The georeference origin cannot be moved while the sub-level is being edited."));
+    return;
+  }
+
   // Another sub-level might be active right now, so we construct the correct
   // GeoTransforms instead of using the CesiumGeoreference's.
   const Ellipsoid& ellipsoid = CesiumGeospatial::Ellipsoid::WGS84;
@@ -517,6 +526,15 @@ void UCesiumSubLevelComponent::OnUnregister() {
   if (pSwitcher)
     pSwitcher->UnregisterSubLevel(pOwner);
 }
+
+#if WITH_EDITOR
+bool UCesiumSubLevelComponent::CanEditChange(
+    const FProperty* InProperty) const {
+  // Don't allow editing this property if the parent Actor isn't editable.
+  return Super::CanEditChange(InProperty) &&
+         (!IsValid(GetOwner()) || GetOwner()->CanEditChange(InProperty));
+}
+#endif
 
 UCesiumSubLevelSwitcherComponent*
 UCesiumSubLevelComponent::_getSwitcher() noexcept {

--- a/Source/CesiumRuntime/Private/CesiumSubLevelComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSubLevelComponent.cpp
@@ -163,13 +163,17 @@ void UCesiumSubLevelComponent::PlaceGeoreferenceOriginAtSubLevelOrigin() {
     return;
   }
 
+  FVector UnrealPosition =
+      pGeoreference->GetActorTransform().InverseTransformPosition(
+          pOwner->GetActorLocation());
+
   FVector NewOriginEcef =
       pGeoreference->TransformUnrealPositionToEarthCenteredEarthFixed(
-          Root->GetRelativeLocation());
+          UnrealPosition);
   this->PlaceOriginAtEcef(NewOriginEcef);
 }
 
-void UCesiumSubLevelComponent::PlaceOriginHere() {
+void UCesiumSubLevelComponent::PlaceGeoreferenceOriginHere() {
   ACesiumGeoreference* pGeoreference = this->ResolveGeoreference();
   if (!IsValid(pGeoreference)) {
     UE_LOG(
@@ -191,9 +195,15 @@ void UCesiumSubLevelComponent::PlaceOriginHere() {
   FEditorViewportClient* pEditorViewportClient =
       static_cast<FEditorViewportClient*>(pViewportClient);
 
+  FVector ViewLocation = pEditorViewportClient->GetViewLocation();
+
+  // Transform the world-space view location to the CesiumGeoreference's frame.
+  ViewLocation =
+      pGeoreference->GetActorTransform().InverseTransformPosition(ViewLocation);
+
   FVector CameraEcefPosition =
       pGeoreference->TransformUnrealPositionToEarthCenteredEarthFixed(
-          pEditorViewportClient->GetViewLocation());
+          ViewLocation);
   this->PlaceOriginAtEcef(CameraEcefPosition);
 }
 

--- a/Source/CesiumRuntime/Private/CesiumSubLevelComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSubLevelComponent.cpp
@@ -267,12 +267,16 @@ void UCesiumSubLevelComponent::PlaceOriginAtEcef(const FVector& NewOriginEcef) {
   ULevelStreaming* LevelStreaming = getLevelStreamingForSubLevel(pOwner);
   ULevel* Level =
       IsValid(LevelStreaming) ? LevelStreaming->GetLoadedLevel() : nullptr;
+
   bool bHasTilesets = Level && IsValid(Level) &&
                       Level->Actors.FindByPredicate([](AActor* Actor) {
                         return Cast<ACesium3DTileset>(Actor) != nullptr;
                       }) != nullptr;
 
-  FTransform OldLevelTransform = LevelStreaming->LevelTransform;
+  FTransform OldLevelTransform;
+  if (bHasTilesets) {
+    OldLevelTransform = LevelStreaming->LevelTransform;
+  }
 
   pOwner->Modify();
   pOwner->SetActorTransform(

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -653,7 +653,8 @@ public:
   /**
    * Places the georeference origin at the camera's current location. Rotates
    * the globe so the current longitude/latitude/height of the camera is at the
-   * Unreal origin. The camera is also teleported to the Unreal origin.
+   * Unreal origin. The camera is also teleported to the new Unreal origin and
+   * rotated so that the view direction is maintained.
    *
    * Warning: Before clicking, ensure that all non-Cesium objects in the
    * persistent level are georeferenced with the "CesiumGlobeAnchorComponent"

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -664,6 +664,16 @@ public:
   UFUNCTION(Category = "Cesium")
   void PlaceGeoreferenceOriginHere();
 
+  /**
+   * Creates a new Level Instance Actor at the current viewport location, and
+   * attaches the Cesium Sub Level Component to it. You will be prompted for
+   * where to store the new level.
+   *
+   * Warning: Before clicking, ensure that all non-Cesium objects in the
+   * persistent level are georeferenced with the "CesiumGlobeAnchorComponent"
+   * or attached to an actor with that component. Ensure that static actors only
+   * exist in georeferenced sub-levels.
+   */
   UFUNCTION(Category = "Cesium")
   void CreateSubLevelHere();
 #endif

--- a/Source/CesiumRuntime/Public/CesiumGeoreference.h
+++ b/Source/CesiumRuntime/Public/CesiumGeoreference.h
@@ -663,6 +663,9 @@ public:
    */
   UFUNCTION(Category = "Cesium")
   void PlaceGeoreferenceOriginHere();
+
+  UFUNCTION(Category = "Cesium")
+  void CreateSubLevelHere();
 #endif
 
 private:

--- a/Source/CesiumRuntime/Public/CesiumSubLevelComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumSubLevelComponent.h
@@ -192,6 +192,11 @@ public:
    * Level Instance's Location to (0,0,0). This improves the precision of the
    * objects in the sub-level as well as makes the Load Radius more sensible.
    *
+   * If your sub-level has any Cesium3DTilesets, Cesium for Unreal will enter
+   * Edit mode for the sub-level and the Cesium3DTilesets' transformations will
+   * be updated based on the new georeference origin. You should Commit this
+   * change.
+   *
    * Warning: Before clicking, ensure that all non-Cesium objects in the
    * persistent level are georeferenced with the "CesiumGeoreferenceComponent"
    * or attached to an actor with that component. Ensure that static actors only
@@ -205,6 +210,11 @@ public:
    * the globe so the current longitude/latitude/height of the camera is at the
    * Unreal origin of this sub-level. The camera is also teleported to the new
    * Unreal origin and rotated so that the view direction is maintained.
+   *
+   * If your sub-level has any Cesium3DTilesets, Cesium for Unreal will enter
+   * Edit mode for the sub-level and the Cesium3DTilesets' transformations will
+   * be updated based on the new georeference origin. You should Commit this
+   * change.
    *
    * Warning: Before clicking, ensure that all non-Cesium objects in the
    * persistent level are georeferenced with the "CesiumGlobeAnchorComponent"

--- a/Source/CesiumRuntime/Public/CesiumSubLevelComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumSubLevelComponent.h
@@ -265,6 +265,15 @@ protected:
    */
   virtual void OnUnregister() override;
 
+#if WITH_EDITOR
+  /**
+   * Called by the Editor to check if it's ok to edit a property on this object.
+   * Used to disable all fields on this component when editing the sub-level
+   * instance that this component is attached to.
+   */
+  virtual bool CanEditChange(const FProperty* InProperty) const override;
+#endif
+
 private:
   /**
    * Whether this sub-level is enabled. An enabled sub-level will be

--- a/Source/CesiumRuntime/Public/CesiumSubLevelComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumSubLevelComponent.h
@@ -211,6 +211,11 @@ public:
    * Unreal origin of this sub-level. The camera is also teleported to the new
    * Unreal origin and rotated so that the view direction is maintained.
    *
+   * This function is similar to "Place Georeference Origin Here" on the
+   * CesiumGeoreference, except that this moves the georeference origin while
+   * also ensuring that the sub-level content stays in the same place on the
+   * globe by adjusting the Level Instance's transform.
+   *
    * If your sub-level has any Cesium3DTilesets, Cesium for Unreal will enter
    * Edit mode for the sub-level and the Cesium3DTilesets' transformations will
    * be updated based on the new georeference origin. You should Commit this
@@ -222,7 +227,7 @@ public:
    * exist in georeferenced sub-levels.
    */
   UFUNCTION(CallInEditor, Category = "Cesium")
-  void PlaceOriginHere();
+  void PlaceGeoreferenceOriginHere();
 #endif
 
   /**

--- a/Source/CesiumRuntime/Public/CesiumSubLevelComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumSubLevelComponent.h
@@ -199,6 +199,20 @@ public:
    */
   UFUNCTION(CallInEditor, Category = "Cesium")
   void PlaceGeoreferenceOriginAtSubLevelOrigin();
+
+  /**
+   * Places the sub-level's origin at the camera's current location. Rotates
+   * the globe so the current longitude/latitude/height of the camera is at the
+   * Unreal origin of this sub-level. The camera is also teleported to the new
+   * Unreal origin and rotated so that the view direction is maintained.
+   *
+   * Warning: Before clicking, ensure that all non-Cesium objects in the
+   * persistent level are georeferenced with the "CesiumGlobeAnchorComponent"
+   * or attached to an actor with that component. Ensure that static actors only
+   * exist in georeferenced sub-levels.
+   */
+  UFUNCTION(CallInEditor, Category = "Cesium")
+  void PlaceOriginHere();
 #endif
 
   /**
@@ -365,4 +379,6 @@ private:
    * Georeference will be re-resolved and re-subscribed.
    */
   void _invalidateResolvedGeoreference();
+
+  void PlaceOriginAtEcef(const FVector& NewOriginEcef);
 };


### PR DESCRIPTION
Numerous sub-level workflow improvements:

* New Cesium Actors are now created with the same world transform as the CesiumGeoreference. This is particularly important when Actors are created in sub-levels, because the previous behavior (an identity world transform) would end up with them misaligned with other Cesium globe things. Outside sub-levels, it should behave the same as before, but it's hopefully a bit clearer. Previously we created the new Tileset (for example) with an identity FTransform, and then moved it under the CesiumGeoreference while preserving the (identity) _relative_ transform. That would cause it to adopt the same world transform as the CesiumGeoreference. Now we create it explicitly with the same world transform as the CesiumGeoreference, and preserve the world transform when moving it under the CesiumGeoreference.
* Added `Create Sub Level Here` button to the `CesiumGeoreference`. Fixes #1162.
* Fixed a bug in the `Place Georeference Origin Here` button where it failed to take into account the CesiumGeoreference's transform.
* Made `PlaceGeoreferenceOriginAtSubLevelOrigin` on `CesiumSubLevelComponent` work correctly when the sub-level contained tilesets. Previously the tilesets would end up misaligned with the rest of the globe. Fixes #1261 
* Added `Place Georeference Origin Here` button on `CesiumSubLevelComponent`. It moves the georeference origin to the current camera position while ensuring the sub-level content doesn't move relative to the globe. It does this by setting the level instance's transform.
