### PR TITLE
Fix build with GLM changes in Cesium Native

### DIFF
--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -113,7 +113,7 @@ public class CesiumRuntime : ModuleRules
                 "LIBASYNC_STATIC",
                 "GLM_FORCE_XYZW_ONLY",
                 "GLM_FORCE_EXPLICIT_CTOR",
-                "GLM_FORCE_SIZE_T_LENGTH",
+                "GLM_ENABLE_EXPERIMENTAL",
                 "TIDY_STATIC",
                 "URI_STATIC_BUILD",
                 "SWL_VARIANT_NO_CONSTEXPR_EMPLACE",

--- a/Source/CesiumRuntime/Private/GeoTransforms.cpp
+++ b/Source/CesiumRuntime/Private/GeoTransforms.cpp
@@ -8,7 +8,6 @@
 #include "VecMath.h"
 #include <glm/gtc/matrix_inverse.hpp>
 
-#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/quaternion.hpp>
 
 using namespace CesiumGeospatial;


### PR DESCRIPTION
At the moment, `GLM_FORCE_SIZE_T_LENGTH` is still defined in the Unreal Build.cs, which - after we removed this define from Cesium Native - means linker errors result when trying to build Cesium for Unreal with the latest changes from Cesium Native. We can fix this by simply removing the define.

Also, I've been receiving errors related to using an experimental header without defining `GLM_ENABLE_EXPERIMENTAL`, despite the only place an experimental header is used in this codebase coming after a `#define GLM_ENABLE_EXPERIMENTAL` declaration. I don't know what's causing this - something to do with Unreal's unity build? - but it can be fixed by defining `GLM_ENABLE_EXPERIMENTAL` in the Build.cs.