### PR TITLE
Create build without Binaries/Intermediates for the Marketplace.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,9 +86,11 @@ jobs:
         run: |
           export CESIUM_UNREAL_VERSION=$GITHUB_REF_NAME
           export BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-52-${CESIUM_UNREAL_VERSION}"
+          export BUILD_CESIUM_UNREAL_SOURCE_ONLY_PACKAGE_NAME="CesiumForUnreal-52-SourceOnly-${CESIUM_UNREAL_VERSION}"
           # Make these available to subsequent steps
           echo "CESIUM_UNREAL_VERSION=$CESIUM_UNREAL_VERSION" >> $GITHUB_ENV
           echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=$BUILD_CESIUM_UNREAL_PACKAGE_NAME" >> $GITHUB_ENV
+          echo "BUILD_CESIUM_UNREAL_SOURCE_ONLY_PACKAGE_NAME=$BUILD_CESIUM_UNREAL_SOURCE_ONLY_PACKAGE_NAME" >> $GITHUB_ENV
       - name: Download iOS build
         uses: actions/download-artifact@v4
         with:
@@ -124,12 +126,12 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}-SourceOnly
+          name: ${{ env.BUILD_CESIUM_UNREAL_SOURCE_ONLY_PACKAGE_NAME}}
           path: |
             combine
             # These are built by Epic, and including them seems to confuse their process.
-            !combine/Binaries/
-            !combine/Intermediates/
+            !combine/Binaries/**
+            !combine/Intermediates/**
   TestPackage52:
     needs: [Combine52]
     uses: ./.github/workflows/testPackageOnWindows.yml
@@ -217,9 +219,11 @@ jobs:
         run: |
           export CESIUM_UNREAL_VERSION=$GITHUB_REF_NAME
           export BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-53-${CESIUM_UNREAL_VERSION}"
+          export BUILD_CESIUM_UNREAL_SOURCE_ONLY_PACKAGE_NAME="CesiumForUnreal-53-SourceOnly-${CESIUM_UNREAL_VERSION}"
           # Make these available to subsequent steps
           echo "CESIUM_UNREAL_VERSION=$CESIUM_UNREAL_VERSION" >> $GITHUB_ENV
           echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=$BUILD_CESIUM_UNREAL_PACKAGE_NAME" >> $GITHUB_ENV
+          echo "BUILD_CESIUM_UNREAL_SOURCE_ONLY_PACKAGE_NAME=$BUILD_CESIUM_UNREAL_SOURCE_ONLY_PACKAGE_NAME" >> $GITHUB_ENV
       - name: Download iOS build
         uses: actions/download-artifact@v4
         with:
@@ -255,12 +259,12 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}-SourceOnly
+          name: ${{ env.BUILD_CESIUM_UNREAL_SOURCE_ONLY_PACKAGE_NAME}}
           path: |
             combine
             # These are built by Epic, and including them seems to confuse their process.
-            !combine/Binaries/
-            !combine/Intermediates/
+            !combine/Binaries/**
+            !combine/Intermediates/**
   TestPackage53:
     needs: [Combine53]
     uses: ./.github/workflows/testPackageOnWindows.yml
@@ -348,9 +352,11 @@ jobs:
         run: |
           export CESIUM_UNREAL_VERSION=$GITHUB_REF_NAME
           export BUILD_CESIUM_UNREAL_PACKAGE_NAME="CesiumForUnreal-54-${CESIUM_UNREAL_VERSION}"
+          export BUILD_CESIUM_UNREAL_SOURCE_ONLY_PACKAGE_NAME="CesiumForUnreal-54-SourceOnly-${CESIUM_UNREAL_VERSION}"
           # Make these available to subsequent steps
           echo "CESIUM_UNREAL_VERSION=$CESIUM_UNREAL_VERSION" >> $GITHUB_ENV
           echo "BUILD_CESIUM_UNREAL_PACKAGE_NAME=$BUILD_CESIUM_UNREAL_PACKAGE_NAME" >> $GITHUB_ENV
+          echo "BUILD_CESIUM_UNREAL_SOURCE_ONLY_PACKAGE_NAME=$BUILD_CESIUM_UNREAL_SOURCE_ONLY_PACKAGE_NAME" >> $GITHUB_ENV
       - name: Download iOS build
         uses: actions/download-artifact@v4
         with:
@@ -386,12 +392,12 @@ jobs:
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}-SourceOnly
+          name: ${{ env.BUILD_CESIUM_UNREAL_SOURCE_ONLY_PACKAGE_NAME}}
           path: |
             combine
             # These are built by Epic, and including them seems to confuse their process.
-            !combine/Binaries/
-            !combine/Intermediates/
+            !combine/Binaries/**
+            !combine/Intermediates/**
   TestPackage54:
     needs: [Combine54]
     uses: ./.github/workflows/testPackageOnWindows.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,8 +130,8 @@ jobs:
           path: |
             combine
             # These are built by Epic, and including them seems to confuse their process.
-            !combine/Binaries/**
-            !combine/Intermediates/**
+            !combine/Binaries/**/*
+            !combine/Intermediates/**/*
   TestPackage52:
     needs: [Combine52]
     uses: ./.github/workflows/testPackageOnWindows.yml
@@ -263,8 +263,8 @@ jobs:
           path: |
             combine
             # These are built by Epic, and including them seems to confuse their process.
-            !combine/Binaries/**
-            !combine/Intermediates/**
+            !combine/Binaries/**/*
+            !combine/Intermediates/**/*
   TestPackage53:
     needs: [Combine53]
     uses: ./.github/workflows/testPackageOnWindows.yml
@@ -396,8 +396,8 @@ jobs:
           path: |
             combine
             # These are built by Epic, and including them seems to confuse their process.
-            !combine/Binaries/**
-            !combine/Intermediates/**
+            !combine/Binaries/**/*
+            !combine/Intermediates/**/*
   TestPackage54:
     needs: [Combine54]
     uses: ./.github/workflows/testPackageOnWindows.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,21 +114,22 @@ jobs:
         with:
           name: CesiumForUnreal-52-windows-${{ env.CESIUM_UNREAL_VERSION}}
           path: combine
-      - name: Unreal Marketplace Workaround
-        run: |
-          # The UE Marketplace deletes our Intermediates directory and fails to produces new
-          # intermediates for the Linux platform. The Marketplace team has suggested we copy
-          # them to the LinuxIntermediate directory instead, as a workaround. Users still have
-          # to move these files to the correct place manually, though, in order for Linux builds
-          # to succeed.
-          mkdir -p combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
-          cp -r combine/CesiumForUnreal/Intermediate/Build/Linux/* combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
       - name: Publish combined package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}
           path: combine
+      - name: Publish combined package artifact for the Unreal Marketplace
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}-SourceOnly
+          path: |
+            combine
+            # These are built by Epic, and including them seems to confuse their process.
+            !combine/Binaries/
+            !combine/Intermediates/
   TestPackage52:
     needs: [Combine52]
     uses: ./.github/workflows/testPackageOnWindows.yml
@@ -244,21 +245,22 @@ jobs:
         with:
           name: CesiumForUnreal-53-windows-${{ env.CESIUM_UNREAL_VERSION}}
           path: combine
-      - name: Unreal Marketplace Workaround
-        run: |
-          # The UE Marketplace deletes our Intermediates directory and fails to produces new
-          # intermediates for the Linux platform. The Marketplace team has suggested we copy
-          # them to the LinuxIntermediate directory instead, as a workaround. Users still have
-          # to move these files to the correct place manually, though, in order for Linux builds
-          # to succeed.
-          mkdir -p combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
-          cp -r combine/CesiumForUnreal/Intermediate/Build/Linux/* combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
       - name: Publish combined package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}
           path: combine
+      - name: Publish combined package artifact for the Unreal Marketplace
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}-SourceOnly
+          path: |
+            combine
+            # These are built by Epic, and including them seems to confuse their process.
+            !combine/Binaries/
+            !combine/Intermediates/
   TestPackage53:
     needs: [Combine53]
     uses: ./.github/workflows/testPackageOnWindows.yml
@@ -374,21 +376,22 @@ jobs:
         with:
           name: CesiumForUnreal-54-windows-${{ env.CESIUM_UNREAL_VERSION}}
           path: combine
-      - name: Unreal Marketplace Workaround
-        run: |
-          # The UE Marketplace deletes our Intermediates directory and fails to produces new
-          # intermediates for the Linux platform. The Marketplace team has suggested we copy
-          # them to the LinuxIntermediate directory instead, as a workaround. Users still have
-          # to move these files to the correct place manually, though, in order for Linux builds
-          # to succeed.
-          mkdir -p combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
-          cp -r combine/CesiumForUnreal/Intermediate/Build/Linux/* combine/CesiumForUnreal/LinuxIntermediate/Build/Linux
       - name: Publish combined package artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}
           path: combine
+      - name: Publish combined package artifact for the Unreal Marketplace
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.BUILD_CESIUM_UNREAL_PACKAGE_NAME}}-SourceOnly
+          path: |
+            combine
+            # These are built by Epic, and including them seems to confuse their process.
+            !combine/Binaries/
+            !combine/Intermediates/
   TestPackage54:
     needs: [Combine54]
     uses: ./.github/workflows/testPackageOnWindows.yml

--- a/Config/FilterPlugin.ini
+++ b/Config/FilterPlugin.ini
@@ -6,15 +6,3 @@
 /ThirdParty.json
 /CHANGES.md
 /Shaders/*
-/Intermediate/Build/Linux/*
-/Binaries/Linux/*
-/LinuxIntermediate/Build/Linux/UnrealEditor/Inc/CesiumEditor/UHT/*
-/LinuxIntermediate/Build/Linux/UnrealEditor/Inc/CesiumRuntime/UHT/*
-/LinuxIntermediate/Build/Linux/UnrealGame/Development/CesiumRuntime/*
-/LinuxIntermediate/Build/Linux/UnrealGame/Inc/CesiumRuntime/UHT/*
-/LinuxIntermediate/Build/Linux/UnrealGame/Shipping/CesiumRuntime/*
-/LinuxIntermediate/Build/Linux/x64/UnrealGame/Development/CesiumRuntime/*
-/LinuxIntermediate/Build/Linux/x64/UnrealGame/Shipping/CesiumRuntime/*
-/LinuxIntermediate/Build/Linux/B4D820EA/UnrealGame/Development/CesiumRuntime/*
-/LinuxIntermediate/Build/Linux/B4D820EA/UnrealGame/Inc/CesiumRuntime/UHT/*
-/LinuxIntermediate/Build/Linux/B4D820EA/UnrealGame/Shipping/CesiumRuntime/*


### PR DESCRIPTION
Produces a new `SourceOnly` build artifact from the Combine steps, which excludes the `Binaries` and `Intermediates` directories. These are produced by Epic's Marketplace build process, and including them has apparently started to cause that process to fail (see #1433).

I've also eliminated the old `LinuxIntermediates` directory. If we're really lucky, the now-less-confused Epic build process will now produce Linux binaries the way it's supposed to. But if not, the LinuxIntermediates directory wasn't doing anyone much good anyway. People needed to know to copy it to Intermediates in order to build for Linux in order to use it, and at that point why not just use our releases on GitHub instead of Epic's?