### PR TITLE
Update cesium-native, fix metadata test failures.

### DIFF
--- a/Source/CesiumRuntime/Private/Tests/CesiumFeatureIdTexture.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumFeatureIdTexture.spec.cpp
@@ -136,8 +136,13 @@ void FCesiumFeatureIdTextureSpec::Define() {
          image.cesium.channels = 1;
          image.cesium.pixelData.push_back(std::byte(42));
 
+         Sampler& sampler = model.samplers.emplace_back();
+         sampler.wrapS = Sampler::WrapS::CLAMP_TO_EDGE;
+         sampler.wrapT = Sampler::WrapT::CLAMP_TO_EDGE;
+
          CesiumGltf::Texture& gltfTexture = model.textures.emplace_back();
          gltfTexture.source = 0;
+         gltfTexture.sampler = 0;
 
          FeatureIdTexture texture;
          texture.index = 0;
@@ -170,8 +175,13 @@ void FCesiumFeatureIdTextureSpec::Define() {
          image.cesium.channels = 1;
          image.cesium.pixelData.push_back(std::byte(42));
 
+         Sampler& sampler = model.samplers.emplace_back();
+         sampler.wrapS = Sampler::WrapS::CLAMP_TO_EDGE;
+         sampler.wrapT = Sampler::WrapT::CLAMP_TO_EDGE;
+
          CesiumGltf::Texture& gltfTexture = model.textures.emplace_back();
          gltfTexture.source = 0;
+         gltfTexture.sampler = 0;
 
          FeatureIdTexture texture;
          texture.index = 0;

--- a/Source/CesiumRuntime/Private/Tests/CesiumGltfSpecUtility.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumGltfSpecUtility.cpp
@@ -77,7 +77,9 @@ CesiumGltf::FeatureId& AddFeatureIDsAsTextureToModel(
   data.resize(imageWidth * imageHeight);
   std::memcpy(data.data(), featureIDs.data(), data.size());
 
-  model.samplers.emplace_back();
+  Sampler& sampler = model.samplers.emplace_back();
+  sampler.wrapS = Sampler::WrapS::CLAMP_TO_EDGE;
+  sampler.wrapT = Sampler::WrapT::CLAMP_TO_EDGE;
 
   CesiumGltf::Texture& texture = model.textures.emplace_back();
   texture.sampler = 0;


### PR DESCRIPTION
Fixes #1342 

This PR just changes the tests, setting the wrapping mode to CLAMP_TO_EDGE where necessary. As I mentioned in the issue above, it's possible there's something we want to change outside of the tests as well, so that a texture coordinate of 1.0 doesn't get wrapped to 0.0.