### PR TITLE
[Draft] Added initial VisionOS support

### DIFF
--- a/CesiumForUnreal.uplugin
+++ b/CesiumForUnreal.uplugin
@@ -15,19 +15,19 @@
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,
 	"Installed": false,
-	"SupportedTargetPlatforms": [ "Win64", "Mac", "Linux", "Android", "IOS" ],
+	"SupportedTargetPlatforms": [ "Win64", "Mac", "Linux", "Android", "IOS", "VisionOS" ],
 	"Modules": [
 		{
 			"Name": "CesiumRuntime",
 			"Type": "Runtime",
 			"LoadingPhase": "PostConfigInit",
-			"WhitelistPlatforms": [ "Win64", "Mac", "Linux", "Android", "IOS" ]
+			"WhitelistPlatforms": [ "Win64", "Mac", "Linux", "Android", "IOS", "VisionOS" ]
 		},
 		{
 			"Name": "CesiumEditor",
 			"Type": "Editor",
 			"LoadingPhase": "PostEngineInit",
-			"WhitelistPlatforms": [ "Win64", "Mac", "Linux", "Android", "IOS" ]
+			"WhitelistPlatforms": [ "Win64", "Mac", "Linux", "Android", "IOS", "VisionOS" ]
 		}
 	],
 	"Plugins": [

--- a/Source/CesiumEditor/CesiumEditor.Build.cs
+++ b/Source/CesiumEditor/CesiumEditor.Build.cs
@@ -54,6 +54,11 @@ public class CesiumEditor : ModuleRules
             libPostfix = ".a";
             libPrefix = "lib";
         }
+        else if(Target.Platform == UnrealTargetPlatform.VisionOS) {
+            platform = "VisionOS-xarm64";
+            libPostfix = ".a";
+            libPrefix = "lib";
+        }
         else {
             platform = "Unknown";
             libPostfix = ".Unknown";

--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -59,6 +59,11 @@ public class CesiumRuntime : ModuleRules
             libPostfix = ".a";
             libPrefix = "lib";
         }
+        else if(Target.Platform == UnrealTargetPlatform.VisionOS) {
+            platform = "VisionOS-xarm64";
+            libPostfix = ".a";
+            libPrefix = "lib";
+        }
         else {
             platform = "Unknown";
             libPostfix = ".Unknown";

--- a/Source/CesiumRuntime/Private/CesiumRuntime.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRuntime.cpp
@@ -73,7 +73,7 @@ namespace {
 std::string getCacheDatabaseName() {
 #if PLATFORM_ANDROID
   FString BaseDirectory = FPaths::ProjectPersistentDownloadDir();
-#elif PLATFORM_IOS
+#elif PLATFORM_IOS || PLATFORM_VISIONOS
   FString BaseDirectory =
       FPaths::Combine(*FPaths::ProjectSavedDir(), TEXT("Cesium"));
   if (!IFileManager::Get().DirectoryExists(*BaseDirectory)) {


### PR DESCRIPTION
Hello,

This is an initial PR to add Apple Vision Pro support for Cesium. It simply adds missing libraries in *.Build.cs and allows compiling for VisionOS in the .uproject.

Next task that can need help:
- Update build script to build VisionOS libs (CMake and build.yml)
- Trigger a build of these libs to be able to test a build in the headset
