### PR TITLE
Initialize fields in FCesiumSampleHeightResult.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 - Fixed a bug that caused incorrect lighting for tilesets using `KHR_materials_unlit`.
 - Reduced the memory used by tiles with `KHR_materials_unlit`.
 - `CesiumGlobeAnchor` properties are no longer shown on the main `CesiumSunSky` Details panel, because it is almost never necessary to set these. They can still be set on the component's own Details panel if needed.
+- Fixed error messages in the Unreal log about uninitialized fields in `FCesiumSampleHeightResult`.
 
 ### v2.9.0 - 2024-10-01
 

--- a/Source/CesiumRuntime/Public/CesiumSampleHeightResult.h
+++ b/Source/CesiumRuntime/Public/CesiumSampleHeightResult.h
@@ -19,7 +19,7 @@ struct CESIUMRUNTIME_API FCesiumSampleHeightResult {
    * is false.
    */
   UPROPERTY(BlueprintReadWrite, Category = "Cesium")
-  FVector LongitudeLatitudeHeight;
+  FVector LongitudeLatitudeHeight{0.0, 0.0, 0.0};
 
   /**
    * True if the height as sampled from the tileset successfully. False if the
@@ -28,5 +28,5 @@ struct CESIUMRUNTIME_API FCesiumSampleHeightResult {
    * will have more information about the problem.
    */
   UPROPERTY(BlueprintReadWrite, Category = "Cesium")
-  bool SampleSuccess;
+  bool SampleSuccess{false};
 };

--- a/Source/CesiumRuntime/Public/CesiumSampleHeightResult.h
+++ b/Source/CesiumRuntime/Public/CesiumSampleHeightResult.h
@@ -19,7 +19,7 @@ struct CESIUMRUNTIME_API FCesiumSampleHeightResult {
    * is false.
    */
   UPROPERTY(BlueprintReadWrite, Category = "Cesium")
-  FVector LongitudeLatitudeHeight{0.0, 0.0, 0.0};
+  FVector LongitudeLatitudeHeight = {0.0, 0.0, 0.0};
 
   /**
    * True if the height as sampled from the tileset successfully. False if the
@@ -28,5 +28,5 @@ struct CESIUMRUNTIME_API FCesiumSampleHeightResult {
    * will have more information about the problem.
    */
   UPROPERTY(BlueprintReadWrite, Category = "Cesium")
-  bool SampleSuccess{false};
+  bool SampleSuccess = false;
 };


### PR DESCRIPTION
Unreal is reporting that the two fields in this class are not initialized. This is probably harmless, but good (and easy) to fix.

As reported here:
https://community.cesium.com/t/fcesiumsampleheightresult-errors/35906
