### PR TITLE
Use a soft object reference for cartographic polygons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### Not Released Yet
+
+##### Fixes :wrench:
+
+- `CesiumPolygonRasterOverlay` now references `CesiumCartographicPolygon` instances using `TSoftObjectPtr`, which allows, for example, a raster overlay in the persistent level to use a polygon in a sub-level.
+
 ### v2.10.0 - 2024-11-01
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Private/CesiumPolygonRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPolygonRasterOverlay.cpp
@@ -28,7 +28,7 @@ UCesiumPolygonRasterOverlay::CreateOverlay(
   std::vector<CartographicPolygon> polygons;
   polygons.reserve(this->Polygons.Num());
 
-  for (ACesiumCartographicPolygon* pPolygon : this->Polygons) {
+  for (auto& pPolygon : this->Polygons) {
     if (!pPolygon) {
       continue;
     }

--- a/Source/CesiumRuntime/Public/CesiumPolygonRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumPolygonRasterOverlay.h
@@ -29,7 +29,7 @@ public:
    * The polygons to rasterize for this overlay.
    */
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
-  TArray<ACesiumCartographicPolygon*> Polygons;
+  TArray<TSoftObjectPtr<ACesiumCartographicPolygon>> Polygons;
 
   /**
    * Whether to invert the selection specified by the polygons.


### PR DESCRIPTION
Use a soft object pointer to store references to cartographic polygons in other level instances (#1544 ).