### PR TITLE
Add missing scale factor to instanced translations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed a bug introduced in the previous release that caused instanced tilesets to render incorrectly.
+
 ### v2.7.1 - 2024-08-01
 
 ##### Fixes :wrench:

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1937,8 +1937,9 @@ static void loadInstancingData(
     if (translationAccessor.status() == AccessorViewStatus::Valid) {
       for (int64_t i = 0; i < count; ++i) {
         glm::dvec3 translation(translationAccessor[i]);
-        instanceTransforms[i] =
-            glm::translate(instanceTransforms[i], translation);
+        instanceTransforms[i] = glm::translate(
+            instanceTransforms[i],
+            translation * CesiumPrimitiveData::positionScaleFactor);
       }
     }
   } else {


### PR DESCRIPTION
Instanced translations were missing the `positionScaleFactor`, which made instances stack on top of each other incorrectly. Thanks @WxpGiser for the fix!

This fixes the translation errors in #1496, but there are still lingering issues, so I'll leave that open for now.