### PR TITLE
Fix intermittent shutdown crash (static class GC'd)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed an issue where tilesets would render completely black on Quest headsets and some iOS devices.
+- Fixed a crash on Unreal Editor shutdown that would happen occassionally.
+
 ### v2.4.1 - 2024-04-01
 
 This release updates [cesium-native](https://github.com/CesiumGS/cesium-native) from v0.33.0 to v0.34.0. See the [changelog](https://github.com/CesiumGS/cesium-native/blob/main/CHANGES.md) for a complete list of changes in cesium-native.

--- a/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.cpp
+++ b/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.cpp
@@ -6,18 +6,22 @@
 #include "DetailCategoryBuilder.h"
 #include "DetailLayoutBuilder.h"
 
+FName FCesium3DTilesetCustomization::RegisteredLayoutName;
+
 void FCesium3DTilesetCustomization::Register(
     FPropertyEditorModule& PropertyEditorModule) {
+
+  RegisteredLayoutName = ACesium3DTileset::StaticClass()->GetFName();
+
   PropertyEditorModule.RegisterCustomClassLayout(
-      ACesium3DTileset::StaticClass()->GetFName(),
+      RegisteredLayoutName,
       FOnGetDetailCustomizationInstance::CreateStatic(
           &FCesium3DTilesetCustomization::MakeInstance));
 }
 
 void FCesium3DTilesetCustomization::Unregister(
     FPropertyEditorModule& PropertyEditorModule) {
-  PropertyEditorModule.UnregisterCustomClassLayout(
-      ACesium3DTileset::StaticClass()->GetFName());
+  PropertyEditorModule.UnregisterCustomClassLayout(RegisteredLayoutName);
 }
 
 TSharedRef<IDetailCustomization> FCesium3DTilesetCustomization::MakeInstance() {

--- a/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.h
+++ b/Source/CesiumEditor/Private/Cesium3DTilesetCustomization.h
@@ -23,4 +23,6 @@ public:
 
   static void SortCustomDetailsCategories(
       const TMap<FName, IDetailCategoryBuilder*>& AllCategoryMap);
+
+  static FName RegisteredLayoutName;
 };

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceCustomization.cpp
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceCustomization.cpp
@@ -7,18 +7,22 @@
 #include "DetailCategoryBuilder.h"
 #include "DetailLayoutBuilder.h"
 
+FName FCesiumGeoreferenceCustomization::RegisteredLayoutName;
+
 void FCesiumGeoreferenceCustomization::Register(
     FPropertyEditorModule& PropertyEditorModule) {
+
+  RegisteredLayoutName = ACesiumGeoreference::StaticClass()->GetFName();
+
   PropertyEditorModule.RegisterCustomClassLayout(
-      ACesiumGeoreference::StaticClass()->GetFName(),
+      RegisteredLayoutName,
       FOnGetDetailCustomizationInstance::CreateStatic(
           &FCesiumGeoreferenceCustomization::MakeInstance));
 }
 
 void FCesiumGeoreferenceCustomization::Unregister(
     FPropertyEditorModule& PropertyEditorModule) {
-  PropertyEditorModule.UnregisterCustomClassLayout(
-      ACesiumGeoreference::StaticClass()->GetFName());
+  PropertyEditorModule.UnregisterCustomClassLayout(RegisteredLayoutName);
 }
 
 TSharedRef<IDetailCustomization>

--- a/Source/CesiumEditor/Private/CesiumGeoreferenceCustomization.h
+++ b/Source/CesiumEditor/Private/CesiumGeoreferenceCustomization.h
@@ -22,4 +22,6 @@ public:
 private:
   TSharedPtr<CesiumDegreesMinutesSecondsEditor> LongitudeEditor;
   TSharedPtr<CesiumDegreesMinutesSecondsEditor> LatitudeEditor;
+
+  static FName RegisteredLayoutName;
 };

--- a/Source/CesiumEditor/Private/CesiumGlobeAnchorCustomization.cpp
+++ b/Source/CesiumEditor/Private/CesiumGlobeAnchorCustomization.cpp
@@ -8,18 +8,22 @@
 #include "DetailLayoutBuilder.h"
 #include "IDetailGroup.h"
 
+FName FCesiumGlobeAnchorCustomization::RegisteredLayoutName;
+
 void FCesiumGlobeAnchorCustomization::Register(
     FPropertyEditorModule& PropertyEditorModule) {
+
+  RegisteredLayoutName = UCesiumGlobeAnchorComponent::StaticClass()->GetFName();
+
   PropertyEditorModule.RegisterCustomClassLayout(
-      UCesiumGlobeAnchorComponent::StaticClass()->GetFName(),
+      RegisteredLayoutName,
       FOnGetDetailCustomizationInstance::CreateStatic(
           &FCesiumGlobeAnchorCustomization::MakeInstance));
 }
 
 void FCesiumGlobeAnchorCustomization::Unregister(
     FPropertyEditorModule& PropertyEditorModule) {
-  PropertyEditorModule.UnregisterCustomClassLayout(
-      UCesiumGlobeAnchorComponent::StaticClass()->GetFName());
+  PropertyEditorModule.UnregisterCustomClassLayout(RegisteredLayoutName);
 }
 
 TSharedRef<IDetailCustomization>

--- a/Source/CesiumEditor/Private/CesiumGlobeAnchorCustomization.h
+++ b/Source/CesiumEditor/Private/CesiumGlobeAnchorCustomization.h
@@ -41,6 +41,8 @@ private:
   TArray<TWeakObjectPtr<UObject>> SelectedObjects;
   TArray<TObjectPtr<UCesiumGlobeAnchorDerivedProperties>> DerivedObjects;
   TArray<UObject*> DerivedPointers;
+
+  static FName RegisteredLayoutName;
 };
 
 UCLASS()


### PR DESCRIPTION
Fixes #1363 .

For all of our classes deriving from `IDetailCustomization`, change the call to `::UnregisterCustomClassLayout` to use a saved version of the class name that we called `::RegisterCustomClassLayout` with.

We don't want to access that class with `::StaticClass()` during shutdown, it's already been sent to the garbage collector to be destroyed. Sometimes the GC wouldn't have gotten to it yet (and you don't crash). But other times the static class data is garbage and we'll get an access violation.

I could reproduce this 100% of the time in UE 5.4 in DebugGame, with the following UI layout...
![image](https://github.com/CesiumGS/cesium-unreal/assets/130494071/94137368-95d4-4133-b3af-9226d0cd7e0a)
