### PR TITLE
Add Doxygen step to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,25 @@ jobs:
         run: |
           npm install
           npm run format -- --dry-run -Werror
+  Documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Doxygen
+        run: |
+          sudo apt install -y doxygen
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Generate Documentation
+        run: |
+          doxygen ./Documentation/Doxyfile
+      - name: Publish Documentation Artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ReferenceDocumentation
+          path: Documentation/Reference
   Windows52:
     uses: ./.github/workflows/buildWindows.yml
     secrets: inherit

--- a/Documentation/Doxyfile
+++ b/Documentation/Doxyfile
@@ -61,7 +61,7 @@ PROJECT_BRIEF          = "Unlock the 3D geospatial ecosystem in Unreal Engine wi
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = ../Content/Cesium-128x128.png
+PROJECT_LOGO           = ./Content/Cesium-128x128.png
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is


### PR DESCRIPTION
Bringing cesium-unreal in line with cesium-unity and cesium-native, this change adds a step to CI that builds the Doxygen documentation for us.