### PR TITLE
Add checks to CesiumSunSky to prevent possible crashes

### DIFF
--- a/.github/workflows/buildWindows.yml
+++ b/.github/workflows/buildWindows.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.0.0"','"EngineVersion": "${{ inputs.unreal-engine-version }}"') | Set-Content -Path CesiumForUnreal.uplugin
       - name: Build CesiumForUnreal plugin
-        timeout-minutes: 120
+        timeout-minutes: 180
         run: |
           echo "Temp directory: $env:TEMP"
           cd "$env:UNREAL_BATCH_FILES_PATH"

--- a/Source/CesiumRuntime/Private/CesiumSunSky.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.cpp
@@ -128,8 +128,10 @@ void ACesiumSunSky::OnConstruction(const FTransform& Transform) {
       TEXT("Called OnConstruction for CesiumSunSky %s"),
       *this->GetName());
 
-  this->GlobeAnchor->MoveToEarthCenteredEarthFixedPosition(
-      FVector(0.0, 0.0, 0.0));
+  if (IsValid(this->GlobeAnchor)) {
+    this->GlobeAnchor->MoveToEarthCenteredEarthFixedPosition(
+        FVector(0.0, 0.0, 0.0));
+  }
 
   UE_LOG(
       LogCesium,
@@ -148,16 +150,18 @@ void ACesiumSunSky::OnConstruction(const FTransform& Transform) {
 }
 
 void ACesiumSunSky::_spawnSkySphere() {
-  if (!UseMobileRendering || !IsValid(GetWorld())) {
+  UWorld* world = GetWorld();
+  if (!UseMobileRendering || !IsValid(world)) {
     return;
   }
 
-  if (!IsValid(this->GetGeoreference())) {
+  ACesiumGeoreference* georeference = this->GetGeoreference();
+  if (!IsValid(georeference)) {
     return;
   }
 
   // Create a new Sky Sphere Actor and anchor it to the center of the Earth.
-  this->SkySphereActor = GetWorld()->SpawnActor<AActor>(SkySphereClass);
+  this->SkySphereActor = world->SpawnActor<AActor>(SkySphereClass);
 
   // Anchor it to the center of the Earth.
   UCesiumGlobeAnchorComponent* GlobeAnchorComponent =
@@ -166,7 +170,7 @@ void ACesiumSunSky::_spawnSkySphere() {
           TEXT("GlobeAnchor"));
   this->SkySphereActor->AddInstanceComponent(GlobeAnchorComponent);
   GlobeAnchorComponent->SetAdjustOrientationForGlobeWhenMoving(false);
-  GlobeAnchorComponent->SetGeoreference(this->GlobeAnchor->GetGeoreference());
+  GlobeAnchorComponent->SetGeoreference(georeference);
   GlobeAnchorComponent->MoveToEarthCenteredEarthFixedPosition(
       FVector(0.0, 0.0, 0.0));
 
@@ -182,7 +186,7 @@ double ACesiumSunSky::_computeScale() const {
 }
 
 void ACesiumSunSky::UpdateSkySphere() {
-  if (!UseMobileRendering || !SkySphereActor) {
+  if (!UseMobileRendering || !IsValid(SkySphereActor)) {
     return;
   }
   UFunction* UpdateSkySphere =
@@ -195,8 +199,10 @@ void ACesiumSunSky::UpdateSkySphere() {
 void ACesiumSunSky::BeginPlay() {
   Super::BeginPlay();
 
-  this->GlobeAnchor->MoveToEarthCenteredEarthFixedPosition(
-      FVector(0.0, 0.0, 0.0));
+  if (IsValid(this->GlobeAnchor)) {
+    this->GlobeAnchor->MoveToEarthCenteredEarthFixedPosition(
+        FVector(0.0, 0.0, 0.0));
+  }
 
   this->_transformUpdatedSubscription =
       this->RootComponent->TransformUpdated.AddUObject(
@@ -489,6 +495,16 @@ FVector getViewLocation(UWorld* pWorld) {
 } // namespace
 
 void ACesiumSunSky::UpdateAtmosphereRadius() {
+  UWorld* world = this->GetWorld();
+  if (!IsValid(world)) {
+    UE_LOG(
+        LogCesium,
+        Error,
+        TEXT("ACesiumSunSky %s GetWorld() returned nullptr"),
+        *this->GetName());
+    return;
+  }
+
   // This Actor is located at the center of the Earth (the CesiumGlobeAnchor
   // keeps it there), so we ignore this Actor's transform and use only its
   // parent transform.
@@ -501,11 +517,20 @@ void ACesiumSunSky::UpdateAtmosphereRadius() {
     }
   }
 
-  FVector location =
-      transform.TransformPosition(getViewLocation(this->GetWorld()));
+  ACesiumGeoreference* georeference = this->GetGeoreference();
+  if (!IsValid(georeference)) {
+
+    UE_LOG(
+        LogCesium,
+        Error,
+        TEXT("ACesiumSunSky %s can't find an ACesiumGeoreference"),
+        *this->GetName());
+    return;
+  }
+
+  FVector location = transform.TransformPosition(getViewLocation(world));
   FVector llh =
-      this->GetGeoreference()->TransformUnrealPositionToLongitudeLatitudeHeight(
-          location);
+      georeference->TransformUnrealPositionToLongitudeLatitudeHeight(location);
 
   // An atmosphere of this radius should circumscribe all Earth terrain.
   double maxRadius = 6387000.0;

--- a/Source/CesiumRuntime/Private/CesiumSunSky.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.cpp
@@ -519,7 +519,6 @@ void ACesiumSunSky::UpdateAtmosphereRadius() {
 
   ACesiumGeoreference* georeference = this->GetGeoreference();
   if (!IsValid(georeference)) {
-
     UE_LOG(
         LogCesium,
         Error,

--- a/Source/CesiumRuntime/Private/CesiumSunSky.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.cpp
@@ -150,18 +150,18 @@ void ACesiumSunSky::OnConstruction(const FTransform& Transform) {
 }
 
 void ACesiumSunSky::_spawnSkySphere() {
-  UWorld* world = GetWorld();
-  if (!UseMobileRendering || !IsValid(world)) {
+  UWorld* pWorld = GetWorld();
+  if (!UseMobileRendering || !IsValid(pWorld)) {
     return;
   }
 
-  ACesiumGeoreference* georeference = this->GetGeoreference();
-  if (!IsValid(georeference)) {
+  ACesiumGeoreference* pGeoreference = this->GetGeoreference();
+  if (!IsValid(pGeoreference)) {
     return;
   }
 
   // Create a new Sky Sphere Actor and anchor it to the center of the Earth.
-  this->SkySphereActor = world->SpawnActor<AActor>(SkySphereClass);
+  this->SkySphereActor = pWorld->SpawnActor<AActor>(SkySphereClass);
 
   // Anchor it to the center of the Earth.
   UCesiumGlobeAnchorComponent* GlobeAnchorComponent =
@@ -495,8 +495,8 @@ FVector getViewLocation(UWorld* pWorld) {
 } // namespace
 
 void ACesiumSunSky::UpdateAtmosphereRadius() {
-  UWorld* world = this->GetWorld();
-  if (!IsValid(world)) {
+  UWorld* pWorld = this->GetWorld();
+  if (!IsValid(pWorld)) {
     UE_LOG(
         LogCesium,
         Error,
@@ -517,8 +517,8 @@ void ACesiumSunSky::UpdateAtmosphereRadius() {
     }
   }
 
-  ACesiumGeoreference* georeference = this->GetGeoreference();
-  if (!IsValid(georeference)) {
+  ACesiumGeoreference* pGeoreference = this->GetGeoreference();
+  if (!IsValid(pGeoreference)) {
     UE_LOG(
         LogCesium,
         Error,
@@ -527,9 +527,9 @@ void ACesiumSunSky::UpdateAtmosphereRadius() {
     return;
   }
 
-  FVector location = transform.TransformPosition(getViewLocation(world));
+  FVector location = transform.TransformPosition(getViewLocation(pWorld));
   FVector llh =
-      georeference->TransformUnrealPositionToLongitudeLatitudeHeight(location);
+      pGeoreference->TransformUnrealPositionToLongitudeLatitudeHeight(location);
 
   // An atmosphere of this radius should circumscribe all Earth terrain.
   double maxRadius = 6387000.0;

--- a/Source/CesiumRuntime/Private/CesiumSunSky.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.cpp
@@ -170,7 +170,7 @@ void ACesiumSunSky::_spawnSkySphere() {
           TEXT("GlobeAnchor"));
   this->SkySphereActor->AddInstanceComponent(GlobeAnchorComponent);
   GlobeAnchorComponent->SetAdjustOrientationForGlobeWhenMoving(false);
-  GlobeAnchorComponent->SetGeoreference(georeference);
+  GlobeAnchorComponent->SetGeoreference(pGeoreference);
   GlobeAnchorComponent->MoveToEarthCenteredEarthFixedPosition(
       FVector(0.0, 0.0, 0.0));
 


### PR DESCRIPTION
There's been a few reports in our forums ([here](https://community.cesium.com/t/cesium-causes-access-violation-crash-in-unreal-5-3-2/28696) and [here](https://community.cesium.com/t/my-project-cannot-be-opened-hello-i-used-cesuim-to-make-the-project-for-a-month-suddenly-cannot-be-opened/29660)) that show some users are experiencing a crash on the line `FVector location = transform.TransformPosition(getViewLocation(this->GetWorld()));` in `CesiumSunSky.cpp`. While none of us are able to reproduce this bug, it seems likely that some sort of race condition is resulting in `this->GetWorld()` returning nullptr. Even if this isn't the source of these crashes, it's a good check to add anyways. I've also gone through `CesiumSunSky` to add checks to other locations where an unexpected nullptr might be possible and would cause a crash.