### PR TITLE
Add missing include for specific UE 5.3 builds

### DIFF
--- a/Source/CesiumEditor/Private/CesiumGlobeAnchorCustomization.cpp
+++ b/Source/CesiumEditor/Private/CesiumGlobeAnchorCustomization.cpp
@@ -3,6 +3,7 @@
 #include "CesiumGlobeAnchorCustomization.h"
 #include "CesiumCustomization.h"
 #include "CesiumDegreesMinutesSecondsEditor.h"
+#include "CesiumGeoreference.h"
 #include "CesiumGlobeAnchorComponent.h"
 #include "DetailCategoryBuilder.h"
 #include "DetailLayoutBuilder.h"


### PR DESCRIPTION
Came up in the forum [here](https://community.cesium.com/t/cesium-for-unreal-v2-7-0-build-errors/33439/5)

```
[1/4] Compile [x64] CesiumGlobeAnchorCustomization.cpp
C:\path\to\project\Plugins\CesiumForUnreal\Source\CesiumEditor\Private\CesiumGlobeAnchorCustomization.cpp(239): error C2664: 'bool IsValid(const UObject *)': cannot convert argument 1 from 'ACesiumGeoreference *' to 'const UObject *'
C:\path\to\project\Plugins\CesiumForUnreal\Source\CesiumEditor\Private\CesiumGlobeAnchorCustomization.cpp(239): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or parenthesized function-style cast
C:\toolchains\unreal\ue-5.3.2-release\Engine\Source\Runtime\CoreUObject\Public\UObject\Object.h(1771): note: see declaration of 'IsValid'
C:\path\to\project\Plugins\CesiumForUnreal\Source\CesiumEditor\Private\CesiumGlobeAnchorCustomization.cpp(239): note: while trying to match the argument list '(ACesiumGeoreference *)'
C:\path\to\project\Plugins\CesiumForUnreal\Source\CesiumEditor\Private\CesiumGlobeAnchorCustomization.cpp(278): error C2664: 'bool IsValid(const UObject *)': cannot convert argument 1 from 'ACesiumGeoreference *' to 'const UObject *'
C:\path\to\project\Plugins\CesiumForUnreal\Source\CesiumEditor\Private\CesiumGlobeAnchorCustomization.cpp(278): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or parenthesized function-style cast
C:\toolchains\unreal\ue-5.3.2-release\Engine\Source\Runtime\CoreUObject\Public\UObject\Object.h(1771): note: see declaration of 'IsValid'
C:\path\to\project\Plugins\CesiumForUnreal\Source\CesiumEditor\Private\CesiumGlobeAnchorCustomization.cpp(278): note: while trying to match the argument list '(ACesiumGeoreference *)'
```
