### PR TITLE
Add missing header for some builds

### DIFF
--- a/Source/CesiumRuntime/Private/Tests/CesiumTextureUtility.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumTextureUtility.spec.cpp
@@ -2,6 +2,7 @@
 
 #include "CesiumTextureUtility.h"
 #include "Misc/AutomationTest.h"
+#include "RenderingThread.h"
 
 using namespace CesiumGltf;
 using namespace CesiumTextureUtility;


### PR DESCRIPTION
Closes #1434.

I repro'd this error by doing this:
1) Downloaded CesiumForUnreal-53-v2.5.0.zip from the releases page
2) Open Unreal 5.3, create a new Blueprints project
3) Unzip the plugin to this projects "Plugins" folder (I had to create this)
4) Open the test project, enable the Cesium For Unreal plugin
5) Close Unreal
6) Delete the contents of `<testProject>/Plugins/CesiumForUnreal/Binaries`
7) Open the test project again, it should ask you to rebuild
8) When it finishes, you'll see a popup dialog that says there were errors (you can see details in `<testProject>/Saved/Logs`

Using the build from this PR should fix this error.