### PR TITLE
Track texture size stats in custom D3D texture loading path.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Fixed a bug in `MLB_DitherFade` that made glTF materials with an `alphaMode` of `MASK` incorrectly appear as fully opaque.
 - Fixed a bug in `CesiumFlyToComponent` that could cause the position of the object to shift suddenly at the very end of the flight.
+- Fixed a bug that caused textures created by Cesium for Unreal on D3D11 and D3D12 (only) to not be counted in the "Texture Memory Used" stat in the "Memory" stat group or in any counter in the "TextureGroup" stat group.
 
 ### v2.2.0 - 2023-12-14
 


### PR DESCRIPTION
This PR makes the "Texture Memory Used" stat of the "Memory" group:

<img width="773" alt="image" src="https://github.com/CesiumGS/cesium-unreal/assets/924374/6a22a7ec-cadd-4ae3-a494-38975f33e3e1">

And the "TextureGroup" stats:

<img width="773" alt="image" src="https://github.com/CesiumGS/cesium-unreal/assets/924374/4db6aa46-0261-4e55-9521-ac60b373f1a0">

show the memory used by our textures even on D3D11 and D3D12. Previously, our custom texture creation path side-stepped Unreal's counter logic, so the memory used by our textures was conspiciously missing from these debug displays.

This was a pain because some things necessary to make it work are inexplicably private to the engine. Specifically `FTextureResource::TextureGroupStatFNames` is a public static field in a class declared in a public header file. But trying to use it results in linker errors on Windows because Epic didn't (forgot to?) mark it as DLL exported. So I had to duplicate the engine code that declares a stat group for each texture group. 