### PR TITLE
Fix `SampleHeightMostDetailed` crash on `Cesium3DTileset` with raster overlay

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - 2024-12-02
+
+##### Fixes :wrench:
+
+- Fixed a crash that could occur when using `SampleHeightMostDetailed` on a `Cesium3DTileset` with a raster overlay.
+
 ### v2.10.0 - 2024-11-01
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -131,6 +131,12 @@ void ACesium3DTileset::SetMobility(EComponentMobility::Type NewMobility) {
 void ACesium3DTileset::SampleHeightMostDetailed(
     const TArray<FVector>& LongitudeLatitudeHeightArray,
     FCesiumSampleHeightMostDetailedCallback OnHeightsSampled) {
+  // It's possible to call this function before a Tick happens, so make sure
+  // that the necessary variables are resolved.
+  this->ResolveGeoreference();
+  this->ResolveCameraManager();
+  this->ResolveCreditSystem();
+
   if (this->_pTileset == nullptr) {
     this->LoadTileset();
   }


### PR DESCRIPTION
Fixes #1549. The cesium-native side isn't included yet since I didn't want to complicate things between PRs like #1552 and #1539.