### PR TITLE
Add option to enforce BuildChaosMeshTriangles for degenerate triangles

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -709,7 +709,10 @@ public:
     }
 
     TUniquePtr<UCesiumGltfComponent::HalfConstructed> pHalf =
-        UCesiumGltfComponent::CreateOffGameThread(transform, options);
+        UCesiumGltfComponent::CreateOffGameThread(
+            transform,
+            options,
+            this->_pActor->ForceBuildChaosTriangleMeshes);
 
     return asyncSystem.createResolvedFuture(
         Cesium3DTilesSelection::TileLoadResultAndRenderResources{

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.h
@@ -66,7 +66,8 @@ public:
 
   static TUniquePtr<HalfConstructed> CreateOffGameThread(
       const glm::dmat4x4& Transform,
-      const CreateGltfOptions::CreateModelOptions& Options);
+      const CreateGltfOptions::CreateModelOptions& Options,
+      bool forceBuildChaosTriangleMeshes);
 
   static UCesiumGltfComponent* CreateOnGameThread(
       CesiumGltf::Model& model,

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -277,6 +277,12 @@ public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
   bool ShowCreditsOnScreen = false;
 
+   /**
+   * Whether or not to enforce collision building even for degenerate triangles
+   */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium|Physics")
+  bool ForceBuildChaosTriangleMeshes = false;
+
   /** @copydoc ACesium3DTileset::CameraManager */
   UFUNCTION(BlueprintGetter, Category = "Cesium")
   TSoftObjectPtr<ACesiumCameraManager> GetCameraManager() const;


### PR DESCRIPTION
Currently, Cesium discards degenerate triangles in the function `BuildChaosMeshTriangles` in `CesiumGltfComponent.cpp`.
This causes collision to not work for the discarded triangles.

```c++
  for (int32 i = 0; i < triangleCount; ++i) {
    const int32 index0 = 3 * i;
    int32 vIndex0 = indices[index0 + 1];
    int32 vIndex1 = indices[index0];
    int32 vIndex2 = indices[index0 + 2];


    if (!isTriangleDegenerate(
            vertices.X(vIndex0),
            vertices.X(vIndex1),
            vertices.X(vIndex2))) {
      triangles.Add(Chaos::TVector<int32, 3>(vIndex0, vIndex1, vIndex2));
      faceRemap.Add(i);
    }
  }
```
https://github.com/arbertrary/cesium-unreal/blob/b6b26aa823bdcbcad41cd44c3d7ab2aa86953a74/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp#L3821C1-L3834C4

As described and discussed with @kring in this thread on the Cesium community forums, there might be cases where users would want to enforce that these degenerate triangles are **not** being discarded.

https://community.cesium.com/t/line-trace-passing-through-cesium3dtileset-on-high-lod/27485

This pull request is a naive approach to adding a boolean option to the `Cesium3DTileset` actor which a user can activate to enforce this behavior. 

Most likely this is not a sensible solution to that issue (dragging that boolean through ~5 different functions seems a bit excessive) but it might serve as a starting point.
