### PR TITLE
Don't crash if an Image is missing its ImageAsset

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGltfTextures.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfTextures.cpp
@@ -238,7 +238,7 @@ SharedFuture<void> createTextureInLoadThread(
 
   CesiumGltf::Image* pImage =
       CesiumGltf::Model::getSafe(&gltf.images, pTexture->source);
-  if (pImage == nullptr)
+  if (pImage == nullptr || pImage->pAsset == nullptr)
     return asyncSystem.createResolvedFuture().share();
 
   check(pTexture->source >= 0 && pTexture->source < imageNeedsMipmaps.size());

--- a/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTextureUtility.cpp
@@ -179,6 +179,10 @@ TUniquePtr<LoadedTextureResult> loadTextureFromModelAnyThreadPart(
   };
 
   CesiumGltf::Image& image = model.images[*optionalSourceIndex];
+  if (image.pAsset == nullptr) {
+    return nullptr;
+  }
+
   const CesiumGltf::Sampler& sampler =
       model.getSafe(model.samplers, texture.sampler);
 


### PR DESCRIPTION
Usually this happens because the `ImageAsset` failed to load, perhaps because the URL is invalid.

Also updates cesium-native to include CesiumGS/cesium-native#1016, so merge that first.
