### PR TITLE
Update cesium-native, fix breakage caused by new bounding volume.

### DIFF
--- a/Source/CesiumRuntime/Private/CalcBounds.cpp
+++ b/Source/CesiumRuntime/Private/CalcBounds.cpp
@@ -76,3 +76,8 @@ FBoxSphereBounds CalcBoundsOperation::operator()(
     const CesiumGeospatial::S2CellBoundingVolume& s2) const {
   return (*this)(s2.computeBoundingRegion());
 }
+
+FBoxSphereBounds CalcBoundsOperation::operator()(
+    const CesiumGeometry::BoundingCylinderRegion& cylinder) const {
+  return (*this)(cylinder.toOrientedBoundingBox());
+}

--- a/Source/CesiumRuntime/Private/CalcBounds.h
+++ b/Source/CesiumRuntime/Private/CalcBounds.h
@@ -45,4 +45,7 @@ struct CalcBoundsOperation {
 
   FBoxSphereBounds
   operator()(const CesiumGeospatial::S2CellBoundingVolume& s2) const;
+
+  FBoxSphereBounds
+  operator()(const CesiumGeometry::BoundingCylinderRegion& cylinder) const;
 };

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -653,6 +653,11 @@ void ACesium3DTileset::OnFocusEditorViewportOnThis() {
     glm::dvec3 operator()(const CesiumGeospatial::S2CellBoundingVolume& s2) {
       return (*this)(s2.computeBoundingRegion());
     }
+
+    glm::dvec3
+    operator()(const CesiumGeometry::BoundingCylinderRegion& cylinder) {
+      return (*this)(cylinder.toOrientedBoundingBox());
+    }
   };
 
   const Cesium3DTilesSelection::Tile* pRootTile =


### PR DESCRIPTION
With the addition of a new `BoundingCylinderRegion` type to the `BoundingVolume` variant, we need to handle it in a couple of places in Cesium for Unreal or it causes a compiler errors. 