### PR TITLE
Experiment: access UE from a VHDX instead of a ZIP.

### DIFF
--- a/.github/workflows/buildWindows.yml
+++ b/.github/workflows/buildWindows.yml
@@ -103,8 +103,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           mkdir -p "D:/Program Files/Epic Games"
-          aws s3 cp "s3://cesium-unreal-engine/5.4.0/UnrealEngine541.vhdx" "D:/Program Files/Epic Games/UnrealEngine541.vhdx" --no-progress
-          Mount-VHD -Path "D:/Program Files/Epic Games/UnrealEngine541.vhdx" -NoDriveLetter -Passthru | Get-Disk | Get-Partition | where { ($_ | Get-Volume) -ne $Null } | Add-PartitionAccessPath -AccessPath "D:\Program Files\Epic Games"
+          aws s3 cp "s3://cesium-unreal-engine/5.4.0/UnrealEngine541.vhdx" "D:/Program Files/UnrealEngine541.vhdx" --no-progress
+          Mount-VHD -Path "D:/Program Files/UnrealEngine541.vhdx" -NoDriveLetter -Passthru | Get-Disk | Get-Partition | where { ($_ | Get-Volume) -ne $Null } | Add-PartitionAccessPath -AccessPath "D:\Program Files\Epic Games"
       - name: Install nasm
         uses: ilammy/setup-nasm@v1.5.1
       - name: Build cesium-native

--- a/.github/workflows/buildWindows.yml
+++ b/.github/workflows/buildWindows.yml
@@ -89,11 +89,22 @@ jobs:
           echo UNREAL_BATCH_FILES_PATH=$env:UNREAL_BATCH_FILES_PATH
       - name: Install Unreal Engine
         uses: ./.github/actions/install-unreal-windows
+        if: ${{ inputs.unreal-engine-version != '5.4.0' }}
         with:
           unreal-engine-zip: ${{ inputs.unreal-engine-zip }}
           unreal-program-name: ${{ inputs.unreal-program-name }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Install Unreal Engine VHDX
+        if: ${{ inputs.unreal-engine-version == '5.4.0' }}
+        env:
+          AWS_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          mkdir -p "D:/Program Files/Epic Games"
+          aws s3 cp "s3://cesium-unreal-engine/5.4.0/UnrealEngine541.vhdx" "D:/Program Files/Epic Games/UnrealEngine541.vhdx" --no-progress
+          Mount-VHD -Path "D:/Program Files/Epic Games/UnrealEngine541.vhdx" -NoDriveLetter -Passthru | Get-Disk | Get-Partition | where { ($_ | Get-Volume) -ne $Null } | Add-PartitionAccessPath -AccessPath "D:\Program Files\Epic Games"
       - name: Install nasm
         uses: ilammy/setup-nasm@v1.5.1
       - name: Build cesium-native


### PR DESCRIPTION
Currently we download Unreal Engine from S3 in a ZIP file, and then extract it. The download is pretty fast (about a minute), but unzipping takes much longer. So this is an experiment to see if we can make our CI go faster by downloading a VHDX instead. The VHDX uses NTFS compression, so it's reasonably small, but still much bigger than the ZIP. (ZIP is 14 GB, VHDX is 24 GB). But once we have a VHDX locally, we can mount it directly; no need to spend time unzipping the whole thing.