### PR TITLE
Raster overlay lifecycle and doc improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - Fixed a bug introduced in the previous release that caused instanced tilesets to render incorrectly.
 - Debug sections are no longer compressed on Linux and Android, improving compatibility.
+- Fixed a bug where calling `Refresh` on a `CesiumRasterOverlay` would cause the overlay to appear on the Cesium3DTileset, even if inactive.
 
 ### v2.7.1 - 2024-08-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ##### Additions :tada:
 
 - Added universal (Intel and Apple Silicon) binaries for Unreal Engine 5.2. Unreal Engine 5.3 and 5.4 already had universal binaries.
+- Raster overlays now have `bAllowAnyoneToDestroyMe` set to true by default. This allows them to be dynamically removed and destroyed at runtime via the Blueprint `Destroy Component` function called from anywhere, including Level Blueprints. Previously, attempting to delete a raster overlay from outside the Actor would result in an error.
 
 ##### Fixes :wrench:
 

--- a/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
@@ -127,7 +127,9 @@ void UCesiumRasterOverlay::RemoveFromTileset() {
 
 void UCesiumRasterOverlay::Refresh() {
   this->RemoveFromTileset();
-  this->AddToTileset();
+  if (this->IsActive()) {
+    this->AddToTileset();
+  }
 }
 
 double UCesiumRasterOverlay::GetMaximumScreenSpaceError() const {

--- a/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
@@ -20,7 +20,11 @@ UCesiumRasterOverlay::UCesiumRasterOverlay()
   // don't need them.
   PrimaryComponentTick.bCanEverTick = false;
 
-  // ...
+  // Allow DestroyComponent to be called from Blueprints by anyone. Without
+  // this, only the Actor (Cesium3DTileset) itself can destroy raster overlays.
+  // That's really annoying because it's fairly common to dynamically add/remove
+  // overlays at runtime.
+  bAllowAnyoneToDestroyMe = true;
 }
 
 #if WITH_EDITOR

--- a/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
@@ -147,7 +147,7 @@ public:
    * have been modified since it was added. To do that, call Refresh.
    *
    * If you created this overlay component via Blueprints, consider setting the
-   * "Auto Activate" property to false on the "Add Component" node and call
+   * "Auto Activate" property to false on the "Add Component" node and calling
    * Activate after setting all the desired properties. This will avoid the need
    * to call Refresh, and will ensure the overlay is not loaded multiple times.
    *

--- a/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
@@ -138,14 +138,13 @@ public:
   void SetSubTileCacheBytes(int64 Value);
 
   /**
-   * Activates this raster overlay, which will add it to (that is: display it
-   * on) the Cesium3DTileset to which the component is attached, if it hasn't
-   * already been added. The overlay will continue to be shown on the tileset
-   * until it is deactivated.
+   * Activates this raster overlay, which will display it on the Cesium3DTileset
+   * to which the component is attached, if it isn't already displayed. The
+   * overlay will continue to be shown on the tileset until it is deactivated.
    *
    * If the overlay is already displayed on the Cesium3DTileset, calling this
    * function will not cause it to pick up any new values for properties that
-   * have been modified since it as added. To do that, call Refresh.
+   * have been modified since it was added. To do that, call Refresh.
    *
    * If you created this overlay component via Blueprints, consider setting the
    * "Auto Activate" property to false on the "Add Component" node and call
@@ -158,9 +157,9 @@ public:
   virtual void Activate(bool bReset) override;
 
   /**
-   * Deactivates this raster overlay. This will remove it from (that is: stop
-   * displaying it on) the Cesium3DTileset to which the component is attached.
-   * The overlay will not be shown again until the component is re-activated.
+   * Deactivates this raster overlay. This will stop displaying it on the
+   * Cesium3DTileset to which the component is attached. The overlay will not be
+   * shown again until the component is re-activated.
    */
   virtual void Deactivate() override;
 
@@ -215,12 +214,12 @@ protected:
   /**
    * The maximum number of bytes to use to cache sub-tiles in memory.
    *
-   * This is used by provider types, that have an underlying tiling
-   * scheme that may not align with the tiling scheme of the geometry tiles on
-   * which the raster overlay tiles are draped. Because a single sub-tile may
-   * overlap multiple geometry tiles, it is useful to cache loaded sub-tiles
-   * in memory in case they're needed again soon. This property controls the
-   * maximum size of that cache.
+   * This is used by provider types that have an underlying tiling scheme that
+   * may not align with the tiling scheme of the geometry tiles on which the
+   * raster overlay tiles are draped. Because a single sub-tile may overlap
+   * multiple geometry tiles, it is useful to cache loaded sub-tiles in memory
+   * in case they're needed again soon. This property controls the maximum size
+   * of that cache.
    */
   UPROPERTY(
       EditAnywhere,

--- a/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
@@ -78,17 +78,27 @@ public:
   UCesiumRasterOverlay();
 
   /**
-   * Adds this raster overlay to its owning Cesium 3D Tileset Actor. If the
-   * overlay is already added or if this component's Owner is not a Cesium 3D
-   * Tileset, this method does nothing.
+   * Displays this raster overlay on its owning Cesium 3D Tileset Actor, without
+   * changing its activation state. It is usually better to call Activate
+   * rather than this function, in order to ensure that the component is also
+   * activated. Otherwise, if the Cesium3DTileset is reloaded for any reason,
+   * this overlay will no longer be shown.
+   *
+   * If the overlay is already added or if this component's Owner is not a
+   * Cesium 3D Tileset, this method does nothing.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   void AddToTileset();
 
   /**
-   * Removes this raster overlay from its owning Cesium 3D Tileset Actor. If the
-   * overlay is not yet added or if this component's Owner is not a Cesium 3D
-   * Tileset, this method does nothing.
+   * Stops displaying this raster overlay on its owning Cesium 3D Tileset Actor.
+   * It is usually better to call Deactivate rather than this function, in order
+   * to ensure that the component is also deactivated. Otherwise, if the
+   * component remains active and the Cesium3DTileset is reloaded for any
+   * reason, this overlay will reappear.
+   *
+   * If the overlay is not yet added or if this component's Owner is not a
+   * Cesium 3D Tileset, this method does nothing.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   void RemoveFromTileset();
@@ -96,7 +106,9 @@ public:
   /**
    * Refreshes this overlay by removing from its owning Cesium 3D Tileset Actor
    * and re-adding it. If this component's Owner is not a Cesium 3D Tileset
-   * Actor, this method does nothing.
+   * Actor, this method does nothing. If this component is not active, the
+   * overlay will be removed from the Cesium3DTileset if already present but not
+   * re-added.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   void Refresh();
@@ -125,8 +137,33 @@ public:
   UFUNCTION(BlueprintCallable, Category = "Cesium")
   void SetSubTileCacheBytes(int64 Value);
 
+  /**
+   * Activates this raster overlay, which will add it to (that is: display it
+   * on) the Cesium3DTileset to which the component is attached, if it hasn't
+   * already been added. The overlay will continue to be shown on the tileset
+   * until it is deactivated.
+   *
+   * If the overlay is already displayed on the Cesium3DTileset, calling this
+   * function will not cause it to pick up any new values for properties that
+   * have been modified since it as added. To do that, call Refresh.
+   *
+   * If you created this overlay component via Blueprints, consider setting the
+   * "Auto Activate" property to false on the "Add Component" node and call
+   * Activate after setting all the desired properties. This will avoid the need
+   * to call Refresh, and will ensure the overlay is not loaded multiple times.
+   *
+   * @param bReset  Whether the activation should happen even if ShouldActivate
+   * returns false.
+   */
   virtual void Activate(bool bReset) override;
+
+  /**
+   * Deactivates this raster overlay. This will remove it from (that is: stop
+   * displaying it on) the Cesium3DTileset to which the component is attached.
+   * The overlay will not be shown again until the component is re-activated.
+   */
   virtual void Deactivate() override;
+
   virtual void OnComponentDestroyed(bool bDestroyingHierarchy) override;
   virtual bool IsReadyForFinishDestroy() override;
 


### PR DESCRIPTION
This PR came out of this community forum post:
https://community.cesium.com/t/remove-clipping-cesiumpolygonrasteroverlay-added-during-runtime/32520/6

It makes it possible to call the `Destroy Component` Blueprint function on a raster overlay from outside the Cesium3DTileset Actor, and have it actually work.

It fixes a small bug where calling `Refresh` on an inactive `CesiumRasterOverlay` would cause that overlay to appear on the tileset. Until the next time the Tileset was refreshed, and then it would disappear.

It also adds some more detailed documentation for the `AddToTileset`, `RemoveFromTileset`, `Refresh`, `Activate`, and `Deactivate` methods on `CesiumRasterOverlay`.