### PR TITLE
Fix bad_any_cast errors by disabling RTTI when building cesium-native

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause a `bad_any_cast` exception when trying to access glTF extensions. This commonly popped up when loading tilesets with metadata.
+
 ### v2.7.0 - 2024-07-01
 
 ##### Additions :tada:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ##### Fixes :wrench:
 
-- Fixed a bug that could cause a `bad_any_cast` exception when trying to access glTF extensions. This commonly popped up when loading tilesets with metadata.
+- Fixed a bug that could cause a `bad_any_cast` exception when trying to access glTF extensions on non-Windows platforms. This commonly popped up when loading tilesets with metadata.
+- Fixed a bug that caused the `GetInteger64` functions on `CesiumMetadataValue`, `CesiumPropertyArray`, and `CesiumPropertyTableProperty` to always return the default value on non-Windows platforms.
 
 ### v2.7.0 - 2024-07-01
 

--- a/Source/CesiumRuntime/Private/CesiumMetadataValue.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMetadataValue.cpp
@@ -91,7 +91,7 @@ int64 UCesiumMetadataValueBlueprintLibrary::GetInteger64(
     int64 DefaultValue) {
   return std::visit(
       [DefaultValue](auto value) -> int64 {
-        return CesiumGltf::MetadataConversions<int64, decltype(value)>::convert(
+        return CesiumGltf::MetadataConversions<int64_t, decltype(value)>::convert(
                    value)
             .value_or(DefaultValue);
       },

--- a/Source/CesiumRuntime/Private/CesiumMetadataValue.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMetadataValue.cpp
@@ -91,9 +91,9 @@ int64 UCesiumMetadataValueBlueprintLibrary::GetInteger64(
     int64 DefaultValue) {
   return std::visit(
       [DefaultValue](auto value) -> int64 {
-        return CesiumGltf::MetadataConversions<int64_t, decltype(value)>::convert(
-                   value)
-            .value_or(DefaultValue);
+        return CesiumGltf::MetadataConversions<int64_t, decltype(value)>::
+            convert(value)
+                .value_or(DefaultValue);
       },
       Value._value);
 }

--- a/Source/CesiumRuntime/Private/CesiumPropertyArrayBlueprintLibrary.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPropertyArrayBlueprintLibrary.cpp
@@ -120,7 +120,7 @@ int64 UCesiumPropertyArrayBlueprintLibrary::GetInteger64(
           return defaultValue;
         }
         auto value = v[index];
-        return CesiumGltf::MetadataConversions<int64, decltype(value)>::convert(
+        return CesiumGltf::MetadataConversions<int64_t, decltype(value)>::convert(
                    value)
             .value_or(defaultValue);
       },

--- a/Source/CesiumRuntime/Private/CesiumPropertyArrayBlueprintLibrary.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPropertyArrayBlueprintLibrary.cpp
@@ -120,9 +120,9 @@ int64 UCesiumPropertyArrayBlueprintLibrary::GetInteger64(
           return defaultValue;
         }
         auto value = v[index];
-        return CesiumGltf::MetadataConversions<int64_t, decltype(value)>::convert(
-                   value)
-            .value_or(defaultValue);
+        return CesiumGltf::MetadataConversions<int64_t, decltype(value)>::
+            convert(value)
+                .value_or(defaultValue);
       },
       array._value);
 }

--- a/Source/CesiumRuntime/Private/CesiumPropertyTableProperty.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPropertyTableProperty.cpp
@@ -969,7 +969,7 @@ int64 UCesiumPropertyTablePropertyBlueprintLibrary::GetInteger64(
         auto maybeValue = v.get(FeatureID);
         if (maybeValue) {
           auto value = *maybeValue;
-          return CesiumGltf::MetadataConversions<int64, decltype(value)>::
+          return CesiumGltf::MetadataConversions<int64_t, decltype(value)>::
               convert(value)
                   .value_or(DefaultValue);
         }

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -54,11 +54,11 @@ set(CMAKE_RELWITHDEBINFO_POSTFIX ${CESIUM_RELEASE_POSTFIX})
 # On Mac and Linux, Unreal uses -fvisibility-ms-compat.
 # On Android, it uses -fvisibility=hidden
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-ms-compat -fvisibility-inlines-hidden")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-ms-compat -fvisibility-inlines-hidden -fno-rtti")
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Android")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden -fno-rtti")
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fno-rtti")
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
   # Unreal Engine adds /Zp8 in 64-bit Windows builds to align structs to 8 bytes instead of the
   # default of 16 bytes. There's this nice note in the documentation for that option:


### PR DESCRIPTION
Fixes #1380 

We're seeing `bad_any_cast` exceptions when loading tilesets with metadata, in release builds, on every platform except Windows. The cause appears to be that cesium-native is compiled with runtime type information (RTTI) enabled, but Cesium for Unreal - as required by Unreal Engine itself - is compiled with RTTI disabled. Windows isn't fussed about this, but apparently it causes subtle problems on Linux/Android/Apple.

