### PR TITLE
Add missing includes, fix a warning

### DIFF
--- a/Source/CesiumRuntime/Private/Tests/CesiumLoadTestCore.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumLoadTestCore.cpp
@@ -146,7 +146,7 @@ DEFINE_LATENT_AUTOMATION_COMMAND_ONE_PARAMETER(
 bool TestCleanupCommand::Update() {
   // Tag the fastest pass
   if (context.testPasses.size() > 0) {
-    size_t fastestPass;
+    size_t fastestPass = 0;
     double fastestTime = -1.0;
     for (size_t index = 0; index < context.testPasses.size(); ++index) {
       const TestPass& pass = context.testPasses[index];

--- a/Source/CesiumRuntime/Private/Tests/CesiumLoadTestCore.h
+++ b/Source/CesiumRuntime/Private/Tests/CesiumLoadTestCore.h
@@ -5,6 +5,7 @@
 #if WITH_EDITOR
 
 #include <functional>
+#include <variant>
 
 #include "CesiumSceneGeneration.h"
 

--- a/Source/CesiumRuntime/Private/Tests/CesiumLoadTestSamples.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumLoadTestSamples.cpp
@@ -6,8 +6,10 @@
 
 #include "Misc/AutomationTest.h"
 
+#include "CesiumAsync/ICacheDatabase.h"
 #include "CesiumGltfComponent.h"
 #include "CesiumIonRasterOverlay.h"
+#include "CesiumRuntime.h"
 #include "CesiumSunSky.h"
 #include "GlobeAwareDefaultPawn.h"
 

--- a/Source/CesiumRuntime/Private/Tests/Google3dTilesLoadTest.cpp
+++ b/Source/CesiumRuntime/Private/Tests/Google3dTilesLoadTest.cpp
@@ -9,6 +9,7 @@
 
 #include "Cesium3DTileset.h"
 #include "CesiumAsync/ICacheDatabase.h"
+#include "CesiumRuntime.h"
 #include "CesiumSunSky.h"
 
 using namespace Cesium;


### PR DESCRIPTION
This fixes some errors caused by missing includes in a non-unity build. Also fixed a warning caused by the compiler being unable to see that a variable would actually be initialized.