### PR TITLE
User-defined credit text for tileset, with priority

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1077,6 +1077,10 @@ void ACesium3DTileset::LoadTileset() {
 
   options.contentOptions.applyTextureTransform = false;
 
+  if (!this->UserCredit.IsEmpty()) {
+      options.credit = TCHAR_TO_UTF8(*this->UserCredit);
+  }
+
   options.requestHeaders.reserve(this->RequestHeaders.Num());
 
   for (const auto& [Key, Value] : this->RequestHeaders) {

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1079,6 +1079,12 @@ void ACesium3DTileset::LoadTileset() {
 
   if (!this->UserCredit.IsEmpty()) {
       options.credit = TCHAR_TO_UTF8(*this->UserCredit);
+      if (this->bHighPriorityUserCredit) {
+          // Set a custom priority so that the user-defined credit always appears
+          // on the left (for now, any value greater than -1 would work, but if
+          // the priority system is generalized, one would need to rework this...)
+          options.creditPriority = 10;
+      }
   }
 
   options.requestHeaders.reserve(this->RequestHeaders.Num());

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -314,6 +314,12 @@ public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
   bool ShowCreditsOnScreen = false;
 
+  /**
+   * Optional user-defined credit text for the tileset.
+   */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
+  FString UserCredit;
+
   /** @copydoc ACesium3DTileset::CameraManager */
   UFUNCTION(BlueprintGetter, Category = "Cesium")
   TSoftObjectPtr<ACesiumCameraManager> GetCameraManager() const;

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -320,6 +320,14 @@ public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
   FString UserCredit;
 
+  /**
+   * If true, the user-defined credit text will have a high priority (i.e will
+   * be on the left, before the credit texts deduced from the currently viewed
+   * tiles).
+   */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
+  bool bHighPriorityUserCredit = false;
+
   /** @copydoc ACesium3DTileset::CameraManager */
   UFUNCTION(BlueprintGetter, Category = "Cesium")
   TSoftObjectPtr<ACesiumCameraManager> GetCameraManager() const;


### PR DESCRIPTION
- Add access to user-defined credit text in Unreal
- Add option to prioritize this user-defined credit text, by leveraging  [CesiumGS/cesium-native/1128](https://github.com/CesiumGS/cesium-native/pull/1128)