### PR TITLE
Fix tiles on edges of frustum disappearing (UE.5.3)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ### ? - ?
 
+##### Fixes :wrench:
+
+- Fixed a bug where viewports could appear wider than configured in the Dynamic Pawn's Camera Field of View. Noticed in Unreal Engine v5.3 when in Play-In-Editor mode, or a packaged game. In extreme cases, tiles would be missing near the edges of the view
+
 ##### Additions :tada:
 
  - Added support for styling with property textures in `EXT_structural_metadata`.

--- a/Config/Engine.ini
+++ b/Config/Engine.ini
@@ -11,6 +11,9 @@ RunningThreadedRequestLimit=100
 [HTTP]
 HttpThreadActiveFrameTimeInSeconds=0.001
 
+[/Script/Engine.LocalPlayer]
+AspectRatioAxisConstraint=AspectRatio_MaintainXFOV
+
 [CoreRedirects]
 +FunctionRedirects=(OldName="CesiumMetadataFeatureTableBlueprintLibrary.GetPropertiesForFeatureID",NewName="GetMetadataValuesForFeatureID")
 


### PR DESCRIPTION
Closes #1303.

Explicitly set the value of `AspectRatioAxisConstraint` to `AspectRatio_MaintainXFOV`. Our code in `ACesium3DTileset::CreateViewStateFromViewParameters` assumes horizontal field of view is constant, and vertical field of view is calculated from this.


This fixes a bug where the editor viewport did not match the viewport you would see when entering Play-in-Editor mode or when running a packaged game. It's noticeable whenever the aspect ratio isn't 1.0, although in extreme cases, tile might not show up around the edges of the view.


In Unreal Engine v5.2, the default was `AspectRatio_MaintainXFOV`. In Unreal Engine v5.3, the default is now `AspectRatio_MaintainYFOV`. This change caused the issue.

![image](https://github.com/CesiumGS/cesium-unreal/assets/130494071/e7b76e8c-7796-4c15-af35-a23c7d030f92)