### PR TITLE
Fix crash when enabling Ignore `KHR_materials_unlit` on point clouds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Fixed a bug in `MLB_DitherFade` that made glTF materials with an `alphaMode` of `MASK` incorrectly appear as fully opaque.
 - Fixed a bug in `CesiumFlyToComponent` that could cause the position of the object to shift suddenly at the very end of the flight.
+- Fixed a bug in `CesiumGltfComponent` that would cause a crash if the `Ignore KHR_materials_unlit` setting was enabled on a point cloud.
 
 ### v2.2.0 - 2023-12-14
 

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1026,6 +1026,13 @@ static void loadPrimitive(
       !options.pMeshOptions->pNodeOptions->pModelOptions
            ->ignoreKhrMaterialsUnlit;
 
+  // We can't calculate flat normals for points or lines, so we have to force
+  // them to be unlit if no normals are specified. Otherwise this causes a
+  // crash when attempting to calculate flat normals.
+  if (primitive.mode < MeshPrimitive::Mode::TRIANGLES && !hasNormals) {
+    primitiveResult.isUnlit = true;
+  }
+
   const MaterialPBRMetallicRoughness& pbrMetallicRoughness =
       material.pbrMetallicRoughness ? material.pbrMetallicRoughness.value()
                                     : defaultPbrMetallicRoughness;

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1029,7 +1029,11 @@ static void loadPrimitive(
   // We can't calculate flat normals for points or lines, so we have to force
   // them to be unlit if no normals are specified. Otherwise this causes a
   // crash when attempting to calculate flat normals.
-  if (primitive.mode < MeshPrimitive::Mode::TRIANGLES && !hasNormals) {
+  bool isTriangles = primitive.mode == MeshPrimitive::Mode::TRIANGLES ||
+                     primitive.mode == MeshPrimitive::Mode::TRIANGLE_FAN ||
+                     primitive.mode == MeshPrimitive::Mode::TRIANGLE_STRIP;
+
+  if (!isTriangles && !hasNormals) {
     primitiveResult.isUnlit = true;
   }
 


### PR DESCRIPTION
Fixes #1268.

Enabling the setting to Ignore `KHR_materials_unlit` forces the glTF implementation to compute flat normals for the primitive, as per the glTF spec. However, we can't compute flat normals for points or line primitives, causing a crash if this setting was enabled on a point cloud. This change adds a check that ignores this setting if specified on a non-triangle primitive. 