### PR TITLE
Update `CesiumRuntime.Build.cs` for Cesium Native changes

### DIFF
--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -95,10 +95,11 @@ public class CesiumRuntime : ModuleRules
             "CesiumGltf",
             "CesiumJsonReader",
             "CesiumRasterOverlays",
+            "CesiumQuantizedMeshTerrain",
             "CesiumUtility",
             "csprng",
             "draco",
-            "ktx_read",
+            "ktx",
             //"MikkTSpace",
             "meshoptimizer",
             "modp_b64",
@@ -109,7 +110,6 @@ public class CesiumRuntime : ModuleRules
             "turbojpeg",
             "uriparser",
             "webpdecoder",
-            "ktx_read",
         };
 
         // Use our own copy of MikkTSpace on Android.


### PR DESCRIPTION
- Updates for KTX library changes: `ktx_read` -> `ktx`
- Adds new `CesiumQuantizedMeshTerrain` namespace