### PR TITLE
Force "None" source code provider on CI.

### DIFF
--- a/.github/workflows/buildAndroid.yml
+++ b/.github/workflows/buildAndroid.yml
@@ -71,6 +71,18 @@ jobs:
       - name: Overwrite plugin engine version
         run: |
           ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.1.0"','"EngineVersion": "${{ inputs.unreal-engine-version }}"') | Set-Content -Path CesiumForUnreal.uplugin
+      - name: Customize BuildConfiguration.xml
+        run: |
+          mkdir -p "$env:USERPROFILE\AppData\Roaming\Unreal Engine\UnrealBuildTool"
+          # - We limit parallel actions because our builds use a lot more memory than UBT thinks they will.
+          # - We set the source code control Provider to None so UBT includes all files in the unity build.
+          Set-Content -Path "$env:USERPROFILE\AppData\Roaming\Unreal Engine\UnrealBuildTool\BuildConfiguration.xml" -Value '<?xml version="1.0" encoding="utf-8" ?>
+            <Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
+              <BuildConfiguration>
+                <MaxParallelActions>2</MaxParallelActions>
+              </BuildConfiguration>
+              <SourceFileWorkingSet><Provider>None</Provider></SourceFileWorkingSet>
+            </Configuration>'
       - name: Build plugin
         run: |
           $env:NDKROOT=$env:ANDROID_NDK_ROOT

--- a/.github/workflows/buildLinux.yml
+++ b/.github/workflows/buildLinux.yml
@@ -82,11 +82,14 @@ jobs:
           sudo mkswap /mnt/swapfile
           sudo swapon /mnt/swapfile
           sudo swapon --show
+      - name: Customize BuildConfiguration.xml
+        run: |
+          mkdir -p ~/.config/Unreal\ Engine/UnrealBuildTool
+          # - We limit parallel actions because our builds use a lot more memory than UBT thinks they will.
+          # - We set the source code control Provider to None so UBT includes all files in the unity build.
+          printf '<?xml version="1.0" encoding="utf-8" ?>\n<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">\n    <BuildConfiguration>\n      <MaxParallelActions>2</MaxParallelActions>\n    </BuildConfiguration>\n    <SourceFileWorkingSet><Provider>None</Provider></SourceFileWorkingSet>\n</Configuration>\n' > ~/.config/Unreal\ Engine/UnrealBuildTool/BuildConfiguration.xml
       - name: Build plugin
         run: |
-          # while true; do cat /proc/meminfo; sleep 5; done &
-          mkdir -p ~/.config/Unreal\ Engine/UnrealBuildTool
-          printf '<?xml version="1.0" encoding="utf-8" ?>\n<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">\n    <BuildConfiguration>\n      <MaxParallelActions>2</MaxParallelActions>\n    </BuildConfiguration>\n</Configuration>\n' > ~/.config/Unreal\ Engine/UnrealBuildTool/BuildConfiguration.xml
           sed -i 's/\"EngineVersion\": \"5.1.0\"/\"EngineVersion\": \"${{ inputs.unreal-engine-version }}\"/g' CesiumForUnreal.uplugin
           cd $UNREAL_ENGINE_DIR/Engine/Build/BatchFiles
           ./RunUAT.sh BuildPlugin -Plugin="$GITHUB_WORKSPACE/CesiumForUnreal.uplugin" -Package="$GITHUB_WORKSPACE/packages/CesiumForUnreal" -CreateSubFolder -TargetPlatforms=Linux

--- a/.github/workflows/buildMac.yml
+++ b/.github/workflows/buildMac.yml
@@ -77,10 +77,14 @@ jobs:
           rm -r -f ${INSTALL_LIBDIR}-silicon
           cd ../..
           rm -rf extern
-      - name: Build plugin
+      - name: Customize BuildConfiguration.xml
         run: |
           mkdir -p ~/.config/Unreal\ Engine/UnrealBuildTool
-          # printf '<?xml version="1.0" encoding="utf-8" ?>\n<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">\n    <BuildConfiguration>\n      <MaxParallelActions>1</MaxParallelActions>\n    </BuildConfiguration>\n</Configuration>\n' > ~/.config/Unreal\ Engine/UnrealBuildTool/BuildConfiguration.xml
+          # - We limit parallel actions because our builds use a lot more memory than UBT thinks they will.
+          # - We set the source code control Provider to None so UBT includes all files in the unity build.
+          printf '<?xml version="1.0" encoding="utf-8" ?>\n<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">\n    <BuildConfiguration>\n      <MaxParallelActions>2</MaxParallelActions>\n    </BuildConfiguration>\n    <SourceFileWorkingSet><Provider>None</Provider></SourceFileWorkingSet>\n</Configuration>\n' > ~/.config/Unreal\ Engine/UnrealBuildTool/BuildConfiguration.xml
+      - name: Build plugin
+        run: |
           sed -i '' 's/\"EngineVersion\": \"5.1.0\"/\"EngineVersion\": \"${{ inputs.unreal-engine-version }}\"/g' CesiumForUnreal.uplugin
           export UNREAL_ENGINE_DIR=$HOME/${{ inputs.unreal-program-name }}
           cd $UNREAL_ENGINE_DIR/Engine/Build/BatchFiles

--- a/.github/workflows/buildWindows.yml
+++ b/.github/workflows/buildWindows.yml
@@ -107,6 +107,18 @@ jobs:
       - name: Overwrite plugin engine version
         run: |
           ((Get-Content -path CesiumForUnreal.uplugin -Raw) -replace '"EngineVersion": "5.1.0"','"EngineVersion": "${{ inputs.unreal-engine-version }}"') | Set-Content -Path CesiumForUnreal.uplugin
+      - name: Customize BuildConfiguration.xml
+        run: |
+          mkdir -p "$env:USERPROFILE\AppData\Roaming\Unreal Engine\UnrealBuildTool"
+          # - We limit parallel actions because our builds use a lot more memory than UBT thinks they will.
+          # - We set the source code control Provider to None so UBT includes all files in the unity build.
+          Set-Content -Path "$env:USERPROFILE\AppData\Roaming\Unreal Engine\UnrealBuildTool\BuildConfiguration.xml" -Value '<?xml version="1.0" encoding="utf-8" ?>
+            <Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
+              <BuildConfiguration>
+                <MaxParallelActions>2</MaxParallelActions>
+              </BuildConfiguration>
+              <SourceFileWorkingSet><Provider>None</Provider></SourceFileWorkingSet>
+            </Configuration>'
       - name: Build CesiumForUnreal plugin
         timeout-minutes: 180
         run: |

--- a/.github/workflows/buildiOS.yml
+++ b/.github/workflows/buildiOS.yml
@@ -68,6 +68,12 @@ jobs:
           cmake --build build-ios -j4 --target install --config Release
           cd ..
           rm -rf extern
+      - name: Customize BuildConfiguration.xml
+        run: |
+          mkdir -p ~/.config/Unreal\ Engine/UnrealBuildTool
+          # - We limit parallel actions because our builds use a lot more memory than UBT thinks they will.
+          # - We set the source code control Provider to None so UBT includes all files in the unity build.
+          printf '<?xml version="1.0" encoding="utf-8" ?>\n<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">\n    <BuildConfiguration>\n      <MaxParallelActions>2</MaxParallelActions>\n    </BuildConfiguration>\n    <SourceFileWorkingSet><Provider>None</Provider></SourceFileWorkingSet>\n</Configuration>\n' > ~/.config/Unreal\ Engine/UnrealBuildTool/BuildConfiguration.xml
       - name: Build plugin
         run: |
           sed -i '' 's/\"EngineVersion\": \"5.1.0\"/\"EngineVersion\": \"${{ inputs.unreal-engine-version }}\"/g' CesiumForUnreal.uplugin


### PR DESCRIPTION
This avoids UE 5.4 considering our non-read-only source files to be part of the working set and leaving them out of the unity build.

Fixes #1410 