### PR TITLE
Fix jump at end of flights.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Fixes :wrench:
 
 - Fixed a bug in `MLB_DitherFade` that made glTF materials with an `alphaMode` of `MASK` incorrectly appear as fully opaque.
+- Fixed a bug in `CesiumFlyToComponent` that could cause the position of the object to shift suddenly at the very end of the flight.
 
 ### v2.2.0 - 2023-12-14
 

--- a/Source/CesiumRuntime/Private/CesiumFlyToComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumFlyToComponent.cpp
@@ -6,6 +6,7 @@
 #include "GameFramework/Controller.h"
 #include "GameFramework/Pawn.h"
 #include "UObject/ConstructorHelpers.h"
+#include "VecMath.h"
 
 #include <glm/gtx/quaternion.hpp>
 
@@ -64,11 +65,10 @@ void UCesiumFlyToComponent::FlyToLocationEarthCenteredEarthFixed(
   this->_destinationEcef = EarthCenteredEarthFixedDestination;
 
   // Compute axis/Angle transform
-  glm::dvec3 glmEcefSource(ecefSource.X, ecefSource.Y, ecefSource.Z);
-  glm::dvec3 glmEcefDestination(
-      _destinationEcef.X,
-      _destinationEcef.Y,
-      _destinationEcef.Z);
+  glm::dvec3 glmEcefSource = VecMath::createVector3D(
+      UCesiumWgs84Ellipsoid::ScaleToGeodeticSurface(ecefSource));
+  glm::dvec3 glmEcefDestination = VecMath::createVector3D(
+      UCesiumWgs84Ellipsoid::ScaleToGeodeticSurface(this->_destinationEcef));
 
   glm::dquat flyQuat = glm::rotation(
       glm::normalize(glmEcefSource),


### PR DESCRIPTION
Fixes #1332

I wrote in the linked issue that I didn't think it was worth fixing the problem, versus porting the flight code from CesiumJS. But then I realized the fix is really easy: just scale the positions to the ellipsoid before computing the start and end directions. So here it is.