### PR TITLE
Fix inconsistent GetEllipsoid compilation error

### DIFF
--- a/Source/CesiumRuntime/Public/CesiumGlobeAnchorComponent.h
+++ b/Source/CesiumRuntime/Public/CesiumGlobeAnchorComponent.h
@@ -182,6 +182,7 @@ public:
    * Obtains the {@link UCesiumEllipsoid} set on the georeference used by this
    * component.
    */
+  UFUNCTION(BlueprintGetter, Category = "Cesium")
   UCesiumEllipsoid* GetEllipsoid() const;
 
   /**


### PR DESCRIPTION
This PR adds a UFUNCTION macro to the GetEllipsoid function in order to fix compilation errors.