### PR TITLE
Check for null tileset in SampleHeightMostDetailed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ##### Fixes :wrench:
 
 - Fixed another bug in `CesiumSubLevelSwitcherComponent` that could prevent all sub-levels from loading if a single sub-level failed to load.
+- Fixed crash when calling `SampleHeightMostDetailed` blueprint function without a valid tileset.
 
 ### v2.12.0 - 2025-01-02
 

--- a/Source/CesiumRuntime/Private/CesiumSampleHeightMostDetailedAsyncAction.cpp
+++ b/Source/CesiumRuntime/Private/CesiumSampleHeightMostDetailedAsyncAction.cpp
@@ -16,13 +16,25 @@ UCesiumSampleHeightMostDetailedAsyncAction::SampleHeightMostDetailed(
 }
 
 void UCesiumSampleHeightMostDetailedAsyncAction::Activate() {
-  this->RegisterWithGameInstance(this->_pTileset);
+  if (!IsValid(this->_pTileset)) {
+    TArray<FString> Warnings;
+    Warnings.Push(TEXT(
+        "Invalid Tileset parameter passed to UCesiumSampleHeightMostDetailedAsyncAction, returning no results"));
 
-  this->_pTileset->SampleHeightMostDetailed(
-      this->_longitudeLatitudeHeightArray,
-      FCesiumSampleHeightMostDetailedCallback::CreateUObject(
-          this,
-          &UCesiumSampleHeightMostDetailedAsyncAction::RaiseOnHeightsSampled));
+    this->RaiseOnHeightsSampled(
+        this->_pTileset,
+        TArray<FCesiumSampleHeightResult>(),
+        Warnings);
+  } else {
+    this->RegisterWithGameInstance(this->_pTileset);
+
+    this->_pTileset->SampleHeightMostDetailed(
+        this->_longitudeLatitudeHeightArray,
+        FCesiumSampleHeightMostDetailedCallback::CreateUObject(
+            this,
+            &UCesiumSampleHeightMostDetailedAsyncAction::
+                RaiseOnHeightsSampled));
+  }
 }
 
 void UCesiumSampleHeightMostDetailedAsyncAction::RaiseOnHeightsSampled(

--- a/Source/CesiumRuntime/Private/Tests/SampleHeightMostDetailed.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/SampleHeightMostDetailed.spec.cpp
@@ -378,6 +378,4 @@ void FSampleHeightMostDetailedSpec::Define() {
           pAsync->Activate();
         });
   });
-
-
 }

--- a/Source/CesiumRuntime/Private/Tests/SampleHeightMostDetailed.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/SampleHeightMostDetailed.spec.cpp
@@ -309,7 +309,7 @@ void FSampleHeightMostDetailedSpec::Define() {
     });
 
     LatentIt(
-        "",
+        "invalid tileset URL",
         EAsyncExecution::TaskGraphMainThread,
         [this](const FDoneDelegate& done) {
           // Two slightly different error messages will occur, depending on
@@ -354,5 +354,30 @@ void FSampleHeightMostDetailedSpec::Define() {
                     done.ExecuteIfBound();
                   }));
         });
+
+    LatentIt(
+        "tileset parameter is nullptr",
+        EAsyncExecution::TaskGraphMainThread,
+        [this](const FDoneDelegate& done) {
+          UCesiumSampleHeightMostDetailedAsyncAction* pAsync =
+              UCesiumSampleHeightMostDetailedAsyncAction::
+                  SampleHeightMostDetailed(
+                      nullptr,
+                      {FVector(144.93406, -37.82457, 1.0)});
+
+          USampleHeightCallbackReceiver::Bind(
+              pAsync->OnHeightsSampled,
+              [this, done](
+                  const TArray<FCesiumSampleHeightResult>& result,
+                  const TArray<FString>& warnings) {
+                TestEqual("Number of results", result.Num(), 0);
+                TestEqual("Number of warnings", warnings.Num(), 1);
+                done.ExecuteIfBound();
+              });
+
+          pAsync->Activate();
+        });
   });
+
+
 }


### PR DESCRIPTION
Fixes #1562. The `SampleHeightMostDetailed` blueprint function will currently crash if called without a valid `ACesium3DTileset` parameter. This PR adds a null check that returns an empty set of results and a warning if called with an invalid tileset.