### PR TITLE
Update ion token for performance tests

### DIFF
--- a/Documentation/release-process.md
+++ b/Documentation/release-process.md
@@ -5,7 +5,6 @@ This is the process we follow when releasing a new version of Cesium for Unreal 
 ## Verify the code
 * Update any hard coded API keys in the code
   * CesiumSceneGeneration.cpp, testIonToken - Make sure matches samples project
-  * Google3dTilesLoadTest.cpp, testGoogleUrl - Make sure matches samples project
 * Verify that the cesium-native submodule in the `extern` directory references the expected commit of cesium-native. Update it if necessary. Verify that CI has completed successfully for that commit of cesium-native.
 * Merge `ue4-main` into `ue5-main`.
 * Wait for CI to complete for the `ue4-main` and `ue5-main` branches. Verify that it does so successfully.

--- a/Source/CesiumRuntime/Private/Tests/CesiumSceneGeneration.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumSceneGeneration.cpp
@@ -19,7 +19,7 @@
 namespace Cesium {
 
 FString SceneGenerationContext::testIonToken(
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyOGUxNjFmMy1mY2ZhLTQwMmEtYTNkYy1kZmExMGJjNjdlNTkiLCJpZCI6MjU5LCJpYXQiOjE2OTYxOTg1MTl9.QN5_xydinXOHF0xqy2zwQ5Hh4I5pVcLeMaqiJ9ZEsD4");
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyN2MxZThhOS1lMDNhLTRmYWMtODk5Yy00NjAyYzY4OTU0NGYiLCJpZCI6MjU5LCJpYXQiOjE3MDY3NTgwMTF9.fsMNJnhN6s-0CiLeVmV_7gLXn4DX62q18q3oKFhI1Ps");
 
 void SceneGenerationContext::setCommonProperties(
     const FVector& origin,


### PR DESCRIPTION
They can't run without a valid ion token. Looks like we missed updating it on the last release.

Also update the release documentation that mentions a separate google key. This is no longer needed.
https://github.com/CesiumGS/cesium-unreal/blob/Update-ion-token-for-performance-tests/Documentation/release-process.md#verify-the-code