### PR TITLE
Cesium3DTileset custom category ordering

### DIFF
--- a/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.cpp
+++ b/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.cpp
@@ -1,15 +1,15 @@
 // Copyright 2020-2023 CesiumGS, Inc. and Contributors
 
 #include "Cesium3DTilesetCustomization.h"
-#include "CesiumCustomization.h"
 #include "Cesium3DTileset.h"
+#include "CesiumCustomization.h"
 #include "DetailCategoryBuilder.h"
 #include "DetailLayoutBuilder.h"
 
 void FCesium3DTilesetCustomization::Register(
     FPropertyEditorModule& PropertyEditorModule) {
   PropertyEditorModule.RegisterCustomClassLayout(
-    ACesium3DTileset::StaticClass()->GetFName(),
+      ACesium3DTileset::StaticClass()->GetFName(),
       FOnGetDetailCustomizationInstance::CreateStatic(
           &FCesium3DTilesetCustomization::MakeInstance));
 }
@@ -17,11 +17,10 @@ void FCesium3DTilesetCustomization::Register(
 void FCesium3DTilesetCustomization::Unregister(
     FPropertyEditorModule& PropertyEditorModule) {
   PropertyEditorModule.UnregisterCustomClassLayout(
-    ACesium3DTileset::StaticClass()->GetFName());
+      ACesium3DTileset::StaticClass()->GetFName());
 }
 
-TSharedRef<IDetailCustomization>
-FCesium3DTilesetCustomization::MakeInstance() {
+TSharedRef<IDetailCustomization> FCesium3DTilesetCustomization::MakeInstance() {
   return MakeShareable(new FCesium3DTilesetCustomization);
 }
 
@@ -30,8 +29,8 @@ void FCesium3DTilesetCustomization::CustomizeDetails(
   DetailBuilder.SortCategories(&SortCustomDetailsCategories);
 }
 
-void FCesium3DTilesetCustomization::SortCustomDetailsCategories(const TMap<FName, IDetailCategoryBuilder*>& AllCategoryMap)
-{
+void FCesium3DTilesetCustomization::SortCustomDetailsCategories(
+    const TMap<FName, IDetailCategoryBuilder*>& AllCategoryMap) {
   (*AllCategoryMap.Find(FName("Transform")))->SetSortOrder(0);
   (*AllCategoryMap.Find(FName("Cesium")))->SetSortOrder(2000);
   (*AllCategoryMap.Find(FName("Rendering")))->SetSortOrder(4000);

--- a/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.cpp
+++ b/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.cpp
@@ -32,5 +32,7 @@ void FCesium3DTilesetCustomization::CustomizeDetails(
 
 void FCesium3DTilesetCustomization::SortCustomDetailsCategories(const TMap<FName, IDetailCategoryBuilder*>& AllCategoryMap)
 {
-  (*AllCategoryMap.Find(FName("Cesium")))->SetSortOrder(0);
+  (*AllCategoryMap.Find(FName("Transform")))->SetSortOrder(0);
+  (*AllCategoryMap.Find(FName("Cesium")))->SetSortOrder(2000);
+  (*AllCategoryMap.Find(FName("Rendering")))->SetSortOrder(4000);
 }

--- a/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.cpp
+++ b/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.cpp
@@ -1,0 +1,36 @@
+// Copyright 2020-2023 CesiumGS, Inc. and Contributors
+
+#include "Cesium3DTilesetCustomization.h"
+#include "CesiumCustomization.h"
+#include "Cesium3DTileset.h"
+#include "DetailCategoryBuilder.h"
+#include "DetailLayoutBuilder.h"
+
+void FCesium3DTilesetCustomization::Register(
+    FPropertyEditorModule& PropertyEditorModule) {
+  PropertyEditorModule.RegisterCustomClassLayout(
+    ACesium3DTileset::StaticClass()->GetFName(),
+      FOnGetDetailCustomizationInstance::CreateStatic(
+          &FCesium3DTilesetCustomization::MakeInstance));
+}
+
+void FCesium3DTilesetCustomization::Unregister(
+    FPropertyEditorModule& PropertyEditorModule) {
+  PropertyEditorModule.UnregisterCustomClassLayout(
+    ACesium3DTileset::StaticClass()->GetFName());
+}
+
+TSharedRef<IDetailCustomization>
+FCesium3DTilesetCustomization::MakeInstance() {
+  return MakeShareable(new FCesium3DTilesetCustomization);
+}
+
+void FCesium3DTilesetCustomization::CustomizeDetails(
+    IDetailLayoutBuilder& DetailBuilder) {
+  DetailBuilder.SortCategories(&SortCustomDetailsCategories);
+}
+
+void FCesium3DTilesetCustomization::SortCustomDetailsCategories(const TMap<FName, IDetailCategoryBuilder*>& AllCategoryMap)
+{
+  (*AllCategoryMap.Find(FName("Cesium")))->SetSortOrder(0);
+}

--- a/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.cpp
+++ b/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.cpp
@@ -31,7 +31,7 @@ void FCesium3DTilesetCustomization::CustomizeDetails(
 
 void FCesium3DTilesetCustomization::SortCustomDetailsCategories(
     const TMap<FName, IDetailCategoryBuilder*>& AllCategoryMap) {
-  (*AllCategoryMap.Find(FName("Transform")))->SetSortOrder(0);
-  (*AllCategoryMap.Find(FName("Cesium")))->SetSortOrder(2000);
-  (*AllCategoryMap.Find(FName("Rendering")))->SetSortOrder(4000);
+  (*AllCategoryMap.Find(FName("TransformCommon")))->SetSortOrder(0);
+  (*AllCategoryMap.Find(FName("Cesium")))->SetSortOrder(1);
+  (*AllCategoryMap.Find(FName("Rendering")))->SetSortOrder(2);
 }

--- a/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.h
+++ b/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.h
@@ -1,0 +1,22 @@
+// Copyright 2020-2023 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "IDetailCustomization.h"
+
+/**
+ * An implementation of the IDetailCustomization interface that customizes
+ * the Details View of a CesiumGeoreference. It is registered in
+ * FCesiumEditorModule::StartupModule.
+ */
+class FCesium3DTilesetCustomization : public IDetailCustomization {
+public:
+  virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+
+  static void Register(FPropertyEditorModule& PropertyEditorModule);
+  static void Unregister(FPropertyEditorModule& PropertyEditorModule);
+
+  static TSharedRef<IDetailCustomization> MakeInstance();
+
+  static void SortCustomDetailsCategories(const TMap<FName, IDetailCategoryBuilder*>& AllCategoryMap);
+};

--- a/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.h
+++ b/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.h
@@ -18,5 +18,6 @@ public:
 
   static TSharedRef<IDetailCustomization> MakeInstance();
 
-  static void SortCustomDetailsCategories(const TMap<FName, IDetailCategoryBuilder*>& AllCategoryMap);
+  static void SortCustomDetailsCategories(
+      const TMap<FName, IDetailCategoryBuilder*>& AllCategoryMap);
 };

--- a/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.h
+++ b/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.h
@@ -6,7 +6,7 @@
 
 /**
  * An implementation of the IDetailCustomization interface that customizes
- * the Details View of a CesiumGeoreference. It is registered in
+ * the Details View of a Cesium3DTileset. It is registered in
  * FCesiumEditorModule::StartupModule.
  */
 class FCesium3DTilesetCustomization : public IDetailCustomization {

--- a/Source/CesiumEditor/Private/CesiumEditor.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditor.cpp
@@ -111,6 +111,7 @@ void registerDetailCustomization() {
 
   FCesiumGeoreferenceCustomization::Register(PropertyEditorModule);
   FCesiumGlobeAnchorCustomization::Register(PropertyEditorModule);
+  FCesium3DTilesetCustomization::Register(PropertyEditorModule);
 
   PropertyEditorModule.NotifyCustomizationModuleChanged();
 }
@@ -126,6 +127,7 @@ void unregisterDetailCustomization() {
 
     FCesiumGeoreferenceCustomization::Unregister(PropertyEditorModule);
     FCesiumGlobeAnchorCustomization::Unregister(PropertyEditorModule);
+    FCesium3DTilesetCustomization::Unregister(PropertyEditorModule);
   }
 }
 


### PR DESCRIPTION
Closes #1260 .

Move Cesium category so it's right after Transform and before Rendering.

These changes allow us to do future customization as well.

![image](https://github.com/CesiumGS/cesium-unreal/assets/130494071/197c8bed-44a2-41cb-b7ff-30281e5b9216)
