### PR TITLE
Let CI be dispatched manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Cesium for Unreal
-on: [push]
+on: [push, workflow_dispatch]
 jobs:
   QuickChecks:
     name: "Quick Checks"


### PR DESCRIPTION
Apparently we need `workflow_dispatch` in our CI to dispatch workflows manually? Anyways, this would be helpful for running CI for community PRs that don't trigger the `push` event.