### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -7,9 +7,9 @@ body:
       value: |
         Thanks for helping us improve Cesium for Unreal!
         
-        First, check if the issue already exists in the [issues](https://github.com/CesiumGS/cesium-unreal/issues) page. If it does, leave a comment on the existing issue instead.
+        First, check if the issue already exists in the [issues](https://github.com/CesiumGS/cesium-unreal/issues) page. If it does, please leave a **comment** on the existing issue instead.
         
-        Otherwise, if you can't find a similar issue, please describe what is happening and provide more information below.
+        Otherwise, if you can't find a similar issue, describe what is happening using the text fields below.
   - type: textarea
     id: what-happened
     attributes:
@@ -50,8 +50,6 @@ body:
   - type: markdown
     attributes:
       value: |
-        If you can also contribute a fix, we'd absolutely appreciate it! Fixing a bug in Cesium for Unreal often means fixing a bug for numerous applications and end users.
+        If you can also contribute a fix, we'd absolutely appreciate it! Fixing a bug in Cesium for Unreal often means fixing a bug for numerous applications and end users. Check out the contributor guide to get started: [CONTRIBUTING.md](https://github.com/CesiumGS/cesium-unreal/tree/main/CONTRIBUTING.md)
 
-        Check out the contributor guide to get started: [CONTRIBUTING.md](https://github.com/CesiumGS/cesium-unreal/tree/main/CONTRIBUTING.md)
-
-        Just let us know you're working on it and we'd be happy to provide advice and feedback.
+        Let us know you're working on it, and we'd be happy to provide advice and feedback.

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,57 @@
+name: Report a bug
+description: Let us know so we can fix it!
+labels: ["needs triage", "bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve Cesium for Unreal!
+        
+        First, check if the issue already exists in the [issues](https://github.com/CesiumGS/cesium-unreal/issues) page. If it does, leave a comment on the existing issue instead.
+        
+        Otherwise, if you can't find a similar issue, please describe what is happening and provide more information below.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: What environment are you experiencing this issue in?
+      value: |
+        Cesium for Unreal version:
+        Unreal Engine Version:
+        Operating System:
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: "How do you trigger this bug? Please walk us through it step by step, starting from either a blank project or the Cesium for Unreal Samples. (We can triage bugs much faster when we have these steps.)"
+      value: |
+        1.
+        2.
+        3.
+        ...
+    validations:
+      required: false
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Supporting evidence
+      description: Providing screenshots, videos, or GIFs of the issue helps us a lot, especially for visual bugs. If there were any error messages or logs in the console, please include those too.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        If you can also contribute a fix, we'd absolutely appreciate it! Fixing a bug in Cesium for Unreal often means fixing a bug for numerous applications and end users.
+
+        Check out the contributor guide to get started: [CONTRIBUTING.md](https://github.com/CesiumGS/cesium-unreal/tree/main/CONTRIBUTING.md)
+
+        Just let us know you're working on it and we'd be happy to provide advice and feedback.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+- name: Ask a question
+  url: https://community.cesium.com/c/cesium-for-unreal/10
+  about: Please use the community forum for general questions. The Cesium team and community actively monitor it and love to see what people are working on! We reserve GitHub for confirmed bug reports and feature requests. 

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,20 @@
+name: Request a feature
+description: New ideas & improvements to Cesium for Unreal are always welcome.
+labels: ["needs triage", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve Cesium for Unreal!
+
+        When suggesting an idea, give examples of the intended use case. Features that benefit the wider community are more likely to be prioritized.
+  - type: textarea
+    id: new-feature
+    attributes:
+      label: Feature
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        The best way to get your ideas into Cesium for Unreal is to help us! We love contributions and are always happy to be provide feedback and advice. Check out the contributor guide to get started: [CONTRIBUTING.md](https://github.com/CesiumGS/cesium-unreal/tree/main/CONTRIBUTING.md)


### PR DESCRIPTION
This follows CesiumJS's lead by adding issue templates to the repo. Hopefully the bug report form, in particular, streamlines the process for creating such reports :smile: