### PR TITLE
Fix warnings in UE 5.2.

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCreditSystem.cpp
@@ -300,7 +300,7 @@ void ACesiumCreditSystem::removeCreditsFromViewports() {
 #endif
 
   if (IsValid(CreditsWidget)) {
-    CreditsWidget->RemoveFromViewport();
+    CreditsWidget->RemoveFromParent();
   }
 }
 


### PR DESCRIPTION
UE deprecated `ULevelStreaming::ECurrentState` in UE 5.2 and removed it in 5.3. We had some ifdef's to use the new type in 5.3+, but because we were still using the (now deprecated) type in 5.2, we were getting tons of warnings. So this PR just removes the ifdef and uses the new type in all UE versions.