### PR TITLE
Metadata: retrieve a property by name in c++

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumMetadataPropertyAccess.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMetadataPropertyAccess.cpp
@@ -1,0 +1,45 @@
+// Copyright 2020-2023 CesiumGS, Inc. and Contributors
+
+#include "CesiumMetadataPropertyAccess.h"
+
+#include "CesiumFeatureIdSet.h"
+#include "CesiumModelMetadata.h"
+#include "CesiumPrimitiveFeatures.h"
+
+/*static*/
+const FCesiumPropertyTableProperty*
+FCesiumMetadataPropertyAccess::FindValidProperty(
+    const FCesiumPrimitiveFeatures& Features,
+    const FCesiumModelMetadata& Metadata,
+    const FString& PropertyName,
+    int64 FeatureIDSetIndex) {
+  const TArray<FCesiumFeatureIdSet>& featureIDSets =
+      UCesiumPrimitiveFeaturesBlueprintLibrary::GetFeatureIDSets(Features);
+
+  if (FeatureIDSetIndex < 0 || FeatureIDSetIndex >= featureIDSets.Num()) {
+    return nullptr;
+  }
+
+  const FCesiumFeatureIdSet& featureIDSet =
+      featureIDSets[FeatureIDSetIndex];
+  const int64 propertyTableIndex =
+      UCesiumFeatureIdSetBlueprintLibrary::GetPropertyTableIndex(
+          featureIDSet);
+
+  const TArray<FCesiumPropertyTable>& propertyTables =
+      UCesiumModelMetadataBlueprintLibrary::GetPropertyTables(Metadata);
+  if (propertyTableIndex < 0 || propertyTableIndex >= propertyTables.Num()) {
+    return nullptr;
+  }
+  const FCesiumPropertyTableProperty& propWithName =
+      UCesiumPropertyTableBlueprintLibrary::FindProperty(
+          propertyTables[propertyTableIndex],
+          PropertyName);
+  const ECesiumPropertyTablePropertyStatus status =
+      UCesiumPropertyTablePropertyBlueprintLibrary::
+          GetPropertyTablePropertyStatus(propWithName);
+  if (status != ECesiumPropertyTablePropertyStatus::Valid) {
+    return nullptr;
+  }
+  return &propWithName;
+}

--- a/Source/CesiumRuntime/Public/CesiumMetadataPropertyAccess.h
+++ b/Source/CesiumRuntime/Public/CesiumMetadataPropertyAccess.h
@@ -1,0 +1,24 @@
+// Copyright 2020-2023 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "Containers/UnrealString.h"
+
+struct FCesiumPrimitiveFeatures;
+struct FCesiumModelMetadata;
+struct FCesiumPropertyTableProperty;
+
+class CESIUMRUNTIME_API FCesiumMetadataPropertyAccess {
+
+public:
+  /**
+   * Retrieves a property by name.
+   * If the specified feature ID set does not exist or if the property table
+   * does not contain a property with that name, this function returns nullptr.
+   */
+  static const FCesiumPropertyTableProperty* FindValidProperty(
+      const FCesiumPrimitiveFeatures& Features,
+      const FCesiumModelMetadata& Metadata,
+      const FString& PropertyName,
+      int64 FeatureIDSetIndex = 0);
+};


### PR DESCRIPTION
This can be useful when we need to retrieve a given property for a large amount of faces, as it is much faster than calling GetMetadataValuesForFace for each face (which allocates a TMap and makes the same validity test each time)