### PR TITLE
Add functions to get the approximate location of a tileset during runtime

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -165,6 +165,31 @@ void ACesium3DTileset::InvalidateResolvedGeoreference() {
   this->ResolvedGeoreference = nullptr;
 }
 
+FVector ACesium3DTileset::GetApproximateTilesetLocationUnreal() {
+    ACesiumGeoreference* pGeoreference = this->ResolveGeoreference();
+
+    FVector approximateRootTileLocationECEF = this->GetApproximateTilesetLocationECEF();
+    FVector approximateRootTileLocationUnreal = pGeoreference->TransformEarthCenteredEarthFixedPositionToUnreal(approximateRootTileLocationECEF);
+
+    return approximateRootTileLocationUnreal;
+}
+
+
+FVector ACesium3DTileset::GetApproximateTilesetLocationECEF() {
+    const Cesium3DTilesSelection::Tile* pRootTile =
+        this->_pTileset->getRootTile();
+    if (!pRootTile) {
+        return FVector::ZeroVector;
+    }
+
+    glm::dmat4x4 rootTileTransform = pRootTile->getTransform();
+    glm::dvec3 translation(rootTileTransform[3][0], rootTileTransform[3][1], rootTileTransform[3][2]);
+
+    FVector approximateRootTileLocationECEF = VecMath::createVector(translation);
+
+    return approximateRootTileLocationECEF;
+}
+
 TSoftObjectPtr<ACesiumCreditSystem> ACesium3DTileset::GetCreditSystem() const {
   return this->CreditSystem;
 }

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -163,6 +163,24 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   void InvalidateResolvedGeoreference();
 
+  /**
+   * Returns the approximate Unreal Location of this tileset
+   */
+  UFUNCTION(
+      BlueprintCallable,
+      Category = "Cesium",
+      meta = (ReturnDisplayName = "approximate Unreal Location"))
+  FVector GetApproximateTilesetLocationUnreal();
+
+  /**
+   * Returns the approximate ECEF Location of this tileset
+   */
+  UFUNCTION(
+      BlueprintCallable,
+      Category = "Cesium",
+      meta = (ReturnDisplayName = "approximate ECEF Location"))
+  FVector GetApproximateTilesetLocationECEF();
+
 private:
   /**
    * The actor managing this tileset's content attributions.


### PR DESCRIPTION
As discussed in the following Cesium community forum thread, there is no API-level support to get the world location of a tileset during runtime from UE blueprints.

https://community.cesium.com/t/get-coordinates-of-cesium3dtileset-spawned-at-unknown-location/33087/4

As suggested by @kring I had a look at the `ACesium3DTileset::OnFocusEditorViewportOnThis()` function. 
With this pull request I added two functions that return an approximate location (Unreal and ECEF) of the tileset calculated using the rootTile.

**Disclaimer:**

- The code might not be in the most suitable locations, I simply lack the overview of the bigger picture of the Cesium for Unreal source code and where to place which kinds of functions
- I did not use the center of the bounding Box or Sphere to calculate the location. This is because for one of my own tilesets that I used to test this code with, this would always place me far above the tileset (thousands of meters)
- I think calling it "approximate" is necessary because otherwise this would probably fuel expectations that this code cannot fulfill 😄 
- I was only able to test these functions anecdotally