### PR TITLE
UE 5.4 - Add include for UStaticMesh and use glm::mat4_cast instead of glm::toMat4

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1939,7 +1939,7 @@ static void loadInstancingData(
               quatView[i].value[0],
               quatView[i].value[1],
               quatView[i].value[2]);
-          instanceTransforms[i] = instanceTransforms[i] * glm::toMat4(quat);
+          instanceTransforms[i] = instanceTransforms[i] * glm::mat4_cast(quat);
         }
       } else if constexpr (is_int_quat_v<ValueType>) {
         for (int64_t i = 0; i < count; ++i) {
@@ -1948,7 +1948,7 @@ static void loadInstancingData(
             val[j] = GltfNormalized(quatView[i].value[j]);
           }
           glm::dquat quat(val[3], val[0], val[1], val[2]);
-          instanceTransforms[i] = instanceTransforms[i] * glm::toMat4(quat);
+          instanceTransforms[i] = instanceTransforms[i] * glm::mat4_cast(quat);
         }
       }
     });

--- a/Source/CesiumRuntime/Private/CesiumGltfPrimitiveComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfPrimitiveComponent.h
@@ -6,6 +6,7 @@
 #include "CesiumPrimitive.h"
 #include "Components/InstancedStaticMeshComponent.h"
 #include "Components/StaticMeshComponent.h"
+#include "Engine/StaticMesh.h"
 #include "CoreMinimal.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "PhysicsEngine/BodySetup.h"


### PR DESCRIPTION
We ran into issues building the plugin with UE 5.4.2, in release configuration. StaticMesh.h is required for the declaration of the UStaticMesh class. Additionally, the toMat4 conversion function does not work here, however we can use mat4_cast instead, without changing dependencies.