### PR TITLE
Fix broken "Auto Fill" on `UCesiumFeaturesMetadataComponent`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Fixed the "Auto Fill" button on `UCesiumFeaturesMetadataComponent`, which broke with the previous release.
+
 ### v2.14.0 - 2025-03-03
 
 ##### Breaking Changes :mega:

--- a/Source/CesiumRuntime/Private/CesiumFeaturesMetadataComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumFeaturesMetadataComponent.cpp
@@ -376,8 +376,12 @@ void UCesiumFeaturesMetadataComponent::AutoFill() {
     }
 
     const FCesiumModelMetadata& modelMetadata = pGltf->Metadata;
-    AutoFillPropertyTableDescriptions(this->PropertyTables, modelMetadata);
-    AutoFillPropertyTextureDescriptions(this->PropertyTextures, modelMetadata);
+    AutoFillPropertyTableDescriptions(
+        this->Description.ModelMetadata.PropertyTables,
+        modelMetadata);
+    AutoFillPropertyTextureDescriptions(
+        this->Description.ModelMetadata.PropertyTextures,
+        modelMetadata);
 
     TArray<USceneComponent*> childComponents;
     pGltf->GetChildrenComponents(false, childComponents);
@@ -400,7 +404,7 @@ void UCesiumFeaturesMetadataComponent::AutoFill() {
         pInstanceFeatures = pInstancedComponent->pInstanceFeatures.Get();
       }
       AutoFillFeatureIdSetDescriptions(
-          this->FeatureIdSets,
+          this->Description.PrimitiveFeatures.FeatureIdSets,
           primitiveFeatures,
           pInstanceFeatures,
           propertyTables);
@@ -410,7 +414,7 @@ void UCesiumFeaturesMetadataComponent::AutoFill() {
           UCesiumModelMetadataBlueprintLibrary::GetPropertyTextures(
               modelMetadata);
       AutoFillPropertyTextureNames(
-          this->PropertyTextureNames,
+          this->Description.PrimitiveMetadata.PropertyTextureNames,
           primitiveMetadata,
           propertyTextures);
     }


### PR DESCRIPTION
Sorry that I missed this in #1616. I didn't push changes that rewired the new field of `CesiumFeaturesMetadataComponent` in `AutoFill()`, so the button doesn't work on `main`.

Since this is breaking it probably rewarrants a re-release 😬 