### PR TITLE
Fix CesiumGltf namespace problems.

### DIFF
--- a/Source/CesiumRuntime/Private/Tests/CesiumPropertyTableProperty.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumPropertyTableProperty.spec.cpp
@@ -6,8 +6,6 @@
 #include "Misc/AutomationTest.h"
 #include <limits>
 
-using namespace CesiumGltf;
-
 BEGIN_DEFINE_SPEC(
     FCesiumPropertyTablePropertySpec,
     "Cesium.Unit.PropertyTableProperty",
@@ -16,6 +14,8 @@ BEGIN_DEFINE_SPEC(
 END_DEFINE_SPEC(FCesiumPropertyTablePropertySpec)
 
 void FCesiumPropertyTablePropertySpec::Define() {
+  using namespace CesiumGltf;
+
   Describe("Constructor", [this]() {
     It("constructs invalid instance by default", [this]() {
       FCesiumPropertyTableProperty property;

--- a/Source/CesiumRuntime/Private/Tests/CesiumPropertyTexture.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumPropertyTexture.spec.cpp
@@ -14,10 +14,10 @@ BEGIN_DEFINE_SPEC(
     "Cesium.Unit.PropertyTexture",
     EAutomationTestFlags::ApplicationContextMask |
         EAutomationTestFlags::ProductFilter)
-Model model;
-MeshPrimitive* pPrimitive;
-ExtensionModelExtStructuralMetadata* pExtension;
-PropertyTexture* pPropertyTexture;
+CesiumGltf::Model model;
+CesiumGltf::MeshPrimitive* pPrimitive;
+CesiumGltf::ExtensionModelExtStructuralMetadata* pExtension;
+CesiumGltf::PropertyTexture* pPropertyTexture;
 TObjectPtr<UCesiumGltfComponent> pModelComponent;
 TObjectPtr<UCesiumGltfPrimitiveComponent> pPrimitiveComponent;
 
@@ -29,6 +29,8 @@ const std::vector<FVector2D> texCoords{
 END_DEFINE_SPEC(FCesiumPropertyTextureSpec)
 
 void FCesiumPropertyTextureSpec::Define() {
+  using namespace CesiumGltf;
+
   BeforeEach([this]() {
     model = Model();
     pExtension = &model.addExtension<ExtensionModelExtStructuralMetadata>();

--- a/Source/CesiumRuntime/Private/Tests/CesiumPropertyTextureProperty.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumPropertyTextureProperty.spec.cpp
@@ -19,6 +19,8 @@ const std::vector<FVector2D> texCoords{
 END_DEFINE_SPEC(FCesiumPropertyTexturePropertySpec)
 
 void FCesiumPropertyTexturePropertySpec::Define() {
+  using namespace CesiumGltf;
+
   Describe("Constructor", [this]() {
     It("constructs invalid instance by default", [this]() {
       FCesiumPropertyTextureProperty property;


### PR DESCRIPTION
In #1521, we worked around a strange macOS compilation problem (conflict between Cocoa `Class` and the `Class` in `CesiumGltf`) by removing occurrences of `using namespace CesiumGltf`. But we missed one. And because of this one we missed, combined with Unreal's unity build system, we also missed adding the necessary `CesiumGltf::` in two source files. This PR fixes both problems.

Fixes #1547.