### PR TITLE
Add `RequestHeaders` properly to relevant raster overlays

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 - Added `CesiumUrlTemplateRasterOverlay`, allowing a raster overlay to be added using tiles requested based on a specified URL template.
 - Added `RequestHeaders` property to `Cesium3DTileset`, allowing per-tileset headers to be specified.
+- Added `RequestHeaders` properties to `CesiumTileMapServiceRasterOverlay`, `CesiumUrlTemplateRasterOverlay`, `CesiumWebMapServiceRasterOverlay`, 
+  and `CesiumWebMapTileServiceRasterOverlay`, allowing per-raster-overlay HTTP headers to be specified.
 
 ##### Fixes :wrench:
 

--- a/Source/CesiumRuntime/Private/CesiumTileMapServiceRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTileMapServiceRasterOverlay.cpp
@@ -17,10 +17,19 @@ UCesiumTileMapServiceRasterOverlay::CreateOverlay(
     tmsOptions.minimumLevel = MinimumLevel;
     tmsOptions.maximumLevel = MaximumLevel;
   }
+
+  std::vector<CesiumAsync::IAssetAccessor::THeader> headers;
+
+  for (auto& [Key, Value] : this->RequestHeaders) {
+    headers.push_back(CesiumAsync::IAssetAccessor::THeader{
+        TCHAR_TO_UTF8(*Key),
+        TCHAR_TO_UTF8(*Value)});
+  }
+
   return std::make_unique<CesiumRasterOverlays::TileMapServiceRasterOverlay>(
       TCHAR_TO_UTF8(*this->MaterialLayerKey),
       TCHAR_TO_UTF8(*this->Url),
-      std::vector<CesiumAsync::IAssetAccessor::THeader>(),
+      headers,
       tmsOptions,
       options);
 }

--- a/Source/CesiumRuntime/Private/CesiumTileMapServiceRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTileMapServiceRasterOverlay.cpp
@@ -20,7 +20,7 @@ UCesiumTileMapServiceRasterOverlay::CreateOverlay(
 
   std::vector<CesiumAsync::IAssetAccessor::THeader> headers;
 
-  for (auto& [Key, Value] : this->RequestHeaders) {
+  for (const auto& [Key, Value] : this->RequestHeaders) {
     headers.push_back(CesiumAsync::IAssetAccessor::THeader{
         TCHAR_TO_UTF8(*Key),
         TCHAR_TO_UTF8(*Value)});

--- a/Source/CesiumRuntime/Private/CesiumUrlTemplateRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumUrlTemplateRasterOverlay.cpp
@@ -55,10 +55,18 @@ UCesiumUrlTemplateRasterOverlay::CreateOverlay(
         RootTilesY);
   }
 
+  std::vector<CesiumAsync::IAssetAccessor::THeader> headers;
+
+  for (auto& [Key, Value] : this->RequestHeaders) {
+    headers.push_back(CesiumAsync::IAssetAccessor::THeader{
+        TCHAR_TO_UTF8(*Key),
+        TCHAR_TO_UTF8(*Value)});
+  }
+
   return std::make_unique<CesiumRasterOverlays::UrlTemplateRasterOverlay>(
       TCHAR_TO_UTF8(*this->MaterialLayerKey),
       TCHAR_TO_UTF8(*this->TemplateUrl),
-      std::vector<CesiumAsync::IAssetAccessor::THeader>(),
+      headers,
       urlTemplateOptions,
       options);
 }

--- a/Source/CesiumRuntime/Private/CesiumUrlTemplateRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumUrlTemplateRasterOverlay.cpp
@@ -57,7 +57,7 @@ UCesiumUrlTemplateRasterOverlay::CreateOverlay(
 
   std::vector<CesiumAsync::IAssetAccessor::THeader> headers;
 
-  for (auto& [Key, Value] : this->RequestHeaders) {
+  for (const auto& [Key, Value] : this->RequestHeaders) {
     headers.push_back(CesiumAsync::IAssetAccessor::THeader{
         TCHAR_TO_UTF8(*Key),
         TCHAR_TO_UTF8(*Value)});

--- a/Source/CesiumRuntime/Private/CesiumWebMapServiceRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumWebMapServiceRasterOverlay.cpp
@@ -21,10 +21,19 @@ UCesiumWebMapServiceRasterOverlay::CreateOverlay(
   wmsOptions.layers = TCHAR_TO_UTF8(*Layers);
   wmsOptions.tileWidth = TileWidth;
   wmsOptions.tileHeight = TileHeight;
+
+  std::vector<CesiumAsync::IAssetAccessor::THeader> headers;
+
+  for (auto& [Key, Value] : this->RequestHeaders) {
+    headers.push_back(CesiumAsync::IAssetAccessor::THeader{
+        TCHAR_TO_UTF8(*Key),
+        TCHAR_TO_UTF8(*Value)});
+  }
+
   return std::make_unique<CesiumRasterOverlays::WebMapServiceRasterOverlay>(
       TCHAR_TO_UTF8(*this->MaterialLayerKey),
       TCHAR_TO_UTF8(*this->BaseUrl),
-      std::vector<CesiumAsync::IAssetAccessor::THeader>(),
+      headers,
       wmsOptions,
       options);
 }

--- a/Source/CesiumRuntime/Private/CesiumWebMapServiceRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumWebMapServiceRasterOverlay.cpp
@@ -24,7 +24,7 @@ UCesiumWebMapServiceRasterOverlay::CreateOverlay(
 
   std::vector<CesiumAsync::IAssetAccessor::THeader> headers;
 
-  for (auto& [Key, Value] : this->RequestHeaders) {
+  for (const auto& [Key, Value] : this->RequestHeaders) {
     headers.push_back(CesiumAsync::IAssetAccessor::THeader{
         TCHAR_TO_UTF8(*Key),
         TCHAR_TO_UTF8(*Value)});

--- a/Source/CesiumRuntime/Private/CesiumWebMapTileServiceRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumWebMapTileServiceRasterOverlay.cpp
@@ -106,7 +106,7 @@ UCesiumWebMapTileServiceRasterOverlay::CreateOverlay(
 
   std::vector<CesiumAsync::IAssetAccessor::THeader> headers;
 
-  for (auto& [Key, Value] : this->RequestHeaders) {
+  for (const auto& [Key, Value] : this->RequestHeaders) {
     headers.push_back(CesiumAsync::IAssetAccessor::THeader{
         TCHAR_TO_UTF8(*Key),
         TCHAR_TO_UTF8(*Value)});

--- a/Source/CesiumRuntime/Private/CesiumWebMapTileServiceRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumWebMapTileServiceRasterOverlay.cpp
@@ -103,10 +103,19 @@ UCesiumWebMapTileServiceRasterOverlay::CreateOverlay(
       wmtsOptions.tileMatrixLabels = labels;
     }
   }
+
+  std::vector<CesiumAsync::IAssetAccessor::THeader> headers;
+
+  for (auto& [Key, Value] : this->RequestHeaders) {
+    headers.push_back(CesiumAsync::IAssetAccessor::THeader{
+        TCHAR_TO_UTF8(*Key),
+        TCHAR_TO_UTF8(*Value)});
+  }
+
   return std::make_unique<CesiumRasterOverlays::WebMapTileServiceRasterOverlay>(
       TCHAR_TO_UTF8(*this->MaterialLayerKey),
       TCHAR_TO_UTF8(*this->BaseUrl),
-      std::vector<CesiumAsync::IAssetAccessor::THeader>(),
+      headers,
       wmtsOptions,
       options);
 }

--- a/Source/CesiumRuntime/Public/CesiumTileMapServiceRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumTileMapServiceRasterOverlay.h
@@ -52,6 +52,12 @@ public:
       meta = (EditCondition = "bSpecifyZoomLevels", ClampMin = 0))
   int32 MaximumLevel = 10;
 
+  /**
+   * HTTP headers to be attached to each request made for this raster overlay.
+   */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
+  TMap<FString, FString> RequestHeaders;
+
 protected:
   virtual std::unique_ptr<CesiumRasterOverlays::RasterOverlay> CreateOverlay(
       const CesiumRasterOverlays::RasterOverlayOptions& options = {}) override;

--- a/Source/CesiumRuntime/Public/CesiumUrlTemplateRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumUrlTemplateRasterOverlay.h
@@ -220,6 +220,12 @@ public:
       meta = (ClampMin = 64, ClampMax = 2048))
   int32 TileHeight = 256;
 
+  /**
+   * HTTP headers to be attached to each request made for this raster overlay.
+   */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
+  TMap<FString, FString> RequestHeaders;
+
 protected:
   virtual std::unique_ptr<CesiumRasterOverlays::RasterOverlay> CreateOverlay(
       const CesiumRasterOverlays::RasterOverlayOptions& options = {}) override;

--- a/Source/CesiumRuntime/Public/CesiumWebMapServiceRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumWebMapServiceRasterOverlay.h
@@ -75,6 +75,12 @@ public:
       meta = (ClampMin = 0))
   int32 MaximumLevel = 14;
 
+  /**
+   * HTTP headers to be attached to each request made for this raster overlay.
+   */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
+  TMap<FString, FString> RequestHeaders;
+
 protected:
   virtual std::unique_ptr<CesiumRasterOverlays::RasterOverlay> CreateOverlay(
       const CesiumRasterOverlays::RasterOverlayOptions& options = {}) override;

--- a/Source/CesiumRuntime/Public/CesiumWebMapTileServiceRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumWebMapTileServiceRasterOverlay.h
@@ -267,6 +267,12 @@ public:
       meta = (ClampMin = 64, ClampMax = 2048))
   int32 TileHeight = 256;
 
+  /**
+   * HTTP headers to be attached to each request made for this raster overlay.
+   */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
+  TMap<FString, FString> RequestHeaders;
+
   virtual void Serialize(FArchive& Ar) override;
 
 protected:


### PR DESCRIPTION
Fixes CesiumGS/cesium-native#1067, at least for Unreal. This change adds `RequestHeaders` properties to `CesiumTileMapServiceRasterOverlay`, `CesiumUrlTemplateRasterOverlay`, `CesiumWebMapServiceRasterOverlay`, and `CesiumWebMapTileServiceRasterOverlay`, allowing custom HTTP request headers to be specified on each.