### PR TITLE
Update `Build.cs` for zlib-ng

### DIFF
--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -126,7 +126,7 @@ public class CesiumRuntime : ModuleRules
     }
     else
     {
-      libs = libs.Concat(new string[] { "tidy", "z" }).ToArray();
+      libs = libs.Concat(new string[] { "tidy", "z-ng" }).ToArray();
     }
 
     if (preferDebug)

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -44,7 +44,6 @@
 #include <CesiumGltf/ExtensionKhrMaterialsUnlit.h>
 #include <CesiumGltf/ExtensionKhrTextureTransform.h>
 #include <CesiumGltf/ExtensionMeshPrimitiveExtStructuralMetadata.h>
-#include <CesiumGltf/ExtensionModelExtFeatureMetadata.h>
 #include <CesiumGltf/ExtensionModelExtStructuralMetadata.h>
 #include <CesiumGltf/PropertyType.h>
 #include <CesiumGltf/TextureInfo.h>

--- a/Source/CesiumRuntime/Private/CesiumMetadataPrimitive.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMetadataPrimitive.cpp
@@ -3,7 +3,6 @@
 PRAGMA_DISABLE_DEPRECATION_WARNINGS
 
 #include "CesiumMetadataPrimitive.h"
-#include "CesiumGltf/ExtensionMeshPrimitiveExtFeatureMetadata.h"
 #include "CesiumGltf/Model.h"
 
 FCesiumMetadataPrimitive::FCesiumMetadataPrimitive(


### PR DESCRIPTION
This PR updates `CesiumRuntime.Build.cs` to refer to the correct zlib library. There were some linker errors due to https://github.com/CesiumGS/cesium-native/pull/798:

![linker errors](https://github.com/CesiumGS/cesium-unreal/assets/32226860/75e25b18-d930-45ef-9ba8-01a1dd2bb3b1)
