### PR TITLE
Fixed build for Unreal Engine 5.4

### DIFF
--- a/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
+++ b/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020-2024 CesiumGS, Inc. and Contributors
 
 #include "UnrealAssetAccessor.h"
+#include "CesiumCommon.h"
 #include "Async/Async.h"
 #include "Async/AsyncWork.h"
 


### PR DESCRIPTION
- Added include for CesiumCommon which contains the definition of the engine version preprocessor
- Fixes #1519 