### PR TITLE
Fix Chaos physics epsilon silliness by scaling meshes up and then down.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ##### Fixes :wrench:
 
+- Improved collision and line tracing against tilesets by working around an overly-aggressive degenerate triangle check in the Chaos physics engine.
 - Fixed a bug that could cause a `bad_any_cast` exception when trying to access glTF extensions on non-Windows platforms. This commonly popped up when loading tilesets with metadata.
 - Fixed a bug that caused the `GetInteger64` functions on `CesiumMetadataValue`, `CesiumPropertyArray`, and `CesiumPropertyTableProperty` to always return the default value on non-Windows platforms.
 - Fixed issue with `UCesiumGlobeAnchorComponent::GetEllipsoid` that caused compilation errors on some machines.

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -3820,17 +3820,6 @@ void UCesiumGltfComponent::UpdateFade(float fadePercentage, bool fadingIn) {
   }
 }
 
-static bool isTriangleDegenerate(
-    const Chaos::FTriangleMeshImplicitObject::ParticleVecType& A,
-    const Chaos::FTriangleMeshImplicitObject::ParticleVecType& B,
-    const Chaos::FTriangleMeshImplicitObject::ParticleVecType& C) {
-  Chaos::FTriangleMeshImplicitObject::ParticleVecType AB = B - A;
-  Chaos::FTriangleMeshImplicitObject::ParticleVecType AC = C - A;
-  Chaos::FTriangleMeshImplicitObject::ParticleVecType Normal =
-      Chaos::FTriangleMeshImplicitObject::ParticleVecType::CrossProduct(AB, AC);
-  return (Normal.SafeNormalize() < 1.e-8f);
-}
-
 template <typename TIndex>
 #if ENGINE_VERSION_5_4_OR_HIGHER
 static Chaos::FTriangleMeshImplicitObjectPtr

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -83,16 +83,6 @@ namespace {
 using TMeshVector2 = FVector2f;
 using TMeshVector3 = FVector3f;
 using TMeshVector4 = FVector4f;
-
-// We scale up the meshes because Chaos has a degenerate triangle
-// epsilon test in `TriangleMeshImplicitObject.cpp` that is almost laughably
-// too eager. Perhaps it would be fine if our meshes actually used units of
-// centimeters like UE, but they usually use meters instead. UE considering
-// a triangle that is ~10cm on each side to be degenerate is... infuriating.
-//
-// We scale up the collision meshes by a power-of-two factor so that only
-// the exponent portion of the floating point number is affected.
-constexpr double scaleFactor = 1024.0;
 } // namespace
 
 static uint32_t nextMaterialId = 0;
@@ -1319,8 +1309,8 @@ static void loadPrimitive(
       maxPosition = glm::dvec3(max[0], max[1], max[2]);
     }
 
-    minPosition *= scaleFactor;
-    maxPosition *= scaleFactor;
+    minPosition *= CesiumPrimitiveData::positionScaleFactor;
+    maxPosition *= CesiumPrimitiveData::positionScaleFactor;
 
     primitiveResult.dimensions =
         glm::vec3(transform * glm::dvec4(maxPosition - minPosition, 0));
@@ -1383,9 +1373,9 @@ static void loadPrimitive(
         FStaticMeshBuildVertex& vertex = StaticMeshBuildVertices[i];
         uint32 vertexIndex = indices[i];
         const TMeshVector3& pos = positionView[vertexIndex];
-        vertex.Position.X = pos.X * scaleFactor;
-        vertex.Position.Y = -pos.Y * scaleFactor;
-        vertex.Position.Z = pos.Z * scaleFactor;
+        vertex.Position.X = pos.X * CesiumPrimitiveData::positionScaleFactor;
+        vertex.Position.Y = -pos.Y * CesiumPrimitiveData::positionScaleFactor;
+        vertex.Position.Z = pos.Z * CesiumPrimitiveData::positionScaleFactor;
         vertex.UVs[0] = TMeshVector2(0.0f, 0.0f);
         vertex.UVs[2] = TMeshVector2(0.0f, 0.0f);
         RenderData->Bounds.SphereRadius = FMath::Max(
@@ -1397,9 +1387,9 @@ static void loadPrimitive(
       for (int i = 0; i < StaticMeshBuildVertices.Num(); ++i) {
         FStaticMeshBuildVertex& vertex = StaticMeshBuildVertices[i];
         const TMeshVector3& pos = positionView[i];
-        vertex.Position.X = pos.X * scaleFactor;
-        vertex.Position.Y = -pos.Y * scaleFactor;
-        vertex.Position.Z = pos.Z * scaleFactor;
+        vertex.Position.X = pos.X * CesiumPrimitiveData::positionScaleFactor;
+        vertex.Position.Y = -pos.Y * CesiumPrimitiveData::positionScaleFactor;
+        vertex.Position.Z = pos.Z * CesiumPrimitiveData::positionScaleFactor;
         vertex.UVs[0] = TMeshVector2(0.0f, 0.0f);
         vertex.UVs[2] = TMeshVector2(0.0f, 0.0f);
         RenderData->Bounds.SphereRadius = FMath::Max(
@@ -1682,7 +1672,7 @@ static void loadPrimitive(
   primitiveResult.pMaterial = &material;
   primitiveResult.pCollisionMesh = nullptr;
 
-  double scale = 1.0 / scaleFactor;
+  double scale = 1.0 / CesiumPrimitiveData::positionScaleFactor;
   glm::dmat4 scaleMatrix = glm::dmat4(
       glm::dvec4(scale, 0.0, 0.0, 0.0),
       glm::dvec4(0.0, scale, 0.0, 0.0),

--- a/Source/CesiumRuntime/Private/CesiumMetadataPickingBlueprintLibrary.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMetadataPickingBlueprintLibrary.cpp
@@ -127,8 +127,9 @@ bool UCesiumMetadataPickingBlueprintLibrary::FindUVFromHit(
   std::array<FVector, 3> Positions;
   for (size_t i = 0; i < Positions.size(); i++) {
     auto& Position = primData.PositionAccessor[VertexIndices[i]];
-    // The Y-component of glTF positions must be inverted
-    Positions[i] = FVector(Position[0], -Position[1], Position[2]);
+    // The Y-component of glTF positions must be inverted\
+    // TODO: don't hardcode this 1024.0 here.
+    Positions[i] = FVector(Position[0], -Position[1], Position[2]) * 1024.0;
   }
 
   const FVector Location =

--- a/Source/CesiumRuntime/Private/CesiumMetadataPickingBlueprintLibrary.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMetadataPickingBlueprintLibrary.cpp
@@ -127,9 +127,10 @@ bool UCesiumMetadataPickingBlueprintLibrary::FindUVFromHit(
   std::array<FVector, 3> Positions;
   for (size_t i = 0; i < Positions.size(); i++) {
     auto& Position = primData.PositionAccessor[VertexIndices[i]];
-    // The Y-component of glTF positions must be inverted\
-    // TODO: don't hardcode this 1024.0 here.
-    Positions[i] = FVector(Position[0], -Position[1], Position[2]) * 1024.0;
+    // The Y-component of glTF positions must be inverted, and the positions
+    // must be scaled to match the UE meshes.
+    Positions[i] = FVector(Position[0], -Position[1], Position[2]) *
+                   primData.positionScaleFactor;
   }
 
   const FVector Location =

--- a/Source/CesiumRuntime/Private/CesiumMetadataPickingBlueprintLibrary.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMetadataPickingBlueprintLibrary.cpp
@@ -130,7 +130,7 @@ bool UCesiumMetadataPickingBlueprintLibrary::FindUVFromHit(
     // The Y-component of glTF positions must be inverted, and the positions
     // must be scaled to match the UE meshes.
     Positions[i] = FVector(Position[0], -Position[1], Position[2]) *
-                   primData.positionScaleFactor;
+                   CesiumPrimitiveData::positionScaleFactor;
   }
 
   const FVector Location =

--- a/Source/CesiumRuntime/Private/CesiumPrimitive.h
+++ b/Source/CesiumRuntime/Private/CesiumPrimitive.h
@@ -111,9 +111,6 @@ public:
    * like UE, but they usually use meters instead. With a factor of 1.0, UE will
    * consider a right triangle that is slightly less than ~10cm on each side to
    * be degenerate.
-   *
-   * This property defaults to 1.0, but is set to a larger value in
-   * CesiumGltfComponent.
    */
   static constexpr double positionScaleFactor = 1024.0;
 

--- a/Source/CesiumRuntime/Private/CesiumPrimitive.h
+++ b/Source/CesiumRuntime/Private/CesiumPrimitive.h
@@ -111,6 +111,10 @@ public:
    * like UE, but they usually use meters instead. With a factor of 1.0, UE will
    * consider a right triangle that is slightly less than ~10cm on each side to
    * be degenerate.
+   *
+   * This value should be a power-of-two so the the scale affects only the
+   * exponent of coordinate values, not the mantissa, in order to reduce the
+   * chances of losing precision.
    */
   static constexpr double positionScaleFactor = 1024.0;
 

--- a/Source/CesiumRuntime/Private/CesiumPrimitive.h
+++ b/Source/CesiumRuntime/Private/CesiumPrimitive.h
@@ -101,6 +101,22 @@ public:
 
   std::optional<Cesium3DTilesSelection::BoundingVolume> boundingVolume;
 
+  /**
+   * The factor by which the positions in the glTF primitive is scaled up when
+   * the Unreal mesh is populated.
+   *
+   * We scale up the meshes because Chaos has a degenerate triangle epsilon test
+   * in `TriangleMeshImplicitObject.cpp` that is almost laughably too eager.
+   * Perhaps it would be fine if our meshes actually used units of centimeters
+   * like UE, but they usually use meters instead. With a factor of 1.0, UE will
+   * consider a right triangle that is slightly less than ~10cm on each side to
+   * be degenerate.
+   *
+   * This property defaults to 1.0, but is set to a larger value in
+   * CesiumGltfComponent.
+   */
+  static constexpr double positionScaleFactor = 1024.0;
+
   void destroy();
 };
 

--- a/Source/CesiumRuntime/Private/Tests/CesiumFeatureIdSet.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumFeatureIdSet.spec.cpp
@@ -478,7 +478,7 @@ void FCesiumFeatureIdSetSpec::Define() {
       std::array<int64, 3> expected{3, 1, 0};
 
       for (size_t i = 0; i < locations.size(); i++) {
-        Hit.Location = locations[i];
+        Hit.Location = locations[i] * CesiumPrimitiveData::positionScaleFactor;
         TestEqual(
             "FeatureIDFromHit",
             UCesiumFeatureIdSetBlueprintLibrary::GetFeatureIDFromHit(
@@ -511,7 +511,7 @@ void FCesiumFeatureIdSetSpec::Define() {
       std::array<int64, 3> expected{0, 3, 0};
       for (size_t i = 0; i < locations.size(); i++) {
         Hit.FaceIndex = faceIndices[i];
-        Hit.Location = locations[i];
+        Hit.Location = locations[i] * CesiumPrimitiveData::positionScaleFactor;
         TestEqual(
             "FeatureIDFromHit",
             UCesiumFeatureIdSetBlueprintLibrary::GetFeatureIDFromHit(
@@ -542,7 +542,8 @@ void FCesiumFeatureIdSetSpec::Define() {
       FHitResult Hit;
       Hit.Component = pPrimitiveComponent;
       Hit.FaceIndex = 0;
-      Hit.Location = FVector_NetQuantize(0, -1, 0);
+      Hit.Location = FVector_NetQuantize(0, -1, 0) *
+                     CesiumPrimitiveData::positionScaleFactor;
       TestEqual(
           "FeatureIDFromHit",
           UCesiumFeatureIdSetBlueprintLibrary::GetFeatureIDFromHit(
@@ -551,7 +552,8 @@ void FCesiumFeatureIdSetSpec::Define() {
           0);
 
       Hit.FaceIndex = 1;
-      Hit.Location = FVector_NetQuantize(0, -4, 0);
+      Hit.Location = FVector_NetQuantize(0, -4, 0) *
+                     CesiumPrimitiveData::positionScaleFactor;
       TestEqual(
           "FeatureIDFromHit",
           UCesiumFeatureIdSetBlueprintLibrary::GetFeatureIDFromHit(

--- a/Source/CesiumRuntime/Private/Tests/CesiumFeatureIdTexture.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumFeatureIdTexture.spec.cpp
@@ -552,7 +552,8 @@ void FCesiumFeatureIdTextureSpec::Define() {
           ECesiumFeatureIdTextureStatus::Valid);
 
       FHitResult Hit;
-      Hit.Location = FVector_NetQuantize::Zero();
+      Hit.Location = FVector_NetQuantize::Zero() *
+                     CesiumPrimitiveData::positionScaleFactor;
       Hit.Component = pPrimitiveComponent;
       Hit.FaceIndex = 0;
 
@@ -611,7 +612,8 @@ void FCesiumFeatureIdTextureSpec::Define() {
           ECesiumFeatureIdTextureStatus::Valid);
 
       FHitResult Hit;
-      Hit.Location = FVector_NetQuantize(0, -1, 0);
+      Hit.Location = FVector_NetQuantize(0, -1, 0) *
+                     CesiumPrimitiveData::positionScaleFactor;
       Hit.FaceIndex = 0;
       Hit.Component = nullptr;
 
@@ -671,7 +673,8 @@ void FCesiumFeatureIdTextureSpec::Define() {
           ECesiumFeatureIdTextureStatus::Valid);
 
       FHitResult Hit;
-      Hit.Location = FVector_NetQuantize(0, -1, 0);
+      Hit.Location = FVector_NetQuantize(0, -1, 0) *
+                     CesiumPrimitiveData::positionScaleFactor;
       Hit.FaceIndex = 0;
       Hit.Component = pPrimitiveComponent;
 
@@ -741,7 +744,7 @@ void FCesiumFeatureIdTextureSpec::Define() {
       std::array<int64, 3> expected{3, 1, 0};
 
       for (size_t i = 0; i < locations.size(); i++) {
-        Hit.Location = locations[i];
+        Hit.Location = locations[i] * CesiumPrimitiveData::positionScaleFactor;
         int64 featureID =
             UCesiumFeatureIdTextureBlueprintLibrary::GetFeatureIDFromHit(
                 featureIDTexture,
@@ -808,7 +811,7 @@ void FCesiumFeatureIdTextureSpec::Define() {
       std::array<int64, 3> expected{3, 1, 0};
 
       for (size_t i = 0; i < locations.size(); i++) {
-        Hit.Location = locations[i];
+        Hit.Location = locations[i] * CesiumPrimitiveData::positionScaleFactor;
         int64 featureID =
             UCesiumFeatureIdTextureBlueprintLibrary::GetFeatureIDFromHit(
                 featureIDTexture,
@@ -901,7 +904,7 @@ void FCesiumFeatureIdTextureSpec::Define() {
       std::array<int64, 3> expected{3, 1, 2};
 
       for (size_t i = 0; i < locations.size(); i++) {
-        Hit.Location = locations[i];
+        Hit.Location = locations[i] * CesiumPrimitiveData::positionScaleFactor;
         int64 featureID =
             UCesiumFeatureIdTextureBlueprintLibrary::GetFeatureIDFromHit(
                 featureIDTexture,

--- a/Source/CesiumRuntime/Private/Tests/CesiumMetadataPickingBlueprintLibrary.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumMetadataPickingBlueprintLibrary.spec.cpp
@@ -86,7 +86,8 @@ void FCesiumMetadataPickingSpec::Define() {
 
     It("returns false if hit has no valid component", [this]() {
       FHitResult Hit;
-      Hit.Location = FVector_NetQuantize(0, -1, 0);
+      Hit.Location = FVector_NetQuantize(0, -1, 0) *
+                     CesiumPrimitiveData::positionScaleFactor;
       Hit.FaceIndex = 0;
       Hit.Component = nullptr;
 
@@ -98,7 +99,8 @@ void FCesiumMetadataPickingSpec::Define() {
 
     It("returns false if specified texcoord set does not exist", [this]() {
       FHitResult Hit;
-      Hit.Location = FVector_NetQuantize(0, -1, 0);
+      Hit.Location = FVector_NetQuantize(0, -1, 0) *
+                     CesiumPrimitiveData::positionScaleFactor;
       Hit.FaceIndex = 0;
       Hit.Component = pPrimitiveComponent;
 
@@ -110,7 +112,8 @@ void FCesiumMetadataPickingSpec::Define() {
 
     It("gets hit for primitive without indices", [this]() {
       FHitResult Hit;
-      Hit.Location = FVector_NetQuantize(0, -1, 0);
+      Hit.Location = FVector_NetQuantize(0, -1, 0) *
+                     CesiumPrimitiveData::positionScaleFactor;
       Hit.FaceIndex = 0;
       Hit.Component = pPrimitiveComponent;
 
@@ -121,7 +124,8 @@ void FCesiumMetadataPickingSpec::Define() {
       TestTrue("UV at point (X)", FMath::IsNearlyEqual(UV[0], 0.0));
       TestTrue("UV at point (Y)", FMath::IsNearlyEqual(UV[1], 1.0));
 
-      Hit.Location = FVector_NetQuantize(0, -0.5, 0);
+      Hit.Location = FVector_NetQuantize(0, -0.5, 0) *
+                     CesiumPrimitiveData::positionScaleFactor;
       TestTrue(
           "found hit",
           UCesiumMetadataPickingBlueprintLibrary::FindUVFromHit(Hit, 0, UV));
@@ -133,7 +137,8 @@ void FCesiumMetadataPickingSpec::Define() {
           FMath::IsNearlyEqual(UV[1], 0.5));
 
       Hit.FaceIndex = 1;
-      Hit.Location = FVector_NetQuantize(0, -4, 0);
+      Hit.Location = FVector_NetQuantize(0, -4, 0) *
+                     CesiumPrimitiveData::positionScaleFactor;
       TestTrue(
           "found hit",
           UCesiumMetadataPickingBlueprintLibrary::FindUVFromHit(Hit, 0, UV));
@@ -156,7 +161,8 @@ void FCesiumMetadataPickingSpec::Define() {
           static_cast<int32_t>(model.accessors.size() - 1));
 
       FHitResult Hit;
-      Hit.Location = FVector_NetQuantize(0, -4, 0);
+      Hit.Location = FVector_NetQuantize(0, -4, 0) *
+                     CesiumPrimitiveData::positionScaleFactor;
       Hit.FaceIndex = 0;
       Hit.Component = pPrimitiveComponent;
 
@@ -168,7 +174,8 @@ void FCesiumMetadataPickingSpec::Define() {
       TestTrue("UV at point (X)", FMath::IsNearlyEqual(UV[0], 0.0));
       TestTrue("UV at point (Y)", FMath::IsNearlyEqual(UV[1], 1.0));
 
-      Hit.Location = FVector_NetQuantize(0, -3.5, 0);
+      Hit.Location = FVector_NetQuantize(0, -3.5, 0) *
+                     CesiumPrimitiveData::positionScaleFactor;
       TestTrue(
           "found hit",
           UCesiumMetadataPickingBlueprintLibrary::FindUVFromHit(Hit, 0, UV));
@@ -180,7 +187,8 @@ void FCesiumMetadataPickingSpec::Define() {
           FMath::IsNearlyEqual(UV[1], 0.5));
 
       Hit.FaceIndex = 1;
-      Hit.Location = FVector_NetQuantize(0, -1, 0);
+      Hit.Location = FVector_NetQuantize(0, -1, 0) *
+                     CesiumPrimitiveData::positionScaleFactor;
       TestTrue(
           "found hit",
           UCesiumMetadataPickingBlueprintLibrary::FindUVFromHit(Hit, 0, UV));
@@ -778,7 +786,8 @@ void FCesiumMetadataPickingSpec::Define() {
              FVector2D(vec2Values[0][0], vec2Values[0][1])};
 
          for (size_t i = 0; i < locations.size(); i++) {
-           Hit.Location = locations[i];
+           Hit.Location =
+               locations[i] * CesiumPrimitiveData::positionScaleFactor;
 
            const auto values = UCesiumMetadataPickingBlueprintLibrary::
                GetPropertyTextureValuesFromHit(Hit);
@@ -861,7 +870,7 @@ void FCesiumMetadataPickingSpec::Define() {
           newScalarValues[2],
           newScalarValues[0]};
       for (size_t i = 0; i < locations.size(); i++) {
-        Hit.Location = locations[i];
+        Hit.Location = locations[i] * CesiumPrimitiveData::positionScaleFactor;
 
         const auto values = UCesiumMetadataPickingBlueprintLibrary::
             GetPropertyTextureValuesFromHit(Hit, 1);

--- a/Source/CesiumRuntime/Private/Tests/CesiumPropertyTexture.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumPropertyTexture.spec.cpp
@@ -676,7 +676,8 @@ void FCesiumPropertyTextureSpec::Define() {
       FHitResult Hit;
       Hit.Component = nullptr;
       Hit.FaceIndex = 0;
-      Hit.Location = {0, 0, 0};
+      Hit.Location = FVector_NetQuantize{0, 0, 0} *
+                     CesiumPrimitiveData::positionScaleFactor;
 
       const auto values =
           UCesiumPropertyTextureBlueprintLibrary::GetMetadataValuesFromHit(
@@ -741,7 +742,7 @@ void FCesiumPropertyTextureSpec::Define() {
           FIntPoint(1, 2)};
 
       for (size_t i = 0; i < locations.size(); i++) {
-        Hit.Location = locations[i];
+        Hit.Location = locations[i] * CesiumPrimitiveData::positionScaleFactor;
         const auto values =
             UCesiumPropertyTextureBlueprintLibrary::GetMetadataValuesFromHit(
                 propertyTexture,
@@ -807,7 +808,8 @@ void FCesiumPropertyTextureSpec::Define() {
       FHitResult Hit;
       Hit.Component = pPrimitiveComponent;
       Hit.FaceIndex = 0;
-      Hit.Location = {0, 0, 0};
+      Hit.Location = FVector_NetQuantize{0, 0, 0} *
+                     CesiumPrimitiveData::positionScaleFactor;
 
       const auto values =
           UCesiumPropertyTextureBlueprintLibrary::GetMetadataValuesFromHit(


### PR DESCRIPTION
Fixes #1250

Lending further support to my theory that "anytime a software developer is typing the word 'epsilon', they're typing a bug"...
(See my previous rant about epsilons in CesiumGS/cesium-native#914)

We've had trouble with Chaos physics ever since Unreal Engine switched to it by default. The first problem was that Chaos would frequently crash in debug builds, or hang and spam the log in release builds, when doing collisions against many of our meshes (#1084). It was caused by checking for (and logging) "degenerate triangles". So, we decided to filter out degenerate triangles from our meshes using the same test that Chaos itself uses (#1106).

That worked well in that it stopped the crashing and freezing. But we still occasionally heard reports (#1250) of failed lined traces against our meshes. We assumed this was because the triangles it was supposed to hit were quite small, and so Chaos is (incorrectly) flagging them as degenerate.

But with the San Francisco Ferry Building model, the triangles being missed really aren't all that small. What is going on here? I finally spent a chunk of time looking at it today.

My diagnosis is that the degenerate triangle test that Chaos is using is astoundingly bad. It looks like this:

```cpp
const ParticleVecType& A = MParticles.X(Elements[FaceIdx][0]);
const ParticleVecType& B = MParticles.X(Elements[FaceIdx][1]);
const ParticleVecType& C = MParticles.X(Elements[FaceIdx][2]);

const ParticleVecType AB = B - A;
const ParticleVecType AC = C - A;
ParticleVecType Normal = ParticleVecType::CrossProduct(AB, AC);
			
if(Normal.SafeNormalize() < UE_SMALL_NUMBER)
{
	UE_LOG(LogChaos, Warning, TEXT("Degenerate triangle %d: (%f %f %f) (%f %f %f) (%f %f %f)"), FaceIdx, A.X, A.Y, A.Z, B.X, B.Y, B.Z, C.X, C.Y, C.Z);
	CHAOS_ENSURE(false);
	return FVec3(0, 0, 1);
}
```

A, B, and C are the three vertex positions and `UE_SMALL_NUMBER` is 1e-8. And if you dig into that `SafeNormalize`, you'll see there's yet another epsilon test. If the squared magnitude of the vector is less then 1e-4, then SafeNormalize will return 0.0. Zero is definitely less than 1e-8, so this warning will be triggered.

This computation is done in model coordinates. Which means.... wait for it... the quantities here do not have any known units (it depends on how the model is scaled). So here we go again applying an absolute epsilon to quantities of unknown magnitude. 🤦 Which is guaranteed to end in heartbreak.

Let's say our model coordinates are meters, and we have a simple right triangle that is 9cm on a side. The `Normal` will have a magnitude of 0.09 * 0.09 = 0.0081 meters. So the magnitude squared of that vector will be 0.00006561 m^2. That is clearly less than 1e-4, therefore SafeNormalize will return 0.0 and Chaos will log a "degenerate triangle" warning about this triangle! For a 9cm per side right triangle!

Maybe the author of this code didn't realize that `SafeNormalize` has a 1e-4 epsilon check on the magnitude squared? Probably not, because I don't think the UE_SMALL_NUMBER check will _ever_ make sense with that in place. I mean, to be fair, it's _absolutely insane_ that SafeNormalize - a function working with double-precision values! - returns zero when the magnitude squared is less then 1e-4.

I guess maybe UE can get away with this when model coordinates match world coordinates, and so the units are centimeters instead of meters. A 9cm triangle being degenerate is a big problem, but a 0.09cm triangle being degenerate is I guess kinda sorta more acceptable.

But it's worth noting that there are a bunch of other peope complaining about this problem; it's not just us:
https://forums.unrealengine.com/t/degenerate-triangle-and-tvector-ensure-crashes/544465

Ok, so what do we do about it? Short of changing UE itself, I can only think of one solution: change the scale of our mesh. So that's what this PR does. It multiplies every vertex position in our meshes by 1024.0 (chosen so that only the exponent of the floating point number is affected, not the mantissa... I think I did that right?). And then adjusts the UCesiumGltfPrimitiveComponent matrix to scale by 1 / 1024.0 to bring the model back down to the correct size. With the mesh scaled up by 1024, the silly absolute epsilon becomes less silly. It means our right triangle would have to be less 0.1mm to be considered degenerate. I tried to find a way to scale only the physics mesh, but it didn't seem possible.

This PR is a draft because it's not super well tested and needs some cleanup, but it seems to work very well with the basis tests I've done so far.