### PR TITLE
Don't crash .build.cs files if native libs haven't been built.

### DIFF
--- a/Source/CesiumEditor/CesiumEditor.Build.cs
+++ b/Source/CesiumEditor/CesiumEditor.Build.cs
@@ -71,7 +71,7 @@ public class CesiumEditor : ModuleRules
 
         string libPath = useDebug ? libPathDebug : libPathRelease;
 
-        string[] allLibs = Directory.GetFiles(libPath, libSearchPattern);
+        string[] allLibs = Directory.Exists(libPath) ? Directory.GetFiles(libPath, libSearchPattern) : new string[0];
 
         PublicAdditionalLibraries.AddRange(allLibs);
 

--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -70,7 +70,7 @@ public class CesiumRuntime : ModuleRules
 
         string libPath = useDebug ? libPathDebug : libPathRelease;
 
-        string[] allLibs = Directory.GetFiles(libPath, libSearchPattern);
+        string[] allLibs = Directory.Exists(libPath) ? Directory.GetFiles(libPath, libSearchPattern) : new string[0];
 
         PublicAdditionalLibraries.AddRange(allLibs);
 


### PR DESCRIPTION
The two .build.cs files have a line like this:

```csharp
string[] allLibs = Directory.GetFiles(libPath, libSearchPattern);
```

That line will throw an exception if `libPath` doesn't exist, which will be the case before cesium-native is built at all. This is mostly only a problem if you're trying to get Unreal to "Generate Visual Studio project files" before building Native. It's not too catastrophic, but slightly annoying, and easy to fix.