### PR TITLE
Metadata: GetUnsignedInteger64

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumMetadataValue.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMetadataValue.cpp
@@ -128,18 +128,6 @@ int64 UCesiumMetadataValueBlueprintLibrary::GetInteger64(
       Value._value);
 }
 
-uint64 FCesiumMetadataValueAccess::GetUnsignedInteger64(
-    const FCesiumMetadataValue& Value,
-    uint64 DefaultValue) {
-  return swl::visit(
-      [DefaultValue](auto value) -> uint64 {
-        return CesiumGltf::MetadataConversions<uint64_t, decltype(value)>::
-            convert(value)
-                .value_or(DefaultValue);
-      },
-      Value._value);
-}
-
 float UCesiumMetadataValueBlueprintLibrary::GetFloat(
     UPARAM(ref) const FCesiumMetadataValue& Value,
     float DefaultValue) {
@@ -344,4 +332,17 @@ TMap<FString, FString> UCesiumMetadataValueBlueprintLibrary::GetValuesAsStrings(
   }
 
   return strings;
+}
+
+
+uint64 CesiumMetadataValueAccess::GetUnsignedInteger64(
+    const FCesiumMetadataValue& Value,
+    uint64 DefaultValue) {
+  return swl::visit(
+      [DefaultValue](auto value) -> uint64 {
+        return CesiumGltf::MetadataConversions<uint64_t, decltype(value)>::
+            convert(value)
+                .value_or(DefaultValue);
+      },
+      Value._value);
 }

--- a/Source/CesiumRuntime/Private/CesiumMetadataValue.cpp
+++ b/Source/CesiumRuntime/Private/CesiumMetadataValue.cpp
@@ -128,6 +128,18 @@ int64 UCesiumMetadataValueBlueprintLibrary::GetInteger64(
       Value._value);
 }
 
+uint64 FCesiumMetadataValueAccess::GetUnsignedInteger64(
+    const FCesiumMetadataValue& Value,
+    uint64 DefaultValue) {
+  return swl::visit(
+      [DefaultValue](auto value) -> uint64 {
+        return CesiumGltf::MetadataConversions<uint64_t, decltype(value)>::
+            convert(value)
+                .value_or(DefaultValue);
+      },
+      Value._value);
+}
+
 float UCesiumMetadataValueBlueprintLibrary::GetFloat(
     UPARAM(ref) const FCesiumMetadataValue& Value,
     float DefaultValue) {

--- a/Source/CesiumRuntime/Private/Tests/CesiumMetadataValue.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumMetadataValue.spec.cpp
@@ -408,7 +408,7 @@ void FCesiumMetadataValueSpec::Define() {
 
       value = FCesiumMetadataValue(std::numeric_limits<int64_t>::max() - 1);
       TestEqual<uint64_t>(
-          "uint64_t",
+          "int64_t",
           FCesiumMetadataValueAccess::GetUnsignedInteger64(
               value,
               defaultValue),

--- a/Source/CesiumRuntime/Private/Tests/CesiumMetadataValue.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumMetadataValue.spec.cpp
@@ -394,101 +394,6 @@ void FCesiumMetadataValueSpec::Define() {
        });
   });
 
-  Describe("GetUnsignedInteger64", [this]() {
-    const uint64_t defaultValue = static_cast<uint64_t>(0);
-
-    It("gets from in-range integers", [this, defaultValue]() {
-      FCesiumMetadataValue value(std::numeric_limits<uint64_t>::max() - 1);
-      TestEqual<uint64_t>(
-          "uint64_t",
-          FCesiumMetadataValueAccess::GetUnsignedInteger64(
-              value,
-              defaultValue),
-          std::numeric_limits<uint64_t>::max() - 1);
-
-      value = FCesiumMetadataValue(std::numeric_limits<int64_t>::max() - 1);
-      TestEqual<uint64_t>(
-          "int64_t",
-          FCesiumMetadataValueAccess::GetUnsignedInteger64(
-              value,
-              defaultValue),
-          static_cast<uint64_t>(std::numeric_limits<int64_t>::max() - 1));
-
-      value = FCesiumMetadataValue(static_cast<int16_t>(12345));
-      TestEqual<uint64_t>(
-          "smaller signed integer",
-          FCesiumMetadataValueAccess::GetUnsignedInteger64(
-              value,
-              defaultValue),
-          static_cast<uint64_t>(12345));
-
-      value = FCesiumMetadataValue(static_cast<uint8_t>(255));
-      TestEqual<uint64_t>(
-          "smaller unsigned integer",
-          FCesiumMetadataValueAccess::GetUnsignedInteger64(
-              value,
-              defaultValue),
-          static_cast<uint64_t>(255));
-    });
-
-    It("gets from boolean", [this, defaultValue]() {
-      FCesiumMetadataValue value(true);
-      TestEqual<uint64_t>(
-          "value",
-          FCesiumMetadataValueAccess::GetUnsignedInteger64(
-              value,
-              defaultValue),
-          static_cast<uint64_t>(1));
-    });
-
-    It("gets from in-range floating point number", [this, defaultValue]() {
-      FCesiumMetadataValue value(1234.56f);
-      TestEqual<uint64_t>(
-          "float",
-          FCesiumMetadataValueAccess::GetUnsignedInteger64(
-              value,
-              defaultValue),
-          static_cast<uint64_t>(1234));
-    });
-
-    It("gets from string", [this, defaultValue]() {
-      FCesiumMetadataValue value(std::string_view("1234"));
-      TestEqual<uint64_t>(
-          "value",
-          FCesiumMetadataValueAccess::GetUnsignedInteger64(
-              value,
-              defaultValue),
-          static_cast<uint64_t>(1234));
-    });
-
-    It("returns default value for out-of-range numbers",
-       [this, defaultValue]() {
-         FCesiumMetadataValue value(-5);
-         TestEqual<uint64_t>(
-             "negative integer",
-             FCesiumMetadataValueAccess::GetUnsignedInteger64(
-                 value,
-                 defaultValue),
-             defaultValue);
-
-         value = FCesiumMetadataValue(-59.62f);
-         TestEqual<uint64_t>(
-             "negative floating-point number",
-             FCesiumMetadataValueAccess::GetUnsignedInteger64(
-                 value,
-                 defaultValue),
-             defaultValue);
-
-         value = FCesiumMetadataValue(std::numeric_limits<float>::max());
-         TestEqual<uint64_t>(
-             "positive floating-point number",
-             FCesiumMetadataValueAccess::GetUnsignedInteger64(
-                 value,
-                 defaultValue),
-             defaultValue);
-       });
-  });
-
   Describe("GetFloat", [this]() {
     It("gets from in-range floating point number", [this]() {
       FCesiumMetadataValue value(1234.56f);
@@ -1360,5 +1265,86 @@ void FCesiumMetadataValueSpec::Define() {
       TestTrue("has array value", pString != nullptr);
       TestEqual("array value as string", *pString, FString());
     });
+  });
+
+  Describe("GetUnsignedInteger64", [this]() {
+    const uint64_t defaultValue = static_cast<uint64_t>(0);
+
+    It("gets from in-range integers", [this, defaultValue]() {
+      FCesiumMetadataValue value(std::numeric_limits<uint64_t>::max() - 1);
+      TestEqual<uint64_t>(
+          "uint64_t",
+          CesiumMetadataValueAccess::GetUnsignedInteger64(value, defaultValue),
+          std::numeric_limits<uint64_t>::max() - 1);
+
+      value = FCesiumMetadataValue(std::numeric_limits<int64_t>::max() - 1);
+      TestEqual<uint64_t>(
+          "int64_t",
+          CesiumMetadataValueAccess::GetUnsignedInteger64(value, defaultValue),
+          static_cast<uint64_t>(std::numeric_limits<int64_t>::max() - 1));
+
+      value = FCesiumMetadataValue(static_cast<int16_t>(12345));
+      TestEqual<uint64_t>(
+          "smaller signed integer",
+          CesiumMetadataValueAccess::GetUnsignedInteger64(value, defaultValue),
+          static_cast<uint64_t>(12345));
+
+      value = FCesiumMetadataValue(static_cast<uint8_t>(255));
+      TestEqual<uint64_t>(
+          "smaller unsigned integer",
+          CesiumMetadataValueAccess::GetUnsignedInteger64(value, defaultValue),
+          static_cast<uint64_t>(255));
+    });
+
+    It("gets from boolean", [this, defaultValue]() {
+      FCesiumMetadataValue value(true);
+      TestEqual<uint64_t>(
+          "value",
+          CesiumMetadataValueAccess::GetUnsignedInteger64(value, defaultValue),
+          static_cast<uint64_t>(1));
+    });
+
+    It("gets from in-range floating point number", [this, defaultValue]() {
+      FCesiumMetadataValue value(1234.56f);
+      TestEqual<uint64_t>(
+          "float",
+          CesiumMetadataValueAccess::GetUnsignedInteger64(value, defaultValue),
+          static_cast<uint64_t>(1234));
+    });
+
+    It("gets from string", [this, defaultValue]() {
+      FCesiumMetadataValue value(std::string_view("1234"));
+      TestEqual<uint64_t>(
+          "value",
+          CesiumMetadataValueAccess::GetUnsignedInteger64(value, defaultValue),
+          static_cast<uint64_t>(1234));
+    });
+
+    It("returns default value for out-of-range numbers",
+       [this, defaultValue]() {
+         FCesiumMetadataValue value(-5);
+         TestEqual<uint64_t>(
+             "negative integer",
+             CesiumMetadataValueAccess::GetUnsignedInteger64(
+                 value,
+                 defaultValue),
+             defaultValue);
+
+         value = FCesiumMetadataValue(-59.62f);
+         TestEqual<uint64_t>(
+             "negative floating-point number",
+             CesiumMetadataValueAccess::GetUnsignedInteger64(
+                 value,
+                 defaultValue),
+             defaultValue);
+
+         value = FCesiumMetadataValue(std::numeric_limits<float>::max());
+         TestEqual<uint64_t>(
+             "positive floating-point number",
+             CesiumMetadataValueAccess::GetUnsignedInteger64(
+                 value,
+                 defaultValue),
+             defaultValue);
+       });
   });
 }

--- a/Source/CesiumRuntime/Private/Tests/CesiumMetadataValue.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumMetadataValue.spec.cpp
@@ -394,6 +394,101 @@ void FCesiumMetadataValueSpec::Define() {
        });
   });
 
+  Describe("GetUnsignedInteger64", [this]() {
+    const uint64_t defaultValue = static_cast<uint64_t>(0);
+
+    It("gets from in-range integers", [this, defaultValue]() {
+      FCesiumMetadataValue value(std::numeric_limits<uint64_t>::max() - 1);
+      TestEqual<uint64_t>(
+          "uint64_t",
+          FCesiumMetadataValueAccess::GetUnsignedInteger64(
+              value,
+              defaultValue),
+          std::numeric_limits<uint64_t>::max() - 1);
+
+      value = FCesiumMetadataValue(std::numeric_limits<int64_t>::max() - 1);
+      TestEqual<uint64_t>(
+          "uint64_t",
+          FCesiumMetadataValueAccess::GetUnsignedInteger64(
+              value,
+              defaultValue),
+          static_cast<uint64_t>(std::numeric_limits<int64_t>::max() - 1));
+
+      value = FCesiumMetadataValue(static_cast<int16_t>(12345));
+      TestEqual<uint64_t>(
+          "smaller signed integer",
+          FCesiumMetadataValueAccess::GetUnsignedInteger64(
+              value,
+              defaultValue),
+          static_cast<uint64_t>(12345));
+
+      value = FCesiumMetadataValue(static_cast<uint8_t>(255));
+      TestEqual<uint64_t>(
+          "smaller unsigned integer",
+          FCesiumMetadataValueAccess::GetUnsignedInteger64(
+              value,
+              defaultValue),
+          static_cast<uint64_t>(255));
+    });
+
+    It("gets from boolean", [this, defaultValue]() {
+      FCesiumMetadataValue value(true);
+      TestEqual<uint64_t>(
+          "value",
+          FCesiumMetadataValueAccess::GetUnsignedInteger64(
+              value,
+              defaultValue),
+          static_cast<uint64_t>(1));
+    });
+
+    It("gets from in-range floating point number", [this, defaultValue]() {
+      FCesiumMetadataValue value(1234.56f);
+      TestEqual<uint64_t>(
+          "float",
+          FCesiumMetadataValueAccess::GetUnsignedInteger64(
+              value,
+              defaultValue),
+          static_cast<uint64_t>(1234));
+    });
+
+    It("gets from string", [this, defaultValue]() {
+      FCesiumMetadataValue value(std::string_view("1234"));
+      TestEqual<uint64_t>(
+          "value",
+          FCesiumMetadataValueAccess::GetUnsignedInteger64(
+              value,
+              defaultValue),
+          static_cast<uint64_t>(1234));
+    });
+
+    It("returns default value for out-of-range numbers",
+       [this, defaultValue]() {
+         FCesiumMetadataValue value(-5);
+         TestEqual<uint64_t>(
+             "negative integer",
+             FCesiumMetadataValueAccess::GetUnsignedInteger64(
+                 value,
+                 defaultValue),
+             defaultValue);
+
+         value = FCesiumMetadataValue(-59.62f);
+         TestEqual<uint64_t>(
+             "negative floating-point number",
+             FCesiumMetadataValueAccess::GetUnsignedInteger64(
+                 value,
+                 defaultValue),
+             defaultValue);
+
+         value = FCesiumMetadataValue(std::numeric_limits<float>::max());
+         TestEqual<uint64_t>(
+             "positive floating-point number",
+             FCesiumMetadataValueAccess::GetUnsignedInteger64(
+                 value,
+                 defaultValue),
+             defaultValue);
+       });
+  });
+
   Describe("GetFloat", [this]() {
     It("gets from in-range floating point number", [this]() {
       FCesiumMetadataValue value(1234.56f);

--- a/Source/CesiumRuntime/Public/CesiumMetadataValue.h
+++ b/Source/CesiumRuntime/Public/CesiumMetadataValue.h
@@ -266,6 +266,7 @@ private:
   TSharedPtr<FCesiumMetadataEnum> _pEnumDefinition;
 
   friend class UCesiumMetadataValueBlueprintLibrary;
+  friend class FCesiumMetadataValueAccess;
 };
 
 UCLASS()
@@ -858,4 +859,40 @@ public:
       Category = "Cesium|Metadata|Value")
   static TMap<FString, FString>
   GetValuesAsStrings(const TMap<FString, FCesiumMetadataValue>& Values);
+};
+
+/// Grants access to metadata value types not currently supported in blueprint.
+/// Can be useful in C++ code.
+/// Should be moved to UCesiumMetadataValueBlueprintLibrary if those types
+/// become compatible with blueprints in the future.
+class CESIUMRUNTIME_API FCesiumMetadataValueAccess {
+
+public:
+  /**
+   * Attempts to retrieve the value as an unsigned 64-bit integer.
+   *
+   * If the value is an integer and between 0 and (2^64 - 1),
+   * it is returned as-is.
+   *
+   * If the value is a floating-point number in the aforementioned range, it
+   * is truncated (rounded toward zero) and returned;
+   *
+   * If the value is a boolean, 1 is returned for true and 0 for false.
+   *
+   * If the value is a string and the entire string can be parsed as an
+   * integer in the valid range, the parsed value is returned. If it can be
+   * parsed as a floating-point number, the parsed value is truncated (rounded
+   * toward zero). In either case, the string is parsed in a locale-independent
+   * way and does not support the use of commas or other delimiters to group
+   * digits together.
+   *
+   * In all other cases, the default value is returned.
+   *
+   * @param DefaultValue The default value to use if the given value cannot
+   * be converted to an uint64.
+   * @return The value as an unsigned 64-bit integer.
+   */
+  static uint64 GetUnsignedInteger64(
+      const FCesiumMetadataValue& Value,
+      uint64 DefaultValue);
 };

--- a/Source/CesiumRuntime/Public/CesiumMetadataValue.h
+++ b/Source/CesiumRuntime/Public/CesiumMetadataValue.h
@@ -868,7 +868,7 @@ public:
  * These should be moved to UCesiumMetadataValueBlueprintLibrary if those types
  * become compatible with Blueprints in the future.
  */
-class CESIUMRUNTIME_API FCesiumMetadataValueAccess {
+class CESIUMRUNTIME_API CesiumMetadataValueAccess {
 
 public:
   /**

--- a/Source/CesiumRuntime/Public/CesiumMetadataValue.h
+++ b/Source/CesiumRuntime/Public/CesiumMetadataValue.h
@@ -861,10 +861,13 @@ public:
   GetValuesAsStrings(const TMap<FString, FCesiumMetadataValue>& Values);
 };
 
-/// Grants access to metadata value types not currently supported in blueprint.
-/// Can be useful in C++ code.
-/// Should be moved to UCesiumMetadataValueBlueprintLibrary if those types
-/// become compatible with blueprints in the future.
+/**
+ * Grants access to metadata value types that are not currently supported in
+ * Blueprints. This can be useful in C++ code.
+ *
+ * These should be moved to UCesiumMetadataValueBlueprintLibrary if those types
+ * become compatible with Blueprints in the future.
+ */
 class CESIUMRUNTIME_API FCesiumMetadataValueAccess {
 
 public:

--- a/Source/CesiumRuntime/Public/CesiumMetadataValue.h
+++ b/Source/CesiumRuntime/Public/CesiumMetadataValue.h
@@ -266,7 +266,7 @@ private:
   TSharedPtr<FCesiumMetadataEnum> _pEnumDefinition;
 
   friend class UCesiumMetadataValueBlueprintLibrary;
-  friend class FCesiumMetadataValueAccess;
+  friend class CesiumMetadataValueAccess;
 };
 
 UCLASS()


### PR DESCRIPTION
- Added an access to meta-data values as unsigned 64-bit integer
- Kept outside of UCesiumMetadataValueBlueprintLibrary because uint64 is not supported in blueprints (but this access can be useful in C++ code)