### PR TITLE
Move new unit tests to Cesium.Unit.X namespace

### DIFF
--- a/Source/CesiumRuntime/Private/Tests/CesiumPropertyTexture.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumPropertyTexture.spec.cpp
@@ -11,7 +11,7 @@ using namespace CesiumGltf;
 
 BEGIN_DEFINE_SPEC(
     FCesiumPropertyTextureSpec,
-    "Cesium.PropertyTexture",
+    "Cesium.Unit.PropertyTexture",
     EAutomationTestFlags::ApplicationContextMask |
         EAutomationTestFlags::ProductFilter)
 Model model;

--- a/Source/CesiumRuntime/Private/Tests/CesiumPropertyTextureProperty.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumPropertyTextureProperty.spec.cpp
@@ -8,7 +8,7 @@ using namespace CesiumGltf;
 
 BEGIN_DEFINE_SPEC(
     FCesiumPropertyTexturePropertySpec,
-    "Cesium.PropertyTextureProperty",
+    "Cesium.Unit.PropertyTextureProperty",
     EAutomationTestFlags::ApplicationContextMask |
         EAutomationTestFlags::ProductFilter)
 const std::vector<FVector2D> texCoords{


### PR DESCRIPTION
They were added previously, but not in this namespace.

CI executes the tests from this namespace. If your test isn't here, it won't run.