### PR TITLE
Support in Unreal for Cesium ion servers running in single-user authentication mode.

### DIFF
--- a/Source/CesiumEditor/Private/CesiumCommands.cpp
+++ b/Source/CesiumEditor/Private/CesiumCommands.cpp
@@ -46,7 +46,9 @@ void FCesiumCommands::RegisterCommands() {
   UI_COMMAND(
       OpenTokenSelector,
       "Token",
-      "Select or create a token to use to access Cesium ion assets",
+      "Select or create a token to use to access Cesium ion assets. "
+      "This won't be available if connected to ion servers that don't "
+      "need tokens for authentication.",
       EUserInterfaceActionType::Button,
       FInputChord());
 

--- a/Source/CesiumEditor/Private/CesiumIonSession.h
+++ b/Source/CesiumEditor/Private/CesiumIonSession.h
@@ -46,6 +46,8 @@ public:
   bool isDefaultsLoaded() const { return this->_defaults.has_value(); }
   bool isLoadingDefaults() const { return this->_isLoadingDefaults; }
 
+  bool isAuthenticationRequired() const;
+
   void connect();
   void resume();
   void disconnect();
@@ -66,6 +68,7 @@ public:
   const CesiumIonClient::Assets& getAssets();
   const std::vector<CesiumIonClient::Token>& getTokens();
   const CesiumIonClient::Defaults& getDefaults();
+  const CesiumIonClient::ApplicationData& getAppData();
 
   const std::string& getAuthorizeUrl() const { return this->_authorizeUrl; }
   const std::string& getRedirectUrl() const { return this->_redirectUrl; }
@@ -117,12 +120,14 @@ private:
   std::optional<CesiumIonClient::Assets> _assets;
   std::optional<std::vector<CesiumIonClient::Token>> _tokens;
   std::optional<CesiumIonClient::Defaults> _defaults;
+  std::optional<CesiumIonClient::ApplicationData> _appData;
 
   std::optional<CesiumAsync::SharedFuture<CesiumIonClient::Token>>
       _projectDefaultTokenDetailsFuture;
 
   bool _isConnecting;
   bool _isResuming;
+  bool _hasEverConnected = false;
   bool _isLoadingProfile;
   bool _isLoadingAssets;
   bool _isLoadingTokens;

--- a/Source/CesiumEditor/Private/CesiumIonTokenTroubleshooting.cpp
+++ b/Source/CesiumEditor/Private/CesiumIonTokenTroubleshooting.cpp
@@ -548,6 +548,7 @@ TSharedRef<SWidget> CesiumIonTokenTroubleshooting::createTokenPanel(
       ionSession.getAsyncSystem(),
       ionSession.getAssetAccessor(),
       TCHAR_TO_UTF8(*state.token),
+      ionSession.getAppData(),
       TCHAR_TO_UTF8(*getCesiumIonServer(pIonObject)->ApiUrl));
 
   // Don't let this panel be destroyed while the async operations below are in

--- a/Source/CesiumEditor/Private/CesiumPanel.cpp
+++ b/Source/CesiumEditor/Private/CesiumPanel.cpp
@@ -145,6 +145,13 @@ static bool isSignedIn() {
       ->isConnected();
 }
 
+static bool doesNeedToken() {
+  return FCesiumEditorModule::serverManager()
+      .GetCurrentSession()
+      ->getAppData()
+      .needsOauthAuthentication();
+}
+
 TSharedRef<SWidget> CesiumPanel::Toolbar() {
   TSharedRef<FUICommandList> commandList = MakeShared<FUICommandList>();
 
@@ -158,7 +165,8 @@ TSharedRef<SWidget> CesiumPanel::Toolbar() {
       FCanExecuteAction::CreateStatic(isSignedIn));
   commandList->MapAction(
       FCesiumCommands::Get().OpenTokenSelector,
-      FExecuteAction::CreateSP(this, &CesiumPanel::openTokenSelector));
+      FExecuteAction::CreateSP(this, &CesiumPanel::openTokenSelector),
+      FCanExecuteAction::CreateStatic(doesNeedToken));
   commandList->MapAction(
       FCesiumCommands::Get().SignOut,
       FExecuteAction::CreateSP(this, &CesiumPanel::signOut),

--- a/Source/CesiumEditor/Private/SelectCesiumIonToken.cpp
+++ b/Source/CesiumEditor/Private/SelectCesiumIonToken.cpp
@@ -185,7 +185,25 @@ void SelectCesiumIonToken::Construct(const FArguments& InArgs) {
       this,
       &SelectCesiumIonToken::RefreshTokens);
 
-  TSharedRef<SVerticalBox> pLoaderOrContent = SNew(SVerticalBox);
+  TSharedRef<SVerticalBox> pLoaderOrContent =
+      SNew(SVerticalBox).Visibility_Lambda([pSession]() {
+        return pSession->getAppData().needsOauthAuthentication()
+                   ? EVisibility::Visible
+                   : EVisibility::Collapsed;
+      });
+
+  TSharedRef<SVerticalBox> pSingleUserText =
+      SNew(SVerticalBox).Visibility_Lambda([pSession]() {
+        return !pSession->getAppData().needsOauthAuthentication()
+                   ? EVisibility::Visible
+                   : EVisibility::Collapsed;
+      });
+
+  pSingleUserText->AddSlot().AutoHeight()
+      [SNew(STextBlock)
+           .AutoWrapText(true)
+           .Text(FText::FromString(TEXT(
+               "Cesium for Unreal is currently connected to a Cesium ion server running in single-user authentication mode. Tokens are not used in this mode.")))];
 
   pLoaderOrContent->AddSlot().AutoHeight()
       [SNew(STextBlock)
@@ -347,16 +365,22 @@ void SelectCesiumIonToken::Construct(const FArguments& InArgs) {
                 .Text(FText::FromString(
                     TEXT("Create New Project Default Token")))];
 
+  TSharedRef<SVerticalBox> totalBox = SNew(SVerticalBox);
+
+  totalBox->AddSlot().AutoHeight()[pLoaderOrContent];
+  totalBox->AddSlot().AutoHeight()[pSingleUserText];
+
   SWindow::Construct(
       SWindow::FArguments()
           .Title(FText::FromString(TEXT("Select a Cesium ion Token")))
           .AutoCenter(EAutoCenter::PreferredWorkArea)
           .SizingRule(ESizingRule::UserSized)
-          .ClientSize(FVector2D(635, 500))
-              [SNew(SBorder)
-                   .Visibility(EVisibility::Visible)
-                   .Padding(
-                       FMargin(10.0f, 10.0f, 10.0f, 10.0f))[pLoaderOrContent]]);
+          .ClientSize(FVector2D(
+              635,
+              500))[SNew(SBorder)
+                        .Visibility(EVisibility::Visible)
+                        .Padding(
+                            FMargin(10.0f, 10.0f, 10.0f, 10.0f))[totalBox]]);
 
   pSession->refreshTokens();
 }


### PR DESCRIPTION
Requires CesiumGS/cesium-native#841.

As described in the above ticket, we don't currently support Cesium ion Self-Hosted servers that are running in single-user authentication mode. This is inconvenient, especially since single-user mode is both the easiest to setup and the default authentication mode in Cesium ion Self-Hosted.

This PR changes the behavior of Cesium for Unreal to request the current authentication mode from the `/appData` endpoint before connecting, ignoring the authentication flow and token options if in single-user mode. 