### PR TITLE
Update `testIonToken` to latest Unreal Samples token

### DIFF
--- a/Source/CesiumRuntime/Private/Tests/CesiumSceneGeneration.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumSceneGeneration.cpp
@@ -19,7 +19,7 @@
 namespace Cesium {
 
 FString SceneGenerationContext::testIonToken(
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwNzA3YWIzNS0xMjI5LTQ3MWEtOTgyNS05OTk0YThlOTE4NzMiLCJpZCI6MjU5LCJpYXQiOjE3Mjc3MzgxNjJ9.vll2Xe-NPuNPiC0KSe8uN7hgG-ldlalcXfdDBxxDkXY");
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI5ZThmNmNmZC1mOTM3LTRjMjUtYWFlMS01NGQxODFmYzQ1OGMiLCJpZCI6MjU5LCJpYXQiOjE3MzU3NzYxNjN9.DrabtSRqLQAZnKPqrwSVUpB0m5fpcGEKICnXYV2IijU");
 
 void SceneGenerationContext::setCommonProperties(
     const FVector& origin,


### PR DESCRIPTION
Updating `SceneGenerationContext::testIonToken` to the Cesium for Unreal Samples v2.12.0 token to fix broken tests.