### PR TITLE
Fix macOS build by freeing up disk space on the runner

### DIFF
--- a/.github/workflows/buildApple.yml
+++ b/.github/workflows/buildApple.yml
@@ -28,10 +28,13 @@ jobs:
       - name: Make some more disk space
         run: |
           df -h
+          ls /Applications
           brew uninstall google-chrome
           sudo rm -rf /Users/runner/Library/Android
           sudo rm -rf /Applications/Xcode_16.0.app
           sudo rm -rf /Applications/Xcode_16.0
+          sudo rm -rf /Applications/Xcode_16.1.app
+          sudo rm -rf /Applications/Xcode_16.1
           df -h
       - name: Set XCode version
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/buildApple.yml
+++ b/.github/workflows/buildApple.yml
@@ -29,11 +29,6 @@ jobs:
         run: |
           df -h
           ls /Applications
-          old_xcode="$(xcode-select --print-path)"
-          echo $old_xcode
-          ls $old_xcode
-          ls $old_xcode/..
-          ls $old_xcode/../..
           brew uninstall google-chrome
           sudo rm -rf /Users/runner/Library/Android
           sudo rm -rf /Applications/Xcode_15.0.1.app
@@ -52,8 +47,8 @@ jobs:
           sudo rm -rf /Applications/Xcode_16.1.app
           sudo rm -rf /Applications/Xcode_16.1_beta.app
           sudo rm -rf /Applications/Xcode_16_beta_6.app
-          df -h
           ls /Applications
+          df -h
       - name: Set XCode version
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/buildApple.yml
+++ b/.github/workflows/buildApple.yml
@@ -31,10 +31,12 @@ jobs:
           ls /Applications
           brew uninstall google-chrome
           sudo rm -rf /Users/runner/Library/Android
+          sudo rm -rf /Applications/Xcode_16.0.0.app
           sudo rm -rf /Applications/Xcode_16.0.app
-          sudo rm -rf /Applications/Xcode_16.0
+          sudo rm -rf /Applications/Xcode_16.1.0.app
           sudo rm -rf /Applications/Xcode_16.1.app
-          sudo rm -rf /Applications/Xcode_16.1
+          sudo rm -rf /Applications/Xcode_16.1_beta.app
+          sudo rm -rf /Applications/Xcode_16_beta_6.app
           df -h
       - name: Set XCode version
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/buildApple.yml
+++ b/.github/workflows/buildApple.yml
@@ -36,6 +36,16 @@ jobs:
           ls $old_xcode/../..
           brew uninstall google-chrome
           sudo rm -rf /Users/runner/Library/Android
+          sudo rm -rf /Applications/Xcode_15.0.1.app
+          sudo rm -rf /Applications/Xcode_15.0.app
+          sudo rm -rf /Applications/Xcode_15.1.0.app
+          sudo rm -rf /Applications/Xcode_15.1.app
+          sudo rm -rf /Applications/Xcode_15.2.0.app
+          sudo rm -rf /Applications/Xcode_15.2.app
+          sudo rm -rf /Applications/Xcode_15.3.0.app
+          sudo rm -rf /Applications/Xcode_15.3.app
+          sudo rm -rf /Applications/Xcode_15.4.0.app
+          sudo rm -rf /Applications/Xcode_15.4.app
           sudo rm -rf /Applications/Xcode_16.0.0.app
           sudo rm -rf /Applications/Xcode_16.0.app
           sudo rm -rf /Applications/Xcode_16.1.0.app

--- a/.github/workflows/buildApple.yml
+++ b/.github/workflows/buildApple.yml
@@ -38,6 +38,7 @@ jobs:
           sudo rm -rf /Applications/Xcode_16.1_beta.app
           sudo rm -rf /Applications/Xcode_16_beta_6.app
           df -h
+          ls /Applications
       - name: Set XCode version
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/buildApple.yml
+++ b/.github/workflows/buildApple.yml
@@ -29,6 +29,11 @@ jobs:
         run: |
           df -h
           ls /Applications
+          old_xcode="$(xcode-select --print-path)"
+          echo $old_xcode
+          ls $old_xcode
+          ls $old_xcode/..
+          ls $old_xcode/../..
           brew uninstall google-chrome
           sudo rm -rf /Users/runner/Library/Android
           sudo rm -rf /Applications/Xcode_16.0.0.app


### PR DESCRIPTION
The [latest update](https://github.com/actions/runner-images/compare/macos-14-arm64/20240818.4...macos-14-arm64/20240827.4#diff-5c04a529d3c8adf7a5f23afe544071dad1853e281c9c7b44cd8d626b6c57444d) to the GitHub Actions macos-14 runner has drastically less disk than the previous image version, mostly because more stuff is installed. So this PR uninstalls some of that stuff so we have enough space for our builds again.

See here:
https://github.com/actions/runner-images/issues/10511
