### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+<!--
+Thanks for the Pull Request!
+
+Please review the [Contributor Guide](https://cesium.com/learn/cesium-unreal/ref-doc/contributing-unreal.html) before opening your first Pull Request.
+
+To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://cesium.com/learn/cesium-unreal/ref-doc/contributing-unreal.html#opening-a-pull-request).
+
+-->
+
+## Description
+
+<!-- Summarize the pull request. -- >
+
+< !-- Provide context for the reviewer to understand the pull request. Include what changes were made and why. -->
+
+<!-- Mention any lingering questions -->
+
+<!-- Include screenshots if appropriate -->
+
+## Issue number or link
+
+<!-- If it fixes an open issue, link to the issue here -->
+
+<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->
+
+## Author checklist
+
+- [ ] I submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs).
+- [ ] I did a full self-review of my code.
+- [ ] I updated `CHANGES.md` with a short summary of my change (for user-facing changes).
+- [ ] I added or updated unit tests to ensure consistent code coverage when necessary.
+- [ ] I updated the documentation when necessary.
+
+## Remaining Tasks
+
+<!-- Are there any remaining tasks to do or blocking questions to answer before we can merge this? -->
+
+<!-- If so, please convert this to a draft PR and let us know how we can help. Otherwise, you may remove this section. -->
+
+## Testing plan
+
+<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->
+
+<!-- Include links to any required data or screenshots. Mention any edge cases such as user error, invalid data, etc. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,11 +23,11 @@ To ensure your Pull Request is reviewed and accepted quickly, please refer to ou
 
 ## Author checklist
 
-- [ ] I submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs).
-- [ ] I did a full self-review of my code.
-- [ ] I updated `CHANGES.md` with a short summary of my change (for user-facing changes).
-- [ ] I added or updated unit tests to ensure consistent code coverage when necessary.
-- [ ] I updated the documentation when necessary.
+- [ ] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
+- [ ] I have done a full self-review of my code.
+- [ ] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
+- [ ] I have added or updated unit tests to ensure consistent code coverage as necessary.
+- [ ] I have updated the documentation as necessary.
 
 ## Remaining Tasks
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,9 +13,7 @@ To ensure your Pull Request is reviewed and accepted quickly, please refer to ou
 
 < !-- Provide context for the reviewer to understand the pull request. Include what changes were made and why. -->
 
-<!-- Mention any lingering questions -->
-
-<!-- Include screenshots if appropriate -->
+<!-- Include screenshots if appropriate. -->
 
 ## Issue number or link
 


### PR DESCRIPTION
This adds a PR template to streamline the PR opening + reviewing process. It includes clearly marked sections for the contributor to describe the impact of their PR, as well as an author checklist. This is adapted from existing examples such as the [CesiumJS PR template](https://github.com/CesiumGS/cesium/blob/main/.github/pull_request_template.md).

Contributors are encouraged to self-review before a reviewer looks over their PR, with the intent to reduce the amount of back-and-forth between reviewers and contributors. This will hopefully improve the small logistics we commonly point out (sign CLA, update CHANGES.md, etc.) and expedite the review process.
