### PR TITLE
Fix Duplicate Library from CesiumRuntime.Build.cs

### DIFF
--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -104,7 +104,6 @@ public class CesiumRuntime : ModuleRules
             "turbojpeg",
             "uriparser",
             "webpdecoder",
-            "ktx_read",
         };
 
         // Use our own copy of MikkTSpace on Android.


### PR DESCRIPTION
Fix the duplicate "ktx_read", in library list.