### PR TITLE
Multiple cesium ions review

### DIFF
--- a/Source/CesiumEditor/Private/IonLoginPanel.cpp
+++ b/Source/CesiumEditor/Private/IonLoginPanel.cpp
@@ -4,6 +4,7 @@
 #include "CesiumEditor.h"
 #include "CesiumIonClient/Connection.h"
 #include "CesiumIonClient/Token.h"
+#include "CesiumIonServer.h"
 #include "HAL/PlatformApplicationMisc.h"
 #include "HttpModule.h"
 #include "Interfaces/IHttpRequest.h"
@@ -25,8 +26,11 @@ void IonLoginPanel::Construct(const FArguments& InArgs) {
 
   auto visibleWhenConnecting = [this]() {
     return FCesiumEditorModule::serverManager()
-                   .GetCurrentSession()
-                   ->isConnecting()
+                       .GetCurrentSession()
+                       ->isConnecting() &&
+                   !FCesiumEditorModule::serverManager()
+                        .GetCurrent()
+                        ->ApiUrl.IsEmpty()
                ? EVisibility::Visible
                : EVisibility::Hidden;
   };


### PR DESCRIPTION
Fixes two bugs:

1. When resuming, the connection could still be connected even when the API url is incorrect and so the UI appears that the user is logged in. Now, the Login Panel shows instead.

2. When the API url is being fetched, the ConnectionStatus Widget would show the URL to be blank and the Cancel button wouldn't work. Now, the ConnectionStatus Widget will appear only after the Server has acquired the API url and tries to authorize.