### PR TITLE
Fix missing textures caused by sharing a single texture between multiple primitives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - Fixed an issue with pixel dithering artifacts that could appear on tilesets.
 - Fixed an issue where DynamicPawn could get stuck after interrupting a flight from `UCesiumFlyToComponent`.
 - Fixed a bug where `CesiumTileMapServiceRasterOverlay`, `CesiumWebMapServiceRasterOverlay`, and `CesiumWebMapTileServiceRasterOverlay` would attempt to load empty URLs.
+- Fixed a bug that caused some textures shared between multiple glTF primitives to be missing entirely.
 
 ### v2.5.0 - 2024-05-01
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -862,7 +862,7 @@ public:
             rasterTile,
             static_cast<CesiumTextureUtility::ReferenceCountedUnrealTexture*>(
                 pMainThreadRendererResources)
-                ->pUnrealTexture,
+                ->getUnrealTexture(),
             translation,
             scale,
             overlayTextureCoordinateID);
@@ -888,7 +888,7 @@ public:
             rasterTile,
             static_cast<CesiumTextureUtility::ReferenceCountedUnrealTexture*>(
                 pMainThreadRendererResources)
-                ->pUnrealTexture);
+                ->getUnrealTexture());
       }
     }
   }

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -407,7 +407,7 @@ static TUniquePtr<CesiumTextureUtility::LoadedTextureResult> loadTexture(
   }
 
   int32_t textureIndex = gltfTexture.value().index;
-  const CesiumGltf::Texture& texture = model.textures[textureIndex];
+  CesiumGltf::Texture& texture = model.textures[textureIndex];
   return loadTextureFromModelAnyThreadPart(
       model,
       texture,
@@ -2173,7 +2173,7 @@ bool applyTexture(
     return false;
   }
 
-  pMaterial->SetTextureParameterValueByInfo(info, pTexture->pUnrealTexture);
+  pMaterial->SetTextureParameterValueByInfo(info, pTexture->getUnrealTexture());
 
   return true;
 }
@@ -2440,7 +2440,7 @@ static void SetFeatureIdTextureParameterValues(
           FName(name + CesiumEncodedFeaturesMetadata::MaterialTextureSuffix),
           association,
           index),
-      encodedFeatureIdTexture.pTexture->pTexture->pUnrealTexture);
+      encodedFeatureIdTexture.pTexture->pTexture->getUnrealTexture());
 
   size_t numChannels = encodedFeatureIdTexture.channels.size();
   pMaterial->SetScalarParameterValueByInfo(
@@ -2545,7 +2545,7 @@ static void SetPropertyTableParameterValues(
     if (encodedProperty.pTexture) {
       pMaterial->SetTextureParameterValueByInfo(
           FMaterialParameterInfo(FName(fullPropertyName), association, index),
-          encodedProperty.pTexture->pTexture->pUnrealTexture);
+          encodedProperty.pTexture->pTexture->getUnrealTexture());
     }
 
     if (!UCesiumMetadataValueBlueprintLibrary::IsEmpty(
@@ -2631,7 +2631,7 @@ static void SetPropertyTextureParameterValues(
     if (encodedProperty.pTexture) {
       pMaterial->SetTextureParameterValueByInfo(
           FMaterialParameterInfo(FName(fullPropertyName), association, index),
-          encodedProperty.pTexture->pTexture->pUnrealTexture);
+          encodedProperty.pTexture->pTexture->getUnrealTexture());
     }
 
     pMaterial->SetVectorParameterValueByInfo(
@@ -2817,7 +2817,7 @@ static void SetMetadataFeatureTableParameterValues_DEPRECATED(
 
     pMaterial->SetTextureParameterValueByInfo(
         FMaterialParameterInfo(FName(encodedProperty.name), association, index),
-        encodedProperty.pTexture->pTexture->pUnrealTexture);
+        encodedProperty.pTexture->pTexture->getUnrealTexture());
   }
 }
 
@@ -2885,7 +2885,7 @@ static void SetMetadataParameterValues_DEPRECATED(
                 FName(encodedProperty.baseName + "TX"),
                 association,
                 index),
-            encodedProperty.pTexture->pTexture->pUnrealTexture);
+            encodedProperty.pTexture->pTexture->getUnrealTexture());
 
         pMaterial->SetVectorParameterValueByInfo(
             FMaterialParameterInfo(
@@ -2910,7 +2910,7 @@ static void SetMetadataParameterValues_DEPRECATED(
             FName(encodedFeatureIdTexture.baseName + "TX"),
             association,
             index),
-        encodedFeatureIdTexture.pTexture->pTexture->pUnrealTexture);
+        encodedFeatureIdTexture.pTexture->pTexture->getUnrealTexture());
 
     FLinearColor channelMask;
     switch (encodedFeatureIdTexture.channel) {

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -143,17 +143,12 @@ struct ExtensionUnrealTexture {
 
 namespace CesiumTextureUtility {
 
-ReferenceCountedUnrealTexture::ReferenceCountedUnrealTexture(
-    TObjectPtr<UTexture2D> p) noexcept
-    : pUnrealTexture(p) {
-  if (this->pUnrealTexture) {
-    this->pUnrealTexture->AddToRoot();
-  }
-}
+ReferenceCountedUnrealTexture::ReferenceCountedUnrealTexture() noexcept
+    : _pUnrealTexture(nullptr), _pTextureResource(nullptr) {}
 
 ReferenceCountedUnrealTexture::~ReferenceCountedUnrealTexture() noexcept {
-  UTexture2D* pLocal = this->pUnrealTexture;
-  this->pUnrealTexture = nullptr;
+  UTexture2D* pLocal = this->_pUnrealTexture;
+  this->_pUnrealTexture = nullptr;
 
   if (IsValid(pLocal)) {
     if (IsInGameThread()) {
@@ -168,9 +163,44 @@ ReferenceCountedUnrealTexture::~ReferenceCountedUnrealTexture() noexcept {
   }
 }
 
+TObjectPtr<UTexture2D> ReferenceCountedUnrealTexture::getUnrealTexture() const {
+  return this->_pUnrealTexture;
+}
+
+void ReferenceCountedUnrealTexture::setUnrealTexture(
+    const TObjectPtr<UTexture2D>& p) {
+  if (p == this->_pUnrealTexture)
+    return;
+
+  if (p) {
+    p->AddToRoot();
+  }
+
+  if (this->_pUnrealTexture) {
+    this->_pUnrealTexture->RemoveFromRoot();
+  }
+
+  this->_pUnrealTexture = p;
+}
+
+const TUniquePtr<FCesiumTextureResourceBase>&
+ReferenceCountedUnrealTexture::getTextureResource() const {
+  return this->_pTextureResource;
+}
+
+TUniquePtr<FCesiumTextureResourceBase>&
+ReferenceCountedUnrealTexture::getTextureResource() {
+  return this->_pTextureResource;
+}
+
+void ReferenceCountedUnrealTexture::setTextureResource(
+    TUniquePtr<FCesiumTextureResourceBase>&& p) {
+  this->_pTextureResource = std::move(p);
+}
+
 TUniquePtr<LoadedTextureResult> loadTextureFromModelAnyThreadPart(
     CesiumGltf::Model& model,
-    const CesiumGltf::Texture& texture,
+    CesiumGltf::Texture& texture,
     bool sRGB,
     std::vector<FCesiumTextureResourceBase*>& textureResources) {
   check(textureResources.size() == model.images.size());
@@ -181,14 +211,17 @@ TUniquePtr<LoadedTextureResult> loadTextureFromModelAnyThreadPart(
     textureIndex = -1;
   }
 
-  const ExtensionUnrealTexture* pUnrealTextureExtension =
-      texture.getExtension<ExtensionUnrealTexture>();
-  if (pUnrealTextureExtension && pUnrealTextureExtension->pTexture) {
-    // There's an existing Unreal texture for this glTF texture.
-    // This will commonly be the case when this model was upsampled from a
-    // parent tile.
+  ExtensionUnrealTexture& extension =
+      texture.addExtension<ExtensionUnrealTexture>();
+
+  if (extension.pTexture && (extension.pTexture->getUnrealTexture() ||
+                             extension.pTexture->getTextureResource())) {
+    // There's an existing Unreal texture for this glTF texture. This will
+    // happen if this texture is used by multiple primitives on the same model.
+    // It will also be the case when this model was upsampled from a parent
+    // tile.
     TUniquePtr<LoadedTextureResult> pResult = MakeUnique<LoadedTextureResult>();
-    pResult->pTexture = pUnrealTextureExtension->pTexture;
+    pResult->pTexture = extension.pTexture;
     pResult->textureIndex = textureIndex;
     return pResult;
   }
@@ -259,13 +292,15 @@ TUniquePtr<LoadedTextureResult> loadTextureFromModelAnyThreadPart(
           sRGB,
           pExistingImageResource);
   if (pResult) {
+    extension.pTexture = pResult->pTexture;
+
     // Note the index of this texture within the glTF.
     pResult->textureIndex = textureIndex;
 
     if (source >= 0 && source < textureResources.size()) {
       // Make the RHI resource known so it can be used by other textures that
       // reference this same image.
-      textureResources[source] = pResult->pTextureResource.Get();
+      textureResources[source] = pResult->pTexture->getTextureResource().Get();
     }
   }
   return pResult;
@@ -353,7 +388,7 @@ static UTexture2D* CreateTexture2D(LoadedTextureResult* pHalfLoadedTexture) {
   }
 
   UTexture2D* pTexture = pHalfLoadedTexture->pTexture
-                             ? pHalfLoadedTexture->pTexture->pUnrealTexture
+                             ? pHalfLoadedTexture->pTexture->getUnrealTexture()
                              : nullptr;
   if (!pTexture) {
     pTexture = NewObject<UTexture2D>(
@@ -372,7 +407,7 @@ static UTexture2D* CreateTexture2D(LoadedTextureResult* pHalfLoadedTexture) {
 
     pTexture->NeverStream = true;
 
-    pHalfLoadedTexture->pTexture = new ReferenceCountedUnrealTexture(pTexture);
+    pHalfLoadedTexture->pTexture->setUnrealTexture(pTexture);
   }
 
   return pTexture;
@@ -446,6 +481,7 @@ TUniquePtr<LoadedTextureResult> loadTextureAnyThreadPart(
   }
 
   TUniquePtr<LoadedTextureResult> pResult = MakeUnique<LoadedTextureResult>();
+  pResult->pTexture = new ReferenceCountedUnrealTexture();
 
   pResult->addressX = addressX;
   pResult->addressY = addressY;
@@ -459,18 +495,19 @@ TUniquePtr<LoadedTextureResult> loadTextureAnyThreadPart(
   imageCesium.sizeBytes = int64_t(imageCesium.pixelData.size());
 
   if (pExistingImageResource) {
-    pResult->pTextureResource = MakeUnique<FCesiumUseExistingTextureResource>(
-        pExistingImageResource,
-        group,
-        imageCesium.width,
-        imageCesium.height,
-        pixelFormat,
-        filter,
-        addressX,
-        addressY,
-        sRGB,
-        useMipMapsIfAvailable,
-        0);
+    pResult->pTexture->setTextureResource(
+        MakeUnique<FCesiumUseExistingTextureResource>(
+            pExistingImageResource,
+            group,
+            imageCesium.width,
+            imageCesium.height,
+            pixelFormat,
+            filter,
+            addressX,
+            addressY,
+            sRGB,
+            useMipMapsIfAvailable,
+            0));
   } else if (
       GRHISupportsAsyncTextureCreation && !imageCesium.pixelData.empty()) {
     // Create RHI texture resource on this worker thread, and then hand it off
@@ -479,18 +516,19 @@ TUniquePtr<LoadedTextureResult> loadTextureAnyThreadPart(
 
     FTexture2DRHIRef textureReference =
         CreateRHITexture2D_Async(imageCesium, pixelFormat, sRGB);
-    pResult->pTextureResource = MakeUnique<FCesiumUseExistingTextureResource>(
-        textureReference,
-        group,
-        imageCesium.width,
-        imageCesium.height,
-        pixelFormat,
-        filter,
-        addressX,
-        addressY,
-        sRGB,
-        useMipMapsIfAvailable,
-        0);
+    pResult->pTexture->setTextureResource(
+        MakeUnique<FCesiumUseExistingTextureResource>(
+            textureReference,
+            group,
+            imageCesium.width,
+            imageCesium.height,
+            pixelFormat,
+            filter,
+            addressX,
+            addressY,
+            sRGB,
+            useMipMapsIfAvailable,
+            0));
 
     // Clear the now-unnecessary copy of the pixel data. Calling clear() isn't
     // good enough because it won't actually release the memory.
@@ -506,21 +544,22 @@ TUniquePtr<LoadedTextureResult> loadTextureAnyThreadPart(
       return nullptr;
     }
 
-    pResult->pTextureResource = MakeUnique<FCesiumCreateNewTextureResource>(
-        std::move(imageCesium),
-        group,
-        imageCesium.width,
-        imageCesium.height,
-        pixelFormat,
-        filter,
-        addressX,
-        addressY,
-        sRGB,
-        useMipMapsIfAvailable,
-        0);
+    pResult->pTexture->setTextureResource(
+        MakeUnique<FCesiumCreateNewTextureResource>(
+            std::move(imageCesium),
+            group,
+            imageCesium.width,
+            imageCesium.height,
+            pixelFormat,
+            filter,
+            addressX,
+            addressY,
+            sRGB,
+            useMipMapsIfAvailable,
+            0));
   }
 
-  check(pResult->pTextureResource != nullptr);
+  check(pResult->pTexture->getTextureResource() != nullptr);
 
   return pResult;
 }
@@ -551,13 +590,20 @@ CesiumUtility::IntrusivePointer<ReferenceCountedUnrealTexture>
 loadTextureGameThreadPart(LoadedTextureResult* pHalfLoadedTexture) {
   TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::LoadTexture)
 
+  TUniquePtr<FCesiumTextureResourceBase>& pTextureResource =
+      pHalfLoadedTexture->pTexture->getTextureResource();
+  if (pTextureResource == nullptr) {
+    // Texture is already loaded (or unloadable).
+    return pHalfLoadedTexture->pTexture;
+  }
+
   UTexture2D* pTexture = CreateTexture2D(pHalfLoadedTexture);
   if (pTexture == nullptr) {
     return nullptr;
   }
 
   FCesiumTextureResourceBase* pCesiumTextureResource =
-      pHalfLoadedTexture->pTextureResource.Release();
+      pTextureResource.Release();
   if (pCesiumTextureResource) {
     pTexture->SetResource(pCesiumTextureResource);
 

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -383,13 +383,11 @@ TUniquePtr<LoadedTextureResult> loadTextureFromImageAndSamplerAnyThreadPart(
 }
 
 static UTexture2D* CreateTexture2D(LoadedTextureResult* pHalfLoadedTexture) {
-  if (!pHalfLoadedTexture) {
+  if (!pHalfLoadedTexture || !pHalfLoadedTexture->pTexture) {
     return nullptr;
   }
 
-  UTexture2D* pTexture = pHalfLoadedTexture->pTexture
-                             ? pHalfLoadedTexture->pTexture->getUnrealTexture()
-                             : nullptr;
+  UTexture2D* pTexture = pHalfLoadedTexture->pTexture->getUnrealTexture();
   if (!pTexture) {
     pTexture = NewObject<UTexture2D>(
         GetTransientPackage(),

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.h
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.h
@@ -38,9 +38,21 @@ namespace CesiumTextureUtility {
 // created.
 struct ReferenceCountedUnrealTexture
     : CesiumUtility::ReferenceCountedThreadSafe<ReferenceCountedUnrealTexture> {
-  ReferenceCountedUnrealTexture(TObjectPtr<UTexture2D> p) noexcept;
+  ReferenceCountedUnrealTexture() noexcept;
   ~ReferenceCountedUnrealTexture() noexcept;
-  TObjectPtr<UTexture2D> pUnrealTexture;
+
+  // The texture game object, once it's created.
+  TObjectPtr<UTexture2D> getUnrealTexture() const;
+  void setUnrealTexture(const TObjectPtr<UTexture2D>& p);
+
+  // The renderer / RHI FTextureResource holding the pixel data.
+  const TUniquePtr<FCesiumTextureResourceBase>& getTextureResource() const;
+  TUniquePtr<FCesiumTextureResourceBase>& getTextureResource();
+  void setTextureResource(TUniquePtr<FCesiumTextureResourceBase>&& p);
+
+private:
+  TObjectPtr<UTexture2D> _pUnrealTexture;
+  TUniquePtr<FCesiumTextureResourceBase> _pTextureResource;
 };
 
 /**
@@ -60,9 +72,6 @@ struct LoadedTextureResult {
 
   // The UTexture2D that has already been created, if any.
   CesiumUtility::IntrusivePointer<ReferenceCountedUnrealTexture> pTexture;
-
-  // The RHI FTextureResource holding the pixel data.
-  TUniquePtr<FCesiumTextureResourceBase> pTextureResource;
 };
 
 /**
@@ -74,7 +83,9 @@ struct LoadedTextureResult {
  * it.
  *
  * @param model The glTF Model for which to load this texture.
- * @param texture The glTF Texture to load.
+ * @param texture The glTF Texture to load. This parameter is non-const because
+ * a private extension will be added to this `Texture` in order to track the
+ * associated Unreal texture.
  * @param sRGB True if the texture should be treated as sRGB; false if it should
  * be treated as linear.
  * @param textureResources Unreal RHI texture resources that have already been
@@ -85,7 +96,7 @@ struct LoadedTextureResult {
  */
 TUniquePtr<LoadedTextureResult> loadTextureFromModelAnyThreadPart(
     CesiumGltf::Model& model,
-    const CesiumGltf::Texture& texture,
+    CesiumGltf::Texture& texture,
     bool sRGB,
     std::vector<FCesiumTextureResourceBase*>& textureResources);
 

--- a/Source/CesiumRuntime/Private/Tests/CesiumTextureUtility.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumTextureUtility.spec.cpp
@@ -204,10 +204,11 @@ void CesiumTextureUtilitySpec::RunTests() {
             true,
             textureResources);
     TestNotNull("pHalfLoaded", pHalfLoaded.Get());
+    TestNotNull("pHalfLoaded->pTexture", pHalfLoaded->pTexture.get());
     TestEqual(
         "textureResources[0]",
         textureResources[0],
-        pHalfLoaded->pTextureResource.Get());
+        pHalfLoaded->pTexture->getTextureResource().Get());
 
     IntrusivePointer<ReferenceCountedUnrealTexture> pRefCountedTexture =
         loadTextureGameThreadPart(model, pHalfLoaded.Get());
@@ -256,11 +257,12 @@ void CesiumTextureUtilitySpec::RunTests() {
             model.textures[0],
             true,
             textureResources);
-    TestNotNull("pHalfLoaded", pHalfLoaded1.Get());
+    TestNotNull("pHalfLoaded1", pHalfLoaded1.Get());
+    TestNotNull("pHalfLoaded1->pTexture", pHalfLoaded1->pTexture.get());
     TestEqual(
         "textureResources[0]",
         textureResources[0],
-        pHalfLoaded1->pTextureResource.Get());
+        pHalfLoaded1->pTexture->getTextureResource().Get());
 
     TUniquePtr<LoadedTextureResult> pHalfLoaded2 =
         loadTextureFromModelAnyThreadPart(
@@ -268,11 +270,12 @@ void CesiumTextureUtilitySpec::RunTests() {
             model.textures[1],
             false,
             textureResources);
-    TestNotNull("pHalfLoaded", pHalfLoaded2.Get());
+    TestNotNull("pHalfLoaded2", pHalfLoaded2.Get());
+    TestNotNull("pHalfLoaded2->pTexture", pHalfLoaded2->pTexture.get());
     TestEqual(
         "textureResources[0]",
         textureResources[0],
-        pHalfLoaded2->pTextureResource.Get());
+        pHalfLoaded2->pTexture->getTextureResource().Get());
 
     IntrusivePointer<ReferenceCountedUnrealTexture> pRefCountedTexture1 =
         loadTextureGameThreadPart(model, pHalfLoaded1.Get());
@@ -299,8 +302,10 @@ void CesiumTextureUtilitySpec::RunTests() {
 
     TestEqual(
         "Textures share RHI resource",
-        pRefCountedTexture1->pUnrealTexture->GetResource()->GetTextureRHI(),
-        pRefCountedTexture2->pUnrealTexture->GetResource()->GetTextureRHI());
+        pRefCountedTexture1->getUnrealTexture()->GetResource()->GetTextureRHI(),
+        pRefCountedTexture2->getUnrealTexture()
+            ->GetResource()
+            ->GetTextureRHI());
   });
 
   It("Loading the same texture twice", [this]() {
@@ -329,10 +334,11 @@ void CesiumTextureUtilitySpec::RunTests() {
             true,
             textureResources);
     TestNotNull("pHalfLoaded", pHalfLoaded.Get());
+    TestNotNull("pHalfLoaded->pTexture", pHalfLoaded->pTexture.get());
     TestEqual(
         "textureResources[0]",
         textureResources[0],
-        pHalfLoaded->pTextureResource.Get());
+        pHalfLoaded->pTexture->getTextureResource().Get());
 
     IntrusivePointer<ReferenceCountedUnrealTexture> pRefCountedTexture =
         loadTextureGameThreadPart(model, pHalfLoaded.Get());
@@ -358,10 +364,11 @@ void CesiumTextureUtilitySpec::RunTests() {
             model.textures[0],
             true,
             textureResources2);
-    TestNotNull("pHalfLoaded", pHalfLoaded2.Get());
+    TestNotNull("pHalfLoaded2", pHalfLoaded2.Get());
+    TestNotNull("pHalfLoaded2->pTexture", pHalfLoaded2->pTexture.get());
     TestNull(
-        "pHalfLoaded2->pTextureResource",
-        pHalfLoaded2->pTextureResource.Get());
+        "pHalfLoaded2->pTexture->getTextureResource()",
+        pHalfLoaded2->pTexture->getTextureResource().Get());
 
     IntrusivePointer<ReferenceCountedUnrealTexture> pRefCountedTexture2 =
         loadTextureGameThreadPart(model, pHalfLoaded.Get());
@@ -373,10 +380,10 @@ void CesiumTextureUtilitySpec::CheckPixels(
     const IntrusivePointer<ReferenceCountedUnrealTexture>& pRefCountedTexture) {
   TestNotNull("pRefCountedTexture", pRefCountedTexture.get());
   TestNotNull(
-      "pRefCountedTexture->pUnrealTexture",
-      pRefCountedTexture->pUnrealTexture.Get());
+      "pRefCountedTexture->getUnrealTexture()",
+      pRefCountedTexture->getUnrealTexture().Get());
 
-  UTexture2D* pTexture = pRefCountedTexture->pUnrealTexture;
+  UTexture2D* pTexture = pRefCountedTexture->getUnrealTexture();
   TestNotNull("pTexture", pTexture);
   if (pTexture == nullptr)
     return;
@@ -452,7 +459,7 @@ void CesiumTextureUtilitySpec::CheckSRGB(
   if (!pRefCountedTexture)
     return;
 
-  UTexture2D* pTexture = pRefCountedTexture->pUnrealTexture;
+  UTexture2D* pTexture = pRefCountedTexture->getUnrealTexture();
   TestNotNull("pTexture", pTexture);
   if (!pTexture)
     return;
@@ -475,7 +482,7 @@ void CesiumTextureUtilitySpec::CheckAddress(
   if (!pRefCountedTexture)
     return;
 
-  UTexture2D* pTexture = pRefCountedTexture->pUnrealTexture;
+  UTexture2D* pTexture = pRefCountedTexture->getUnrealTexture();
   TestNotNull("pTexture", pTexture);
   if (!pTexture)
     return;
@@ -491,7 +498,7 @@ void CesiumTextureUtilitySpec::CheckFilter(
   if (!pRefCountedTexture)
     return;
 
-  UTexture2D* pTexture = pRefCountedTexture->pUnrealTexture;
+  UTexture2D* pTexture = pRefCountedTexture->getUnrealTexture();
   TestNotNull("pTexture", pTexture);
   if (!pTexture)
     return;
@@ -506,7 +513,7 @@ void CesiumTextureUtilitySpec::CheckGroup(
   if (!pRefCountedTexture)
     return;
 
-  UTexture2D* pTexture = pRefCountedTexture->pUnrealTexture;
+  UTexture2D* pTexture = pRefCountedTexture->getUnrealTexture();
   TestNotNull("pTexture", pTexture);
   if (!pTexture)
     return;


### PR DESCRIPTION
This builds on #1431 so merge that first.

This PR fixes a bug reported on the forum:
https://community.cesium.com/t/textures-appears-white-when-used-multiple-times-on-same-gltf/32278

The model and instructions there make it easy to reproduce.

In this model, two primitives both reference the same material, and that material has a `baseColorTexture`. So when preparing the glTF for use with Unreal, and processing both of the primitives, we indirectly end up processing the same texture twice.

The first time we process the texture, the associated image's `ImageCesium` has pixel data. So in a worker thread, we create a new `FCesiumTextureResourceBase` (RHI texture resource) from it, and then clear the pixel data. So far so good.

The next time we process the texture, we see that an `FCesiumTextureResourceBase` already exists for the associated Image, so we don't need to upload the pixel data again (which is good because we can't; the pixel data has been cleared). Instead, we create a `FCesiumUseExistingTextureResource` referencing the existing RHI texture resources. Still all good so far.

Next, in the game thread, we create a `UTexture2D` for each of the RHI textures previously created. They both refer to the same underlying data, which is no problem.

Now here comes the problem. The way we manage the lifetime of `UTexture2D` instances is that we store them on the glTF `Texture` object in a private extension. But in this scenario, we have two `UTexture2D` instances associated with a single glTF `Texture`. The second one ends up _replacing_ the first, and as a result the first is destroyed. We go through all the motions of creating the textures we need, but then we accidentally destroy one of them before we can use it.

One way to fix this would be to make a single glTF able to reference multiple `UTexture2D` instances. But wait, why do we need two `UTexture2D` instances anyway? They were both created from the same glTF Texture, so they should be identical. They already share the same pixel data, but it would be better if they shared the `UTexture2D` instances, too.

So that's what this PR does. It adds the private extension to the glTF `Texture` earlier in the process, and uses it to store both the `FCesiumTextureResourceBase` texture (during worker thread texture prep) and the `UTexture2D` (during game thread texture prep). If the extension already exists, we don't need to process the texture again, we just need to use the existing reference counted texture resources.