### PR TITLE
Fixes for Unreal Engine 5.4 problems

### DIFF
--- a/Config/Editor.ini
+++ b/Config/Editor.ini
@@ -1,0 +1,6 @@
+# UE 5.3+ defaults this to 11, which is not really high enough.
+# 100 is probably high enough for reasonable values of Cesium3DTileset's 'MaximumSimultaneousTileLoads property,
+# but if you get log messages like "Warning: Reached threaded request limit", and you're sure you want to use
+# such a high value, you may need to increase this.
+[HTTP.HttpThread]
+RunningThreadedRequestLimitEditor=100

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -294,7 +294,11 @@ static void computeFlatNormals(TArray<FStaticMeshBuildVertex>& vertices) {
 }
 
 template <typename TIndex>
+#if ENGINE_VERSION_5_4_OR_HIGHER
+static Chaos::FTriangleMeshImplicitObjectPtr
+#else
 static TSharedPtr<Chaos::FTriangleMeshImplicitObject, ESPMode::ThreadSafe>
+#endif
 BuildChaosTriangleMeshes(
     const TArray<FStaticMeshBuildVertex>& vertexData,
     const TArray<uint32>& indices);
@@ -3234,7 +3238,11 @@ static void loadPrimitiveGameThreadPart(
         ECollisionTraceFlag::CTF_UseComplexAsSimple;
 
     if (loadResult.pCollisionMesh) {
+#if ENGINE_VERSION_5_4_OR_HIGHER
+      pBodySetup->TriMeshGeometries.Add(loadResult.pCollisionMesh);
+#else
       pBodySetup->ChaosTriMeshes.Add(loadResult.pCollisionMesh);
+#endif
     }
 
     // Mark physics meshes created, no matter if we actually have a collision
@@ -3614,7 +3622,11 @@ static bool isTriangleDegenerate(
 }
 
 template <typename TIndex>
+#if ENGINE_VERSION_5_4_OR_HIGHER
+static Chaos::FTriangleMeshImplicitObjectPtr
+#else
 static TSharedPtr<Chaos::FTriangleMeshImplicitObject, ESPMode::ThreadSafe>
+#endif
 BuildChaosTriangleMeshes(
     const TArray<FStaticMeshBuildVertex>& vertexData,
     const TArray<uint32>& indices) {
@@ -3650,6 +3662,15 @@ BuildChaosTriangleMeshes(
   TArray<uint16> materials;
   materials.SetNum(triangles.Num());
 
+#if ENGINE_VERSION_5_4_OR_HIGHER
+  return new Chaos::FTriangleMeshImplicitObject(
+      MoveTemp(vertices),
+      MoveTemp(triangles),
+      MoveTemp(materials),
+      MoveTemp(pFaceRemap),
+      nullptr,
+      false);
+#else
   return MakeShared<Chaos::FTriangleMeshImplicitObject, ESPMode::ThreadSafe>(
       MoveTemp(vertices),
       MoveTemp(triangles),
@@ -3657,4 +3678,5 @@ BuildChaosTriangleMeshes(
       MoveTemp(pFaceRemap),
       nullptr,
       false);
+#endif
 }

--- a/Source/CesiumRuntime/Private/LoadGltfResult.h
+++ b/Source/CesiumRuntime/Private/LoadGltfResult.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "CesiumCommon.h"
 #include "CesiumEncodedFeaturesMetadata.h"
 #include "CesiumMetadataPrimitive.h"
 #include "CesiumModelMetadata.h"
@@ -46,8 +47,12 @@ struct LoadPrimitiveResult {
    */
   const CesiumGltf::Material* pMaterial = nullptr;
   glm::dmat4x4 transform{1.0};
+#if ENGINE_VERSION_5_4_OR_HIGHER
+  Chaos::FTriangleMeshImplicitObjectPtr pCollisionMesh = nullptr;
+#else
   TSharedPtr<Chaos::FTriangleMeshImplicitObject, ESPMode::ThreadSafe>
       pCollisionMesh = nullptr;
+#endif
   std::string name{};
 
   TUniquePtr<CesiumTextureUtility::LoadedTextureResult> baseColorTexture;


### PR DESCRIPTION
Fixes #1407 
In UE 5.4, `UBodySetup::ChaosTriMeshes` has been "deprecated" and replaced with `TriMeshGeometries`. I put deprecated in quotes because the old property still exists, so code that uses it compiles, it just doesn't work at all anymore. Which is not my favorite kind of deprecation, if I'm being honest.

Fixes #1405 
In UE 5.3 we got the `RunningThreadedRequestLimit` configuration property. In UE 5.4 we now have its friend, `RunningThreadedRequestLimitEditor` that needs to be set, too. Both put an unnecessarily low limit on the number of simultaneous network requests that are allowed, so we increase the limits using our plugin's config.
