### PR TITLE
Fix IntrusivePointer threadID assert

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -39,6 +39,10 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
 set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_LIST_DIR}/../Source/ThirdParty)
 set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib/${CMAKE_SYSTEM_NAME}-x${CESIUM_ARCHITECTURE})
 
+# Always define this, since Unreal does in debug anyway
+# We don't want any mismatches, especially with class member ordering
+add_compile_definitions(NDEBUG)
+
 set(CESIUM_DEBUG_POSTFIX "d")
 set(CESIUM_RELEASE_POSTFIX "")
 


### PR DESCRIPTION
This assert is triggering in debug, when it shouldn't.

It may look like the cause is the latest cesium-native changes, https://github.com/CesiumGS/cesium-native/pull/806 ... but really the problem is that the cesium-for-unreal build defines `NDEBUG`, even in debug builds (!!). 

For the previously mentioned PR, this resulted in a mismatch in the header of `ReferenceCounted`. The member declaration order was not the same in the cesium-native and cesium-for-unreal builds. A subtle bug.

Since there may be other subtle bugs we may not be aware of, change the build of cesium-native to always define NDEBUG, even in debug, to avoid these code mismatches.