### PR TITLE
Treat failed to load as unloaded sublevels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 - Removed support for Unreal Engine 5.2. Unreal Engine 5.3 or later is now required.
 
+##### Fixes :wrench:
+
+- Fixed a bug in `CesiumSubLevelSwitcherComponent` that could prevent all sub-levels from loading if a single sub-level failed to load.
+
 ### v2.11.0 - 2024-12-02
 
 This is the last release of Cesium for Unreal that will support Unreal Engine v5.2. Future versions will require Unreal Engine v5.3+.

--- a/Source/CesiumRuntime/Private/CesiumSubLevelSwitcherComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSubLevelSwitcherComponent.cpp
@@ -144,12 +144,12 @@ void UCesiumSubLevelSwitcherComponent::TickComponent(
         case ELevelStreamingState::MakingVisible:
           anyLevelsStillLoaded = true;
           break;
-        case ELevelStreamingState::FailedToLoad:
         case ELevelStreamingState::LoadedNotVisible:
         case ELevelStreamingState::LoadedVisible:
           pSubLevel->UnloadLevelInstance();
           anyLevelsStillLoaded = true;
           break;
+        case ELevelStreamingState::FailedToLoad:
         case ELevelStreamingState::Removed:
         case ELevelStreamingState::Unloaded:
           break;


### PR DESCRIPTION
Fixes #1575 

If a sublevel fails to load, we should not block other sublevels from loading. We can treat it as being unloaded.