### PR TITLE
Reduce texture memory usage on non-Windows systems

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Fixed a bug in `MLB_DitherFade` that made glTF materials with an `alphaMode` of `MASK` incorrectly appear as fully opaque.
 
+##### Additions :tada:
+
+- Significantly reduced CPU memory usage by textures on non-Windows systems.
+
 ### v2.2.0 - 2023-12-14
 
 ##### Breaking Changes :mega:

--- a/Source/CesiumRuntime/Private/CesiumEncodedFeaturesMetadata.cpp
+++ b/Source/CesiumRuntime/Private/CesiumEncodedFeaturesMetadata.cpp
@@ -171,6 +171,7 @@ std::optional<EncodedFeatureIdSet> encodeFeatureIdTexture(
         pFeatureIdImage->pixelData.size());
 
     pMip->BulkData.Unlock();
+    pMip->BulkData.SetBulkDataFlags(BULKDATA_SingleUse);
   }
 
   return result;
@@ -609,6 +610,7 @@ EncodedPropertyTable encodePropertyTableAnyThreadPart(
             encodedFormat.pixelSize);
       }
       pMip->BulkData.Unlock();
+      pMip->BulkData.SetBulkDataFlags(BULKDATA_SingleUse);
     }
 
     if (pDescription->PropertyDetails.bHasOffset) {
@@ -774,6 +776,7 @@ EncodedPropertyTexture encodePropertyTextureAnyThreadPart(
             pImage->pixelData.size());
 
         pMip->BulkData.Unlock();
+        pMip->BulkData.SetBulkDataFlags(BULKDATA_SingleUse);
       }
     };
 

--- a/Source/CesiumRuntime/Private/CesiumEncodedMetadataUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumEncodedMetadataUtility.cpp
@@ -291,6 +291,7 @@ EncodedMetadataFeatureTable encodeMetadataFeatureTableAnyThreadPart(
     }
 
     pMip->BulkData.Unlock();
+    pMip->BulkData.SetBulkDataFlags(BULKDATA_SingleUse);
   }
 
   return encodedFeatureTable;
@@ -572,6 +573,7 @@ EncodedMetadataPrimitive encodeMetadataPrimitiveAnyThreadPart(
               pFeatureIdImage->pixelData.size());
 
           pMip->BulkData.Unlock();
+          pMip->BulkData.SetBulkDataFlags(BULKDATA_SingleUse);
         }
 
         encodedFeatureIdTexture.featureTableName = featureTableName;

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -58,6 +58,7 @@ void legacy_populateMips(
     FMemory::Memcpy(pDest, image.pixelData.data(), image.pixelData.size());
 
     pMip->BulkData.Unlock();
+    pMip->BulkData.SetBulkDataFlags(BULKDATA_SingleUse);
 
     return;
   }
@@ -77,6 +78,7 @@ void legacy_populateMips(
         mipPos.byteSize);
 
     pMip->BulkData.Unlock();
+    pMip->BulkData.SetBulkDataFlags(BULKDATA_SingleUse);
 
     if (!generateMipMaps) {
       // Only populate mip 0 if we don't want the full mip chain.


### PR DESCRIPTION
This is a simple change that significantly reduces the amount of (CPU) memory used by textures on non-Windows systems.

We create textures in most situations and on most platforms by populating Unreal's `FBulkData` class with the raw pixel data from the glTF or raster overlay. Then, sometime later, Unreal's uploads it to the GPU. I noticed while spelunking through the Unreal source code while working on #1327 that `FBulkData` has a flag: `BULKDATA_SingleUse`. When this is set, Unreal directly grabs the buffer from the FBulkData as the source of the GPU upload, and frees it afterward. It's single use because we can't use that buffer ourselves after Unreal has grabbed it. When it's _not_ set (which is the default), Unreal copies the bulk data again, uses the copy as the source of the upload, and leaves our original buffer in FBulkData intact.

We don't need the buffer in FBulkData - we already have our own copy of this data in the glTF - so `BULKDATA_SingleUse` is perfect for our use, and this PR adds it. Specifying this flags avoids a game-thread copy of the texture data. It also significantly reduces memory usage by texture data because the copy in the FBulkData doesn't sit around for the entire lifetime of the texture anymore.

This affects:

1. Every texture on non-Windows platforms (D3D11 and D3D12 use a custom texture creation path that is not affected by this change)
2. Feature metadata-related textures on all platforms (even Windows, because these textures don't use the custom texture creation path on Windows)

To measure the memory reduction, I hacked the Windows implementation to use the standard texture creation instead of the custom one. If you want to do this yourself, look for `GRHISupportsAsyncTextureCreation` in `CesiumTextureUtility.cpp` and replace it with `false`.

Then I opened up level 1 of the Samples project in the Editor and let it load. Before this change, the Editor process used 1.669 GB. Afterward, it used 1.538. Then I loaded the Google Photorealistic 3D Tiles sample level, and let that load. On that level, the Editor process went from 2.182 GB down to 1.918 GB with this change. These don't sound like huge changes percentage-wise, but the Editor uses a lot of memory and only some of it is our textures. Textures are our biggest use of memory in many cases, so eliminating a copy of the texture data is a big deal, especially on on devices with limited memory, like mobile and AR/VR devices.