### PR TITLE
Fix crash caused by CesiumSunSky when no viewport is activated in the Editor.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+? - ?
+
+##### Fixes :wrench:
+
+- Fixed a crash caused by `CesiumSunSky` when no viewport is activated in the Editor.
+
 ### v2.6.0 - 2024-06-03
 
 ##### Breaking Changes :mega:

--- a/Source/CesiumRuntime/Private/CesiumSunSky.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSunSky.cpp
@@ -475,7 +475,7 @@ FVector getViewLocation(UWorld* pWorld) {
     const TArray<FEditorViewportClient*>& viewportClients =
         GEditor->GetAllViewportClients();
     for (FEditorViewportClient* pEditorViewportClient : viewportClients) {
-      if (pEditorViewportClient &&
+      if (pEditorViewportClient && pViewport &&
           pEditorViewportClient == pViewport->GetClient()) {
         return pEditorViewportClient->GetViewLocation();
       }


### PR DESCRIPTION
Check `pViewport` validity before dereferencing it.