### PR TITLE
`apt update` before `apt remove`

### DIFF
--- a/.github/workflows/buildLinux.yml
+++ b/.github/workflows/buildLinux.yml
@@ -36,6 +36,7 @@ jobs:
           apt list --installed
       - name: Removed unneeded packages to gain disk space
         run: |
+          sudo apt update
           sudo apt remove google-chrome-stable clang-13 clang-14 clang-15 llvm-13-dev llvm-13-linker-tools llvm-13-runtime llvm-13-tools llvm-13 llvm-14-dev llvm-14-linker-tools llvm-14-runtime llvm-14-tools llvm-14 llvm-15-dev llvm-15-linker-tools llvm-15-runtime llvm-15-tools llvm-15 x11-common xserver-common aspnetcore-runtime-6.0 aspnetcore-runtime-7.0 aspnetcore-runtime-8.0 aspnetcore-targeting-pack-6.0 aspnetcore-targeting-pack-7.0 aspnetcore-targeting-pack-8.0 docker-ce-cli docker-ce dotnet-apphost-pack-6.0 dotnet-apphost-pack-7.0 dotnet-apphost-pack-8.0 dotnet-host dotnet-hostfxr-6.0 dotnet-hostfxr-7.0 dotnet-hostfxr-8.0 dotnet-runtime-6.0 dotnet-runtime-7.0 dotnet-runtime-8.0 dotnet-runtime-deps-6.0 dotnet-runtime-deps-7.0 dotnet-runtime-deps-8.0 dotnet-sdk-6.0 dotnet-sdk-7.0 dotnet-sdk-8.0 dotnet-targeting-pack-6.0 dotnet-targeting-pack-7.0 dotnet-targeting-pack-8.0 eatmydata emacsen-common firebird3.0-common-doc firebird3.0-common firefox kubectl mercurial-common mercurial microsoft-edge-stable mssql-tools mysql-client-8.0 mysql-client-core-8.0 mysql-client mysql-common mysql-server-8.0 php8.1 postgresql-14
           sudo apt autoremove
           df -h


### PR DESCRIPTION
Otherwise an outdated package source seems to break the removal process and cause CI builds to fail. Which is infurating.