### PR TITLE
Fix crash due to GEditor being nullptr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Fixed a bug in `MLB_DitherFade` that made glTF materials with an `alphaMode` of `MASK` incorrectly appear as fully opaque.
 - Fixed a bug in `CesiumFlyToComponent` that could cause the position of the object to shift suddenly at the very end of the flight.
+- Fixed a bug in `CesiumActors` that would cause the editor to crash when running in Standalone mode.
 
 ### v2.2.0 - 2023-12-14
 

--- a/Source/CesiumRuntime/Private/CesiumActors.cpp
+++ b/Source/CesiumRuntime/Private/CesiumActors.cpp
@@ -31,7 +31,7 @@ glm::dvec4 CesiumActors::getWorldOrigin4D(const AActor* actor) {
 bool CesiumActors::shouldValidateFlags(UObject* object) {
 #if WITH_EDITOR
   // Only fixup flags in the editor, when not in play mode
-  if (GEditor->IsPlaySessionInProgress())
+  if (!IsValid(GEditor) || GEditor->IsPlaySessionInProgress())
     return false;
 
   // In addition, don't fix when loading from an asset file, which sets the


### PR DESCRIPTION
Fixes #1289.

Despite `WITH_EDITOR` being defined, sometimes `GEditor` is nullptr when `CesiumActors::shouldValidateFlags` is called. This change adds a check to return false when that's the case instead of crashing.