### PR TITLE
Enum metadata support

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumPropertyTableProperty.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPropertyTableProperty.cpp
@@ -2,6 +2,7 @@
 
 #include "CesiumPropertyTableProperty.h"
 #include "CesiumGltf/MetadataConversions.h"
+#include "CesiumGltf/PropertyEnumValue.h"
 #include "CesiumGltf/PropertyTypeTraits.h"
 #include "UnrealMetadataConversions.h"
 #include <utility>
@@ -756,6 +757,12 @@ TResult arrayPropertyTablePropertyCallback(
         false,
         TResult,
         Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataType::Enum:
+    return propertyTablePropertyCallback<
+        CesiumGltf::PropertyArrayView<CesiumGltf::PropertyEnumValue>,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
   default:
     return callback(CesiumGltf::PropertyTablePropertyView<uint8_t>());
   }
@@ -821,6 +828,12 @@ TResult propertyTablePropertyCallback(
   case ECesiumMetadataType::String:
     return propertyTablePropertyCallback<
         std::string_view,
+        false,
+        TResult,
+        Callback>(property, std::forward<Callback>(callback));
+  case ECesiumMetadataType::Enum:
+    return propertyTablePropertyCallback<
+        CesiumGltf::PropertyEnumValue,
         false,
         TResult,
         Callback>(property, std::forward<Callback>(callback));
@@ -1257,6 +1270,12 @@ FString UCesiumPropertyTablePropertyBlueprintLibrary::GetString(
             CesiumGltf::IsMetadataMatN<ValueType>::value ||
             CesiumGltf::IsMetadataString<ValueType>::value) {
           return UnrealMetadataConversions::toString(value);
+        } else if constexpr (CesiumGltf::IsMetadataEnum<ValueType>::value) {
+          if (v.enumDefinition()) {
+            return UnrealMetadataConversions::toString(
+                value.name(*v.enumDefinition()));
+          }
+          return FString();
         } else {
           auto maybeString = CesiumGltf::
               MetadataConversions<std::string, decltype(value)>::convert(value);

--- a/Source/CesiumRuntime/Private/Tests/CesiumMetadataValue.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumMetadataValue.spec.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020-2024 CesiumGS, Inc. and Contributors
 
 #include "CesiumMetadataValue.h"
+#include "CesiumGltf/PropertyEnumValue.h"
 #include "CesiumPropertyArrayBlueprintLibrary.h"
 #include "Misc/AutomationTest.h"
 
@@ -100,6 +101,18 @@ void FCesiumMetadataValueSpec::Define() {
           valueType.ComponentType,
           ECesiumMetadataComponentType::Uint8);
       TestTrue("IsArray", valueType.bIsArray);
+    });
+
+    It("constructs enum value with correct type", [this]() {
+      FCesiumMetadataValue value(CesiumGltf::PropertyEnumValue(0));
+      FCesiumMetadataValueType valueType =
+          UCesiumMetadataValueBlueprintLibrary::GetValueType(value);
+      TestEqual("Type", valueType.Type, ECesiumMetadataType::Enum);
+      TestEqual(
+          "ComponentType",
+          valueType.ComponentType,
+          ECesiumMetadataComponentType::None);
+      TestFalse("IsArray", valueType.bIsArray);
     });
   });
 
@@ -257,6 +270,14 @@ void FCesiumMetadataValueSpec::Define() {
           -1234);
     });
 
+    It("gets from enum", [this]() {
+      FCesiumMetadataValue value(CesiumGltf::PropertyEnumValue{0xff});
+      TestEqual(
+          "value",
+          UCesiumMetadataValueBlueprintLibrary::GetInteger(value, 0),
+          0xff);
+    });
+
     It("returns default value for out-of-range numbers", [this]() {
       FCesiumMetadataValue value(std::numeric_limits<int64_t>::min());
       TestEqual(
@@ -349,6 +370,17 @@ void FCesiumMetadataValueSpec::Define() {
               value,
               defaultValue),
           static_cast<int64_t>(-1234));
+    });
+
+    It("gets from enum", [this, defaultValue]() {
+      FCesiumMetadataValue value(
+          CesiumGltf::PropertyEnumValue(0x6fffffffffffffff));
+      TestEqual<int64>(
+          "value",
+          UCesiumMetadataValueBlueprintLibrary::GetInteger64(
+              value,
+              defaultValue),
+          static_cast<int64_t>(0x6fffffffffffffff));
     });
 
     It("returns default value for out-of-range numbers",

--- a/Source/CesiumRuntime/Private/Tests/CesiumPropertyArray.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumPropertyArray.spec.cpp
@@ -169,9 +169,9 @@ void FCesiumPropertyArraySpec::Define() {
         TestEqual("type", valueType.Type, ECesiumMetadataType::Enum);
 
         TestEqual(
-            "int64 value",
-            UCesiumMetadataValueBlueprintLibrary::GetInteger64(value, 0),
-            int64_t(values[i]));
+            "int value",
+            UCesiumMetadataValueBlueprintLibrary::GetInteger(value, 0),
+            int32_t(values[i]));
       }
     });
   });

--- a/Source/CesiumRuntime/Private/Tests/CesiumPropertyArray.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumPropertyArray.spec.cpp
@@ -141,5 +141,38 @@ void FCesiumPropertyArraySpec::Define() {
             values[i]);
       }
     });
+
+    It("gets value for enum array", [this]() {
+      std::vector<std::byte> values{
+          std::byte(1),
+          std::byte(2),
+          std::byte(3),
+          std::byte(4)};
+      CesiumGltf::PropertyArrayCopy<CesiumGltf::PropertyEnumValue> arrayView(
+          std::vector(values),
+          CesiumGltf::PropertyComponentType::Uint8,
+          4);
+      FCesiumPropertyArray array(arrayView);
+      TestEqual(
+          "size",
+          UCesiumPropertyArrayBlueprintLibrary::GetSize(array),
+          static_cast<int64>(values.size()));
+
+      for (size_t i = 0; i < values.size(); i++) {
+        FCesiumMetadataValue value =
+            UCesiumPropertyArrayBlueprintLibrary::GetValue(
+                array,
+                static_cast<int64>(i));
+
+        FCesiumMetadataValueType valueType =
+            UCesiumMetadataValueBlueprintLibrary::GetValueType(value);
+        TestEqual("type", valueType.Type, ECesiumMetadataType::Enum);
+
+        TestEqual(
+            "int64 value",
+            UCesiumMetadataValueBlueprintLibrary::GetInteger64(value, 0),
+            int64_t(values[i]));
+      }
+    });
   });
 }

--- a/Source/CesiumRuntime/Public/CesiumMetadataValue.h
+++ b/Source/CesiumRuntime/Public/CesiumMetadataValue.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "CesiumGltf/PropertyEnumValue.h"
 #include "CesiumGltf/PropertyTypeTraits.h"
 #include "CesiumMetadataValueType.h"
 #include "CesiumPropertyArray.h"
@@ -37,6 +38,7 @@ private:
       double,
       bool,
       std::string_view,
+      CesiumGltf::PropertyEnumValue,
       glm::vec<2, int8_t>,
       glm::vec<2, uint8_t>,
       glm::vec<2, int16_t>,
@@ -168,7 +170,8 @@ private:
       ArrayView<glm::mat<4, 4, int64_t>>,
       ArrayView<glm::mat<4, 4, uint64_t>>,
       ArrayView<glm::mat<4, 4, float>>,
-      ArrayView<glm::mat<4, 4, double>>>;
+      ArrayView<glm::mat<4, 4, double>>,
+      ArrayView<CesiumGltf::PropertyEnumValue>>;
 #pragma endregion
 
 public:

--- a/Source/CesiumRuntime/Public/CesiumPropertyArray.h
+++ b/Source/CesiumRuntime/Public/CesiumPropertyArray.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CesiumGltf/PropertyArrayView.h"
+#include "CesiumGltf/PropertyEnumValue.h"
 #include "CesiumGltf/PropertyTypeTraits.h"
 #include "CesiumMetadataValueType.h"
 #include "UObject/ObjectMacros.h"
@@ -93,7 +94,8 @@ private:
       ArrayPropertyView<glm::mat<4, 4, int64_t>>,
       ArrayPropertyView<glm::mat<4, 4, uint64_t>>,
       ArrayPropertyView<glm::mat<4, 4, float>>,
-      ArrayPropertyView<glm::mat<4, 4, double>>>;
+      ArrayPropertyView<glm::mat<4, 4, double>>,
+      ArrayPropertyView<CesiumGltf::PropertyEnumValue>>;
 #pragma endregion
 
 public:


### PR DESCRIPTION
Requires CesiumGS/cesium-native#1085 to be merged before this. This change implements enum support for structural metadata in Unreal. The implementation is fairly simple, the scalar values of enums can be obtained using `UCesiumMetadataValueBlueprintLibrary::GetInteger` or `UCesiumMetadataValueBlueprintLibrary::GetInteger64`. One wrinkle is in obtaining metadata values as strings - the names corresponding to enum values can only be obtained with the corresponding `CesiumGltf::Enum` definition. This means that we can't just call `UCesiumMetadataValueBlueprintLibrary::GetString` on an enum `FCesiumMetadataValue`, since the metadata value itself doesn't contain enough information to resolve the name. Because of this, I've elected to only implement enum support for `UCesiumPropertyTablePropertyBlueprintLibrary::GetString`, as with the property table reference we have enough information to resolve the enum names. It would be nice to have full support for `GetString` on an enum value, but considering our design in Cesium Native I think this might be the best we can do.