### PR TITLE
Remove unnecessary parameters from glTF normals methods.

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -280,10 +280,9 @@ static void computeTangentSpace(TArray<FStaticMeshBuildVertex>& vertices) {
 }
 
 static void setUniformNormals(
-    const TArray<uint32_t>& indices,
     TArray<FStaticMeshBuildVertex>& vertices,
     TMeshVector3 normal) {
-  for (int i = 0; i < indices.Num(); i++) {
+  for (int i = 0; i < vertices.Num(); i++) {
     FStaticMeshBuildVertex& v = vertices[i];
     v.TangentX = v.TangentY = TMeshVector3(0.0f);
     v.TangentZ = normal;
@@ -291,10 +290,9 @@ static void setUniformNormals(
 }
 
 static void computeFlatNormals(
-    const TArray<uint32_t>& indices,
     TArray<FStaticMeshBuildVertex>& vertices) {
   // Compute flat normals
-  for (int i = 0; i < indices.Num(); i += 3) {
+  for (int i = 0; i < vertices.Num(); i += 3) {
     FStaticMeshBuildVertex& v0 = vertices[i];
     FStaticMeshBuildVertex& v1 = vertices[i + 1];
     FStaticMeshBuildVertex& v2 = vertices[i + 2];
@@ -1405,10 +1403,10 @@ static void loadPrimitive(
                   glm::dvec3(ecefCenter)),
               0.0)));
       upDir.Y *= -1;
-      setUniformNormals(indices, StaticMeshBuildVertices, upDir);
+      setUniformNormals(StaticMeshBuildVertices, upDir);
     } else {
       TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::ComputeFlatNormals)
-      computeFlatNormals(indices, StaticMeshBuildVertices);
+      computeFlatNormals(StaticMeshBuildVertices);
     }
   }
 


### PR DESCRIPTION
Fixes #1290.

As pointed out in the issue, this doesn't actually constitute a bug as these methods will only be called when `indices` and `vertices` are the same length. However, it's a bit confusing and the `indices` parameter is unnecessary regardless. This change removes the parameter from both methods and changes the loops to use the length of the vertices array instead.