### PR TITLE
Fix uninitialized struct members

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,9 +17,6 @@
 - Added `UCesiumFeatureIdTextureBlueprintLibrary::GetFeatureIDForUV`, which samples a feature ID texture with `FVector2D` UV coordinates.
 - Added `GetGltfTextureCoordinateSetIndex` to `UCesiumFeatureIdTextureBlueprintLibrary` and `UCesiumPropertyTexturePropertyBlueprintLibrary` to avoid ambiguity with `GetUnrealUVChannel`.
 - Added `UCesiumMetadataValueBlueprintLibrary::GetValuesAsStrings` to convert a map of `FCesiumMetadataValues` to their string representations.
-
-##### Additions :tada:
-
 - Added support for `file:///` URLs across all platforms and Unreal Engine versions.
 
 ##### Fixes :wrench:

--- a/Source/CesiumRuntime/Public/CesiumFeaturesMetadataComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumFeaturesMetadataComponent.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "CesiumFeatureIdSet.h"
 #include "CesiumMetadataEncodingDetails.h"
 #include "CesiumMetadataPropertyDetails.h"
 #include "Components/ActorComponent.h"
@@ -16,11 +17,6 @@
 #include "CesiumFeaturesMetadataComponent.generated.h"
 
 #pragma region Features descriptions
-
-enum class ECesiumFeatureIdSetType : uint8;
-enum class ECesiumEncodedMetadataType : uint8;
-enum class ECesiumEncodedMetadataComponentType : uint8;
-enum class ECesiumEncodedMetadataConversion : uint8;
 
 /**
  * @brief Description of a feature ID set from EXT_mesh_features.
@@ -55,7 +51,7 @@ struct CESIUMRUNTIME_API FCesiumFeatureIdSetDescription {
    * The type of the feature ID set.
    */
   UPROPERTY(EditAnywhere, Category = "Cesium")
-  ECesiumFeatureIdSetType Type;
+  ECesiumFeatureIdSetType Type = ECesiumFeatureIdSetType::None;
 
   /**
    * The name of the property table that this feature ID set corresponds to.
@@ -70,7 +66,7 @@ struct CESIUMRUNTIME_API FCesiumFeatureIdSetDescription {
    * unnecessarily included in the generated material.
    */
   UPROPERTY(EditAnywhere, Category = "Cesium")
-  bool bHasNullFeatureId;
+  bool bHasNullFeatureId = false;
 };
 
 /**

--- a/Source/CesiumRuntime/Public/CesiumMetadataPropertyDetails.h
+++ b/Source/CesiumRuntime/Public/CesiumMetadataPropertyDetails.h
@@ -30,7 +30,7 @@ struct CESIUMRUNTIME_API FCesiumMetadataPropertyDetails {
    * The type of the metadata property.
    */
   UPROPERTY(EditAnywhere, Category = "Cesium")
-  ECesiumMetadataType Type;
+  ECesiumMetadataType Type = ECesiumMetadataType::Invalid;
 
   /**
    * The component of the metadata property. Only applies when the type is a
@@ -42,14 +42,15 @@ struct CESIUMRUNTIME_API FCesiumMetadataPropertyDetails {
       Meta =
           (EditCondition =
                "Type != ECesiumMetadataType::Invalid && Type != ECesiumMetadataType::Boolean && Type != ECesiumMetadataType::Enum && Type != ECesiumMetadataType::String"))
-  ECesiumMetadataComponentType ComponentType;
+  ECesiumMetadataComponentType ComponentType =
+      ECesiumMetadataComponentType::None;
 
   /**
    * Whether or not this represents an array containing elements of the
    * specified types.
    */
   UPROPERTY(EditAnywhere, Category = "Cesium")
-  bool bIsArray;
+  bool bIsArray = false;
 
   /**
    * The size of the arrays in the metadata property. If the property contains


### PR DESCRIPTION
Fixes #1257 by setting default values for struct members that were missing them.