### PR TITLE
Add support for loading and interacting with GeoJSON data in Blueprint

### DIFF
--- a/Source/CesiumRuntime/CesiumRuntime.Build.cs
+++ b/Source/CesiumRuntime/CesiumRuntime.Build.cs
@@ -91,7 +91,9 @@ public class CesiumRuntime : ModuleRules
                 "DeveloperSettings",
                 "UMG",
                 "Renderer",
-                "OpenSSL"
+                "OpenSSL",
+                "Json",
+                "JsonUtilities"
             }
         );
 

--- a/Source/CesiumRuntime/Private/CesiumCartographicPolygon.cpp
+++ b/Source/CesiumRuntime/Private/CesiumCartographicPolygon.cpp
@@ -48,7 +48,7 @@ ACesiumCartographicPolygon::CreateCartographicPolygon(
   int32 splinePointsCount = this->Polygon->GetNumberOfSplinePoints();
 
   if (splinePointsCount < 3) {
-    return CartographicPolygon({});
+    return CartographicPolygon(std::vector<glm::dvec2>{});
   }
 
   std::vector<glm::dvec2> polygon(splinePointsCount);

--- a/Source/CesiumRuntime/Private/CesiumVectorDocument.cpp
+++ b/Source/CesiumRuntime/Private/CesiumVectorDocument.cpp
@@ -1,0 +1,41 @@
+#include "CesiumVectorDocument.h"
+#include "CesiumRuntime.h"
+
+#include "CesiumUtility/Result.h"
+
+#include <span>
+
+bool UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+    const FString& InString,
+    FCesiumVectorDocument& OutVectorDocument) {
+  const std::string str = TCHAR_TO_UTF8(*InString);
+  std::span<const std::byte> bytes(
+      reinterpret_cast<const std::byte*>(str.data()),
+      str.size());
+  CesiumUtility::Result<CesiumVectorData::VectorDocument> documentResult =
+      CesiumVectorData::VectorDocument::fromGeoJson(bytes);
+
+  if (!documentResult.errors.errors.empty()) {
+    documentResult.errors.logError(
+        spdlog::default_logger(),
+        "Errors while loading GeoJSON from string");
+  }
+
+  if (!documentResult.errors.warnings.empty()) {
+    documentResult.errors.logWarning(
+        spdlog::default_logger(),
+        "Warnings while loading GeoJSON from string");
+  }
+
+  if (documentResult.value) {
+    OutVectorDocument = FCesiumVectorDocument(std::move(*documentResult.value));
+    return true;
+  }
+
+  return false;
+}
+
+FCesiumVectorNode UCesiumVectorDocumentBlueprintLibrary::GetRootNode(
+    const FCesiumVectorDocument& InVectorDocument) {
+  return FCesiumVectorNode(InVectorDocument._document.getRootNode());
+}

--- a/Source/CesiumRuntime/Private/CesiumVectorNode.cpp
+++ b/Source/CesiumRuntime/Private/CesiumVectorNode.cpp
@@ -76,9 +76,9 @@ jsonValueToUnrealJsonValue(const CesiumUtility::JsonValue& value) {
     }
     TSharedPtr<FJsonValue>
     operator()(const CesiumUtility::JsonValue::Object& value) {
-      FJsonObject obj;
+      TSharedPtr<FJsonObject> obj = MakeShared<FJsonObject>();
       for (const auto& [k, v] : value) {
-        obj.SetField(UTF8_TO_TCHAR(k.c_str()), jsonValueToUnrealJsonValue(v));
+        obj->SetField(UTF8_TO_TCHAR(k.c_str()), jsonValueToUnrealJsonValue(v));
       }
       return MakeShared<FJsonValueObject>(MoveTemp(obj));
     };

--- a/Source/CesiumRuntime/Private/CesiumVectorNode.cpp
+++ b/Source/CesiumRuntime/Private/CesiumVectorNode.cpp
@@ -30,6 +30,17 @@ FString UCesiumVectorNodeBlueprintLibrary::GetIdAsString(
   return std::visit(GetIdVisitor{}, InVectorNode._node.id);
 }
 
+TArray<FCesiumVectorNode> UCesiumVectorNodeBlueprintLibrary::GetChildren(
+    const FCesiumVectorNode& InVectorNode) {
+  TArray<FCesiumVectorNode> children;
+  children.Reserve(InVectorNode._node.children.size());
+  for (const CesiumVectorData::VectorNode& child :
+       InVectorNode._node.children) {
+    children.Emplace(child);
+  }
+  return children;
+}
+
 TArray<FCesiumVectorPrimitive> UCesiumVectorNodeBlueprintLibrary::GetPrimitives(
     const FCesiumVectorNode& InVectorNode) {
   TArray<FCesiumVectorPrimitive> primitives;

--- a/Source/CesiumRuntime/Private/CesiumVectorNode.cpp
+++ b/Source/CesiumRuntime/Private/CesiumVectorNode.cpp
@@ -1,0 +1,137 @@
+#include "CesiumVectorNode.h"
+
+#include "CesiumGeospatial/Cartographic.h"
+#include "CesiumGeospatial/CompositeCartographicPolygon.h"
+
+#include <utility>
+#include <variant>
+#include <vector>
+
+int64 UCesiumVectorNodeBlueprintLibrary::GetIdAsInteger(
+    const FCesiumVectorNode& InVectorNode) {
+  const int64_t* pId = std::get_if<int64_t>(&InVectorNode._node.id);
+  if (!pId) {
+    return -1;
+  }
+
+  return *pId;
+}
+
+FString UCesiumVectorNodeBlueprintLibrary::GetIdAsString(
+    const FCesiumVectorNode& InVectorNode) {
+  struct GetIdVisitor {
+    FString operator()(const int64_t& id) { return FString::FromInt(id); }
+    FString operator()(const std::string& id) {
+      return UTF8_TO_TCHAR(id.c_str());
+    }
+    FString operator()(const std::monostate& id) { return FString(); }
+  };
+
+  return std::visit(GetIdVisitor{}, InVectorNode._node.id);
+}
+
+TArray<FCesiumVectorPrimitive> UCesiumVectorNodeBlueprintLibrary::GetPrimitives(
+    const FCesiumVectorNode& InVectorNode) {
+  TArray<FCesiumVectorPrimitive> primitives;
+  primitives.Reserve(InVectorNode._node.primitives.size());
+  for (const CesiumVectorData::VectorPrimitive& primitive :
+       InVectorNode._node.primitives) {
+    primitives.Emplace(primitive);
+  }
+  return primitives;
+}
+
+TArray<FCesiumVectorPrimitive>
+UCesiumVectorNodeBlueprintLibrary::GetPrimitivesOfType(
+    const FCesiumVectorNode& InVectorNode,
+    ECesiumVectorPrimitiveType InType) {
+  struct CheckTypeVisitor {
+    ECesiumVectorPrimitiveType IntendedType;
+    bool operator()(const CesiumGeospatial::Cartographic&) {
+      return IntendedType == ECesiumVectorPrimitiveType::Point;
+    }
+    bool operator()(const std::vector<CesiumGeospatial::Cartographic>&) {
+      return IntendedType == ECesiumVectorPrimitiveType::Line;
+    }
+    bool operator()(const CesiumGeospatial::CompositeCartographicPolygon&) {
+      return IntendedType == ECesiumVectorPrimitiveType::Polygon;
+    }
+  };
+
+  TArray<FCesiumVectorPrimitive> primitives;
+  for (const CesiumVectorData::VectorPrimitive& primitive :
+       InVectorNode._node.primitives) {
+    if (std::visit(CheckTypeVisitor{InType}, primitive)) {
+      primitives.Emplace(primitive);
+    }
+  }
+
+  return primitives;
+}
+
+ECesiumVectorPrimitiveType
+UCesiumVectorPrimitiveBlueprintLibrary::GetPrimitiveType(
+    const FCesiumVectorPrimitive& InPrimitive) {
+  struct GetTypeVisitor {
+    ECesiumVectorPrimitiveType
+    operator()(const CesiumGeospatial::Cartographic&) {
+      return ECesiumVectorPrimitiveType::Point;
+    }
+    ECesiumVectorPrimitiveType
+    operator()(const std::vector<CesiumGeospatial::Cartographic>&) {
+      return ECesiumVectorPrimitiveType::Line;
+    }
+    ECesiumVectorPrimitiveType
+    operator()(const CesiumGeospatial::CompositeCartographicPolygon&) {
+      return ECesiumVectorPrimitiveType::Polygon;
+    }
+  };
+
+  return std::visit(GetTypeVisitor{}, InPrimitive._primitive);
+}
+
+FVector UCesiumVectorPrimitiveBlueprintLibrary::GetPrimitiveAsPoint(
+    const FCesiumVectorPrimitive& InPrimitive) {
+  const CesiumGeospatial::Cartographic* pCartographic =
+      std::get_if<CesiumGeospatial::Cartographic>(&InPrimitive._primitive);
+  if (!pCartographic) {
+    return FVector::ZeroVector;
+  }
+
+  return FVector(
+      pCartographic->longitude,
+      pCartographic->latitude,
+      pCartographic->height);
+}
+
+TArray<FVector> UCesiumVectorPrimitiveBlueprintLibrary::GetPrimitiveAsLine(
+    const FCesiumVectorPrimitive& InPrimitive) {
+  const std::vector<CesiumGeospatial::Cartographic>* pCartographicLine =
+      std::get_if<std::vector<CesiumGeospatial::Cartographic>>(
+          &InPrimitive._primitive);
+  if (!pCartographicLine) {
+    return TArray<FVector>();
+  }
+
+  TArray<FVector> line;
+  line.Reserve(pCartographicLine->size());
+  for (const CesiumGeospatial::Cartographic& point : *pCartographicLine) {
+    line.Emplace(point.longitude, point.latitude, point.height);
+  }
+
+  return line;
+}
+
+FCesiumCompositeCartographicPolygon
+UCesiumVectorPrimitiveBlueprintLibrary::GetPrimitiveAsPolygon(
+    const FCesiumVectorPrimitive& InPrimitive) {
+  const CesiumGeospatial::CompositeCartographicPolygon* pPolygon =
+      std::get_if<CesiumGeospatial::CompositeCartographicPolygon>(
+          &InPrimitive._primitive);
+  if (!pPolygon) {
+    return FCesiumCompositeCartographicPolygon(
+        CesiumGeospatial::CompositeCartographicPolygon({}));
+  }
+
+  return FCesiumCompositeCartographicPolygon(*pPolygon);
+}

--- a/Source/CesiumRuntime/Private/Tests/CesiumVectorDocument.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumVectorDocument.spec.cpp
@@ -1,0 +1,47 @@
+// Copyright 2020-2025 CesiumGS, Inc. and Contributors
+
+#include "CesiumVectorDocument.h"
+#include "CesiumVectorNode.h"
+#include "Misc/AutomationTest.h"
+
+BEGIN_DEFINE_SPEC(
+    FCesiumVectorDocumentSpec,
+    "Cesium.Unit.CesiumVectorDocument",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ClientContext |
+        EAutomationTestFlags::ProductFilter | EAutomationTestFlags::NonNullRHI)
+END_DEFINE_SPEC(FCesiumVectorDocumentSpec)
+
+void FCesiumVectorDocumentSpec::Define() {
+  Describe("UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString", [this]() {
+    It("loads a valid GeoJSON document", [this]() {
+      FCesiumVectorDocument Document;
+      const bool bSuccess =
+          UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+              R"==({ "type": "Point", "coordinates": [1, 2, 3] })==",
+              Document);
+      TestTrue("LoadGeoJsonFromString Success", bSuccess);
+    });
+    It("fails to load an invalid GeoJSON document", [this]() {
+      AddExpectedError(
+          "Errors while loading GeoJSON from string:\n- Failed to parse GeoJSON: Missing a name for object member.");
+      FCesiumVectorDocument Document;
+      bool bSuccess =
+          UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+              R"==({ type: "Point", coordinates: [1, 2, 3] })==",
+              Document);
+      TestFalse("LoadGeoJsonFromString Success", bSuccess);
+      AddExpectedError(
+          "Errors while loading GeoJSON from string:\n- Unknown GeoJSON object type: 'Invalid'");
+      bSuccess = UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+          R"==({ "type": "Invalid", "coordinates": [] })==",
+          Document);
+      TestFalse("LoadGeoJsonFromString Success", bSuccess);
+      AddExpectedError(
+          "Errors while loading GeoJSON from string:\n- Failed to parse GeoJSON: Invalid value.");
+      bSuccess = UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+          R"==(<some_xml_idk />)==",
+          Document);
+      TestFalse("LoadGeoJsonFromString Success", bSuccess);
+    });
+  });
+}

--- a/Source/CesiumRuntime/Private/Tests/CesiumVectorDocument.spec.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumVectorDocument.spec.cpp
@@ -44,4 +44,279 @@ void FCesiumVectorDocumentSpec::Define() {
       TestFalse("LoadGeoJsonFromString Success", bSuccess);
     });
   });
+
+  Describe("UCesiumVectorNodeBlueprintLibrary::GetIdAsInteger", [this]() {
+    It("correctly interprets an integer ID", [this]() {
+      FCesiumVectorDocument Document;
+      TestTrue(
+          "LoadGeoJsonFromString Success",
+          UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+              R"==({ "type": "Feature", "id": 10, "geometry": null, "properties": null })==",
+              Document));
+      TestEqual(
+          "GetIdAsInteger",
+          UCesiumVectorNodeBlueprintLibrary::GetIdAsInteger(
+              UCesiumVectorDocumentBlueprintLibrary::GetRootNode(Document)),
+          10);
+    });
+    It("returns -1 when the ID is missing", [this]() {
+      FCesiumVectorDocument Document;
+      TestTrue(
+          "LoadGeoJsonFromString Success",
+          UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+              R"==({ "type": "Feature", "geometry": null, "properties": null })==",
+              Document));
+      TestEqual(
+          "GetIdAsInteger",
+          UCesiumVectorNodeBlueprintLibrary::GetIdAsInteger(
+              UCesiumVectorDocumentBlueprintLibrary::GetRootNode(Document)),
+          -1);
+    });
+  });
+
+  Describe("UCesiumVectorNodeBlueprintLibrary::GetIdAsString", [this]() {
+    It("correctly interprets a string ID", [this]() {
+      FCesiumVectorDocument Document;
+      TestTrue(
+          "LoadGeoJsonFromString Success",
+          UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+              R"==({ "type": "Feature", "id": "test", "geometry": null, "properties": null })==",
+              Document));
+      TestEqual(
+          "GetIdAsString",
+          UCesiumVectorNodeBlueprintLibrary::GetIdAsString(
+              UCesiumVectorDocumentBlueprintLibrary::GetRootNode(Document)),
+          "test");
+    });
+    It("stringifies an integer ID", [this]() {
+      FCesiumVectorDocument Document;
+      TestTrue(
+          "LoadGeoJsonFromString Success",
+          UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+              R"==({ "type": "Feature", "id": 10, "geometry": null, "properties": null })==",
+              Document));
+      TestEqual(
+          "GetIdAsString",
+          UCesiumVectorNodeBlueprintLibrary::GetIdAsString(
+              UCesiumVectorDocumentBlueprintLibrary::GetRootNode(Document)),
+          "10");
+    });
+    It("returns an empty string when the ID is missing", [this]() {
+      FCesiumVectorDocument Document;
+      TestTrue(
+          "LoadGeoJsonFromString Success",
+          UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+              R"==({ "type": "Feature", "geometry": null, "properties": null })==",
+              Document));
+      TestEqual(
+          "GetIdAsString",
+          UCesiumVectorNodeBlueprintLibrary::GetIdAsString(
+              UCesiumVectorDocumentBlueprintLibrary::GetRootNode(Document)),
+          "");
+    });
+  });
+
+  Describe("UCesiumVectorNodeBlueprintLibrary::GetChildren", [this]() {
+    It("returns an array of children", [this]() {
+      FCesiumVectorDocument Document;
+      TestTrue(
+          "LoadGeoJsonFromString Success",
+          UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+              R"==({
+                  "type": "FeatureCollection",
+                  "features": [
+                    { "type": "Feature", "id": "test", "geometry": null, "properties": null },
+                    { "type": "Feature", "id": "test2", "geometry": null, "properties": null }
+                  ]
+                 })==",
+              Document));
+      TArray<FCesiumVectorNode> Children =
+          UCesiumVectorNodeBlueprintLibrary::GetChildren(
+              UCesiumVectorDocumentBlueprintLibrary::GetRootNode(Document));
+      TestEqual("Children.Num()", Children.Num(), 2);
+      TestEqual(
+          "Children[0] Id",
+          UCesiumVectorNodeBlueprintLibrary::GetIdAsString(Children[0]),
+          "test");
+      TestEqual(
+          "Children[1] Id",
+          UCesiumVectorNodeBlueprintLibrary::GetIdAsString(Children[1]),
+          "test2");
+    });
+  });
+
+  Describe("UCesiumVectorNodeBlueprintLibrary::GetPrimitives", [this]() {
+    It("returns an array of primitives", [this]() {
+      FCesiumVectorDocument Document;
+      TestTrue(
+          "LoadGeoJsonFromString Success",
+          UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+              R"==({
+                  "type": "MultiPoint",
+                  "coordinates": [
+                    [ 1, 2, 3 ],
+                    [ 4, 5, 6 ]
+                  ]
+                 })==",
+              Document));
+      TArray<FCesiumVectorPrimitive> Primitives =
+          UCesiumVectorNodeBlueprintLibrary::GetPrimitives(
+              UCesiumVectorDocumentBlueprintLibrary::GetRootNode(Document));
+      TestEqual("Primitives.Num()", Primitives.Num(), 2);
+      TestEqual(
+          "Primitives[0] as point",
+          UCesiumVectorPrimitiveBlueprintLibrary::GetPrimitiveAsPoint(
+              Primitives[0]),
+          FVector(1, 2, 3));
+      TestEqual(
+          "Primitives[1] as point",
+          UCesiumVectorPrimitiveBlueprintLibrary::GetPrimitiveAsPoint(
+              Primitives[1]),
+          FVector(4, 5, 6));
+    });
+  });
+
+  Describe(
+      "UCesiumVectorNodeBlueprintLibrary::GetPrimitivesOfTypeRecursively",
+      [this]() {
+        It("returns all primitives of a given type in the document", [this]() {
+          FCesiumVectorDocument Document;
+          TestTrue(
+              "LoadGeoJsonFromString Success",
+              UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+                  R"==({
+                  "type": "GeometryCollection",
+                  "geometries": [
+                    {
+                      "type": "GeometryCollection",
+                      "geometries": [
+                        { "type": "Point", "coordinates": [ -2, -1, 0 ] }
+                      ]
+                    },
+                    { "type": "Point", "coordinates": [ 1, 2, 3 ] },
+                    { "type": "LineString", "coordinates": [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] },
+                    { "type": "Point", "coordinates": [ 7, 8, 9 ] }
+                  ]
+                 })==",
+                  Document));
+          TArray<FCesiumVectorPrimitive> Primitives =
+              UCesiumVectorNodeBlueprintLibrary::GetPrimitivesOfTypeRecursively(
+                  UCesiumVectorDocumentBlueprintLibrary::GetRootNode(Document),
+                  ECesiumVectorPrimitiveType::Point);
+          TestEqual("Primitives.Num()", Primitives.Num(), 3);
+          TestEqual(
+              "Primitives[0] as point",
+              UCesiumVectorPrimitiveBlueprintLibrary::GetPrimitiveAsPoint(
+                  Primitives[0]),
+              FVector(-2, -1, 0));
+          TestEqual(
+              "Primitives[0] as point",
+              UCesiumVectorPrimitiveBlueprintLibrary::GetPrimitiveAsPoint(
+                  Primitives[1]),
+              FVector(1, 2, 3));
+          TestEqual(
+              "Primitives[1] as point",
+              UCesiumVectorPrimitiveBlueprintLibrary::GetPrimitiveAsPoint(
+                  Primitives[2]),
+              FVector(7, 8, 9));
+        });
+      });
+
+  Describe("UCesiumVectorNodeBlueprintLibrary::FindNodeByStringId", [this]() {
+    It("obtains a node with the given ID", [this]() {
+      FCesiumVectorDocument Document;
+      TestTrue(
+          "LoadGeoJsonFromString Success",
+          UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+              R"==({
+                  "type": "FeatureCollection",
+                  "features": [
+                    { "type": "Feature", "id": "test1", "geometry": null, "properties": null },
+                    { "type": "Feature", "id": "test2", "geometry": null, "properties": null },
+                    { "type": "Feature", "id": "test3", "geometry": null, "properties": null },
+                    {
+                      "type": "Feature",
+                      "id": "test4",
+                      "geometry": {
+                        "type": "Point",
+                        "coordinates": [ 1, 2, 3 ]
+                      },
+                      "properties": null
+                    },
+                    { "type": "Feature", "id": "test5", "geometry": null, "properties": null },
+                    { "type": "Feature", "id": "test6", "geometry": null, "properties": null }
+                  ]
+                 })==",
+              Document));
+      FCesiumVectorNode Node;
+      TestTrue(
+          "FindNodeByStringId Success",
+          UCesiumVectorNodeBlueprintLibrary::FindNodeByStringId(
+              UCesiumVectorDocumentBlueprintLibrary::GetRootNode(Document),
+              "test4",
+              Node));
+      TestEqual(
+          "Node.Id",
+          UCesiumVectorNodeBlueprintLibrary::GetIdAsString(Node),
+          "test4");
+      TArray<FCesiumVectorPrimitive> Primitives =
+          UCesiumVectorNodeBlueprintLibrary::GetPrimitives(
+              UCesiumVectorNodeBlueprintLibrary::GetChildren(Node)[0]);
+      TestEqual("Primitives.Num()", Primitives.Num(), 1);
+      TestEqual(
+          "Primitives[0] as point",
+          UCesiumVectorPrimitiveBlueprintLibrary::GetPrimitiveAsPoint(
+              Primitives[0]),
+          FVector(1, 2, 3));
+    });
+  });
+
+  Describe("UCesiumVectorNodeBlueprintLibrary::FindNodeByIntId", [this]() {
+    It("obtains a node with the given ID", [this]() {
+      FCesiumVectorDocument Document;
+      TestTrue(
+          "LoadGeoJsonFromString Success",
+          UCesiumVectorDocumentBlueprintLibrary::LoadGeoJsonFromString(
+              R"==({
+                  "type": "FeatureCollection",
+                  "features": [
+                    { "type": "Feature", "id": 1, "geometry": null, "properties": null },
+                    { "type": "Feature", "id": 2, "geometry": null, "properties": null },
+                    { "type": "Feature", "id": 3, "geometry": null, "properties": null },
+                    {
+                      "type": "Feature",
+                      "id": 4,
+                      "geometry": {
+                        "type": "Point",
+                        "coordinates": [ 1, 2, 3 ]
+                      },
+                      "properties": null
+                    },
+                    { "type": "Feature", "id": 5, "geometry": null, "properties": null },
+                    { "type": "Feature", "id": 6, "geometry": null, "properties": null }
+                  ]
+                 })==",
+              Document));
+      FCesiumVectorNode Node;
+      TestTrue(
+          "FindNodeByStringId Success",
+          UCesiumVectorNodeBlueprintLibrary::FindNodeByIntId(
+              UCesiumVectorDocumentBlueprintLibrary::GetRootNode(Document),
+              4,
+              Node));
+      TestEqual(
+          "Node.Id",
+          UCesiumVectorNodeBlueprintLibrary::GetIdAsInteger(Node),
+          4);
+      TArray<FCesiumVectorPrimitive> Primitives =
+          UCesiumVectorNodeBlueprintLibrary::GetPrimitives(
+              UCesiumVectorNodeBlueprintLibrary::GetChildren(Node)[0]);
+      TestEqual("Primitives.Num()", Primitives.Num(), 1);
+      TestEqual(
+          "Primitives[0] as point",
+          UCesiumVectorPrimitiveBlueprintLibrary::GetPrimitiveAsPoint(
+              Primitives[0]),
+          FVector(1, 2, 3));
+    });
+  });
 }

--- a/Source/CesiumRuntime/Public/CesiumIonServer.h
+++ b/Source/CesiumRuntime/Public/CesiumIonServer.h
@@ -14,7 +14,7 @@ template <typename T> class Future;
  * Defines a Cesium ion Server. This may be the public (SaaS) Cesium ion server
  * at ion.cesium.com, or it may be a self-hosted instance.
  */
-UCLASS()
+UCLASS(BlueprintType)
 class CESIUMRUNTIME_API UCesiumIonServer : public UDataAsset {
   GENERATED_BODY()
 
@@ -28,6 +28,7 @@ public:
    * a valid instance. At runtime, this method returns nullptr if the object
    * does not exist.
    */
+  UFUNCTION(BlueprintCallable, Category = "Cesium|ion")
   static UCesiumIonServer* GetDefaultServer();
 
   /**
@@ -59,7 +60,8 @@ public:
   UPROPERTY(
       EditAnywhere,
       AssetRegistrySearchable,
-      Category = "Cesium",
+      BlueprintReadOnly,
+      Category = "Cesium|ion",
       meta = (DisplayName = "Display Name"))
   FString DisplayName = "ion.cesium.com";
 
@@ -70,7 +72,8 @@ public:
   UPROPERTY(
       EditAnywhere,
       AssetRegistrySearchable,
-      Category = "Cesium",
+      BlueprintReadOnly,
+      Category = "Cesium|ion",
       meta = (DisplayName = "Server URL"))
   FString ServerUrl = "https://ion.cesium.com";
 
@@ -82,7 +85,8 @@ public:
   UPROPERTY(
       EditAnywhere,
       AssetRegistrySearchable,
-      Category = "Cesium",
+      BlueprintReadOnly,
+      Category = "Cesium|ion",
       meta = (DisplayName = "API URL"))
   FString ApiUrl = "https://api.cesium.com";
 
@@ -94,7 +98,8 @@ public:
   UPROPERTY(
       EditAnywhere,
       AssetRegistrySearchable,
-      Category = "Cesium",
+      BlueprintReadOnly,
+      Category = "Cesium|ion",
       meta = (DisplayName = "OAuth Application ID"))
   int64 OAuth2ApplicationID = 190;
 
@@ -106,7 +111,8 @@ public:
    */
   UPROPERTY(
       EditAnywhere,
-      Category = "Cesium",
+      BlueprintReadOnly,
+      Category = "Cesium|ion",
       meta = (DisplayName = "Default Cesium ion Access Token ID"))
   FString DefaultIonAccessTokenId;
 
@@ -117,7 +123,8 @@ public:
   UPROPERTY(
       EditAnywhere,
       AssetRegistrySearchable,
-      Category = "Cesium",
+      BlueprintReadOnly,
+      Category = "Cesium|ion",
       meta = (DisplayName = "Default Cesium ion Access Token"))
   FString DefaultIonAccessToken;
 

--- a/Source/CesiumRuntime/Public/CesiumVectorDocument.h
+++ b/Source/CesiumRuntime/Public/CesiumVectorDocument.h
@@ -1,0 +1,47 @@
+// Copyright 2020-2025 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "CesiumVectorData/VectorDocument.h"
+#include "CesiumVectorNode.h"
+
+#include <optional>
+
+#include "CesiumVectorDocument.generated.h"
+
+USTRUCT(BlueprintType)
+struct FCesiumVectorDocument {
+  GENERATED_BODY()
+
+  FCesiumVectorDocument() : _document(CesiumVectorData::VectorNode{}) {}
+
+  FCesiumVectorDocument(CesiumVectorData::VectorDocument&& document)
+      : _document(std::move(document)) {}
+
+private:
+  CesiumVectorData::VectorDocument _document;
+
+  friend class UCesiumVectorDocumentBlueprintLibrary;
+};
+
+UCLASS()
+class UCesiumVectorDocumentBlueprintLibrary : public UBlueprintFunctionLibrary {
+  GENERATED_BODY()
+
+public:
+  UFUNCTION(
+      BlueprintCallable,
+      Category = "Cesium|Vector",
+      meta = (DisplayName = "Load GeoJSON Document From String"))
+  static UPARAM(DisplayName = "Success") bool LoadGeoJsonFromString(
+      const FString& InString,
+      FCesiumVectorDocument& OutVectorDocument);
+
+  UFUNCTION(
+      BlueprintCallable,
+      BlueprintPure,
+      Category = "Cesium|Vector",
+      meta = (DisplayName = "Get Root Node"))
+  static FCesiumVectorNode
+  GetRootNode(const FCesiumVectorDocument& InVectorDocument);
+};

--- a/Source/CesiumRuntime/Public/CesiumVectorDocument.h
+++ b/Source/CesiumRuntime/Public/CesiumVectorDocument.h
@@ -9,12 +9,22 @@
 
 #include "CesiumVectorDocument.generated.h"
 
+/**
+ * @brief A vector document containing a tree of `FCesiumVectorNode` values.
+ */
 USTRUCT(BlueprintType)
 struct FCesiumVectorDocument {
   GENERATED_BODY()
 
+  /**
+   * @brief Creates an empty `FCesiumVectorDocument`.
+   */
   FCesiumVectorDocument() : _document(CesiumVectorData::VectorNode{}) {}
 
+  /**
+   * @brief Creates a `FCesiumVectorDocument` wrapping the provided
+   * `CesiumVectorData::VectorDocument`.
+   */
   FCesiumVectorDocument(CesiumVectorData::VectorDocument&& document)
       : _document(std::move(document)) {}
 
@@ -24,23 +34,37 @@ private:
   friend class UCesiumVectorDocumentBlueprintLibrary;
 };
 
+/**
+ * @brief A Blueprint Function Library providing functions for interacting with
+ * a `FCesiumVectorDocument`.
+ */
 UCLASS()
 class UCesiumVectorDocumentBlueprintLibrary : public UBlueprintFunctionLibrary {
   GENERATED_BODY()
 
 public:
+  /**
+   * @brief Attempts to load a `FCesiumVectorDocument` from a string containing
+   * GeoJSON data.
+   *
+   * If loading fails, this function will return false and `OutVectorDocument`
+   * will be empty.
+   */
   UFUNCTION(
       BlueprintCallable,
-      Category = "Cesium|Vector",
+      Category = "Cesium|Vector|Document",
       meta = (DisplayName = "Load GeoJSON Document From String"))
   static UPARAM(DisplayName = "Success") bool LoadGeoJsonFromString(
       const FString& InString,
       FCesiumVectorDocument& OutVectorDocument);
 
+  /**
+   * @brief Obtains the root node of the provided vector document.
+   */
   UFUNCTION(
       BlueprintCallable,
       BlueprintPure,
-      Category = "Cesium|Vector",
+      Category = "Cesium|Vector|Document",
       meta = (DisplayName = "Get Root Node"))
   static FCesiumVectorNode
   GetRootNode(const FCesiumVectorDocument& InVectorDocument);

--- a/Source/CesiumRuntime/Public/CesiumVectorDocument.h
+++ b/Source/CesiumRuntime/Public/CesiumVectorDocument.h
@@ -4,6 +4,9 @@
 
 #include "CesiumVectorData/VectorDocument.h"
 #include "CesiumVectorNode.h"
+#include "Kismet/BlueprintAsyncActionBase.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "UObject/ObjectMacros.h"
 
 #include <optional>
 
@@ -19,7 +22,7 @@ struct FCesiumVectorDocument {
   /**
    * @brief Creates an empty `FCesiumVectorDocument`.
    */
-  FCesiumVectorDocument() : _document(CesiumVectorData::VectorNode{}) {}
+  FCesiumVectorDocument() : _document(CesiumVectorData::VectorNode{}, {}) {}
 
   /**
    * @brief Creates a `FCesiumVectorDocument` wrapping the provided
@@ -68,4 +71,43 @@ public:
       meta = (DisplayName = "Get Root Node"))
   static FCesiumVectorNode
   GetRootNode(const FCesiumVectorDocument& InVectorDocument);
+};
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(
+    FCesiumVectorDocumentIonLoadDelegate,
+    bool,
+    Success,
+    FCesiumVectorDocument,
+    Document);
+
+UCLASS()
+class CESIUMRUNTIME_API UCesiumLoadVectorDocumentFromIonAsyncAction
+    : public UBlueprintAsyncActionBase {
+  GENERATED_BODY()
+public:
+  /**
+   * @brief Attempts to load a vector document from a Cesium ion asset.
+   *
+   * If successful, `Success` will be true and `Document` will contain the
+   * loaded document.
+   */
+  UFUNCTION(
+      BlueprintCallable,
+      Category = "Cesium|Vector|Document",
+      meta =
+          (BlueprintInternalUseOnly = true,
+           DisplayName = "Load Vector Document from Cesium ion"))
+  static UCesiumLoadVectorDocumentFromIonAsyncAction* LoadFromIon(
+      int64 AssetId,
+      const FString& IonAccessToken,
+      const FString& IonAssetEndpointUrl = "https://api.cesium.com/");
+
+  UPROPERTY(BlueprintAssignable)
+  FCesiumVectorDocumentIonLoadDelegate OnLoadResult;
+
+  virtual void Activate() override;
+
+  int64 AssetId;
+  FString IonAccessToken;
+  FString IonAssetEndpointUrl;
 };

--- a/Source/CesiumRuntime/Public/CesiumVectorNode.h
+++ b/Source/CesiumRuntime/Public/CesiumVectorNode.h
@@ -6,10 +6,25 @@
 
 #include "CesiumVectorNode.generated.h"
 
+/**
+ * @brief A single node in the vector document.
+ *
+ * A node typically contains geometry along with metadata attached to that
+ * geometry.
+ */
 USTRUCT(BlueprintType)
 struct FCesiumVectorNode {
   GENERATED_BODY()
 
+  /**
+   * @brief Creates a new `FCesiumVectorNode` containing an empty vector node.
+   */
+  FCesiumVectorNode() : _node() {}
+
+  /**
+   * @brief Creates a new `FCesiumVectorNode` wrapping the provided
+   * `CesiumVectorData::VectorNode`.
+   */
   FCesiumVectorNode(const CesiumVectorData::VectorNode& node) : _node(node) {}
 
 private:
@@ -18,17 +33,41 @@ private:
   friend class UCesiumVectorNodeBlueprintLibrary;
 };
 
+/**
+ * @brief The supported types of vector data geometry primitive.
+ */
 UENUM(BlueprintType)
 enum class ECesiumVectorPrimitiveType : uint8 {
+  /** @brief The Point primitive represents a single point in space. */
   Point = 0,
+  /**
+   * @brief The Line primitive represents a series of one or more line
+   * segments.
+   */
   Line = 1,
+  /**
+   * @brief The Polygon primitive represents a polygon made up of one or more
+   * linear rings.
+   */
   Polygon = 2
 };
 
+/**
+ * @brief A single geometry primitive. The type of the primitive is represented
+ * by `ECesiumVectorPrimitiveType`.
+ */
 USTRUCT(BlueprintType)
 struct FCesiumVectorPrimitive {
   GENERATED_BODY()
 
+  /** @brief Creates a new `FCesiumVectorPrimitive` with an empty primitive. */
+  FCesiumVectorPrimitive()
+      : _primitive(std::vector<CesiumGeospatial::Cartographic>()) {}
+
+  /**
+   * @brief Creates a new `FCesiumVectorPrimitive` wrapping the provided
+   * `CesiumVectorData::VectorPrimitive`.
+   */
   FCesiumVectorPrimitive(const CesiumVectorData::VectorPrimitive& primitive)
       : _primitive(primitive) {}
 
@@ -38,6 +77,10 @@ private:
   friend class UCesiumVectorPrimitiveBlueprintLibrary;
 };
 
+/**
+ * @brief A Blueprint Funciton Library for interacting with `FCesiumVectorNode`
+ * values.
+ */
 UCLASS()
 class UCesiumVectorNodeBlueprintLibrary : public UBlueprintFunctionLibrary {
   GENERATED_BODY()
@@ -47,58 +90,194 @@ public:
    * @brief Returns the ID of the provided vector node, or -1 if no ID was
    * present or if the ID is not an integer.
    */
-  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|Vector")
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|Vector|Node")
   static int64 GetIdAsInteger(const FCesiumVectorNode& InVectorNode);
 
   /**
    * @brief Returns the ID of the provided vector node, or an empty string if no
    * ID was present. If the ID is an integer, it will be converted to a string.
    */
-  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|Vector")
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|Vector|Node")
   static FString GetIdAsString(const FCesiumVectorNode& InVectorNode);
 
   /**
    * @brief Returns an array of primitives contained in this node.
    */
-  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector")
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector|Node")
   static TArray<FCesiumVectorPrimitive>
   GetPrimitives(const FCesiumVectorNode& InVectorNode);
 
-  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector")
+  /**
+   * @brief Returns all primitives of the given type from this node.
+   */
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector|Node")
   static TArray<FCesiumVectorPrimitive> GetPrimitivesOfType(
       const FCesiumVectorNode& InVectorNode,
       ECesiumVectorPrimitiveType InType);
+
+  /**
+   * @brief Returns all primitives of the given type in this node or in any
+   * child nodes, recursively.
+   */
+  UFUNCTION(
+      BlueprintCallable,
+      Category = "Cesium|Vector|Node",
+      meta = (DisplayName = "Get All Primitives of Type"))
+  static TArray<FCesiumVectorPrimitive> GetPrimitivesOfTypeRecursively(
+      const FCesiumVectorNode& InVectorNode,
+      ECesiumVectorPrimitiveType InType);
+
+  /**
+   * @brief Returns the first child node found with the given ID. If no node was
+   * found, "Success" will return false.
+   */
+  UFUNCTION(
+      BlueprintCallable,
+      Category = "Cesium|Vector|Node",
+      meta = (DisplayName = "Find Node By String ID"))
+  static UPARAM(DisplayName = "Success") bool FindNodeByStringId(
+      const FCesiumVectorNode& InVectorNode,
+      const FString& InNodeId,
+      FCesiumVectorNode& OutNode);
+
+  /**
+   * @brief Returns the first child node found with the given ID. If no node was
+   * found, "Success" will return false.
+   */
+  UFUNCTION(
+      BlueprintCallable,
+      Category = "Cesium|Vector|Node",
+      meta = (DisplayName = "Find Node By Integer ID"))
+  static UPARAM(DisplayName = "Success") bool FindNodeByIntId(
+      const FCesiumVectorNode& InVectorNode,
+      int64 InNodeId,
+      FCesiumVectorNode& OutNode);
 };
 
+/**
+ * @brief A `FCesiumCompositeCartographicPolygon` is a polygon made up of one or
+ * more linear rings.
+ */
 USTRUCT(BlueprintType)
 struct FCesiumCompositeCartographicPolygon {
   GENERATED_BODY()
 
+  /**
+   * @brief Creates a new `FCesiumCompositeCartographicPolygon` with an empty
+   * composite polygon.
+   */
+  FCesiumCompositeCartographicPolygon() : _polygon({}) {}
+
+  /**
+   * @brief Creates a new `FCesiumCompositeCartographicPolygon` wrapping the
+   * provided `CesiumGeospatial::CompositeCartographicPolygon`.
+   */
   FCesiumCompositeCartographicPolygon(
       const CesiumGeospatial::CompositeCartographicPolygon& polygon)
       : _polygon(polygon) {}
 
 private:
   CesiumGeospatial::CompositeCartographicPolygon _polygon;
+
+  friend class UCesiumCompositeCartographicPolygonBlueprintLibrary;
 };
 
+/**
+ * @brief A `FCesiumPolygonLinearRing` is a single linear ring of a
+ * `FCesiumCompositeCartographicPolygon`.
+ */
+USTRUCT(BlueprintType)
+struct FCesiumPolygonLinearRing {
+  GENERATED_BODY()
+public:
+  /**
+   * @brief Creates a new `FCesiumPolygonLinearRing` with an empty linear ring.
+   */
+  FCesiumPolygonLinearRing() : Points() {}
+
+  /**
+   * @brief Creates a new `FCesiumPolygonLinearRing` from a set of
+   * Longitude-Latitude-Height points.
+   */
+  FCesiumPolygonLinearRing(TArray<FVector>&& InPoints);
+
+  /**
+   * @brief The Longitude-Latitude-Height points of this polygon.
+   */
+  UPROPERTY(BlueprintReadOnly)
+  TArray<FVector> Points;
+};
+
+UCLASS()
+class UCesiumCompositeCartographicPolygonBlueprintLibrary
+    : public UBlueprintFunctionLibrary {
+  GENERATED_BODY()
+public:
+  /**
+   * @brief Returns whether this `FCesiumCompositeCartographicPolygon` contains
+   * the provided Longitude-Latitude-Height position.
+   */
+  UFUNCTION(
+      BlueprintCallable,
+      BlueprintPure,
+      Category = "Cesium|Vector|Polygon")
+  static bool PolygonContainsPoint(
+      const FCesiumCompositeCartographicPolygon& InPolygon,
+      const FVector& InPoint);
+
+  /**
+   * @brief Returns the linear rings that make up this composite polygon.
+   *
+   * The first returned ring represents the outer bounds of the polygon. Any
+   * additional rings define holes within those bounds.
+   */
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector|Polygon")
+  static TArray<FCesiumPolygonLinearRing>
+  GetPolygonRings(const FCesiumCompositeCartographicPolygon& InPolygon);
+};
+
+/**
+ * @brief A Blueprint Funciton Library for interacting with
+ * `FCesiumVectorPrimitive` values.
+ */
 UCLASS()
 class UCesiumVectorPrimitiveBlueprintLibrary
     : public UBlueprintFunctionLibrary {
   GENERATED_BODY()
 public:
-  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|Vector")
+  /**
+   * @brief Returns the `ECesiumVectorPrimitiveType` of this
+   * `FCesiumVectorPrimitive`.
+   */
+  UFUNCTION(
+      BlueprintCallable,
+      BlueprintPure,
+      Category = "Cesium|Vector|Primitive")
   static ECesiumVectorPrimitiveType
   GetPrimitiveType(const FCesiumVectorPrimitive& InPrimitive);
 
-  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector")
+  /**
+   * @brief Assuming this primitive is a `ECesiumVectorPrimitiveType::Point`,
+   * returns the point value. If it is not a point, returns `FVector(0, 0, 0)`.
+   */
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector|Primitive")
   static FVector GetPrimitiveAsPoint(const FCesiumVectorPrimitive& InPrimitive);
 
-  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector")
+  /**
+   * @brief Assuming this primitive is a `ECesiumVectorPrimitiveType::Line`,
+   * returns the points defining the line segments. If it is not a line, returns
+   * an empty `TArray<FVector>`.
+   */
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector|Primitive")
   static TArray<FVector>
   GetPrimitiveAsLine(const FCesiumVectorPrimitive& InPrimitive);
 
-  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector")
+  /**
+   * @brife Assuming this primitive is a `ECesiumVectorPrimitiveType::Polygon`,
+   * returns the `FCesiumCompositeCartographicPolygon`. If it is not a polygon,
+   * returns a default-constructed `FCesiumCompositeCartographicPolygon`.
+   */
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector|Primitive")
   static FCesiumCompositeCartographicPolygon
   GetPrimitiveAsPolygon(const FCesiumVectorPrimitive& InPrimitive);
 };

--- a/Source/CesiumRuntime/Public/CesiumVectorNode.h
+++ b/Source/CesiumRuntime/Public/CesiumVectorNode.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CesiumVectorData/VectorNode.h"
+#include "JsonObjectWrapper.h"
 
 #include "CesiumVectorNode.generated.h"
 
@@ -103,13 +104,21 @@ public:
   /**
    * @brief Returns any child nodes of this vector node.
    */
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|Vector|Node")
   static TArray<FCesiumVectorNode>
   GetChildren(const FCesiumVectorNode& InVectorNode);
 
   /**
+   * @brief Obtains the properties attached to this node, if any.
+   */
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|Vector|Node")
+  static FJsonObjectWrapper
+  GetProperties(const FCesiumVectorNode& InVectorNode);
+
+  /**
    * @brief Returns an array of primitives contained in this node.
    */
-  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector|Node")
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|Vector|Node")
   static TArray<FCesiumVectorPrimitive>
   GetPrimitives(const FCesiumVectorNode& InVectorNode);
 

--- a/Source/CesiumRuntime/Public/CesiumVectorNode.h
+++ b/Source/CesiumRuntime/Public/CesiumVectorNode.h
@@ -1,0 +1,104 @@
+// Copyright 2020-2025 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "CesiumVectorData/VectorNode.h"
+
+#include "CesiumVectorNode.generated.h"
+
+USTRUCT(BlueprintType)
+struct FCesiumVectorNode {
+  GENERATED_BODY()
+
+  FCesiumVectorNode(const CesiumVectorData::VectorNode& node) : _node(node) {}
+
+private:
+  CesiumVectorData::VectorNode _node;
+
+  friend class UCesiumVectorNodeBlueprintLibrary;
+};
+
+UENUM(BlueprintType)
+enum class ECesiumVectorPrimitiveType : uint8 {
+  Point = 0,
+  Line = 1,
+  Polygon = 2
+};
+
+USTRUCT(BlueprintType)
+struct FCesiumVectorPrimitive {
+  GENERATED_BODY()
+
+  FCesiumVectorPrimitive(const CesiumVectorData::VectorPrimitive& primitive)
+      : _primitive(primitive) {}
+
+private:
+  CesiumVectorData::VectorPrimitive _primitive;
+
+  friend class UCesiumVectorPrimitiveBlueprintLibrary;
+};
+
+UCLASS()
+class UCesiumVectorNodeBlueprintLibrary : public UBlueprintFunctionLibrary {
+  GENERATED_BODY()
+
+public:
+  /**
+   * @brief Returns the ID of the provided vector node, or -1 if no ID was
+   * present or if the ID is not an integer.
+   */
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|Vector")
+  static int64 GetIdAsInteger(const FCesiumVectorNode& InVectorNode);
+
+  /**
+   * @brief Returns the ID of the provided vector node, or an empty string if no
+   * ID was present. If the ID is an integer, it will be converted to a string.
+   */
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|Vector")
+  static FString GetIdAsString(const FCesiumVectorNode& InVectorNode);
+
+  /**
+   * @brief Returns an array of primitives contained in this node.
+   */
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector")
+  static TArray<FCesiumVectorPrimitive>
+  GetPrimitives(const FCesiumVectorNode& InVectorNode);
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector")
+  static TArray<FCesiumVectorPrimitive> GetPrimitivesOfType(
+      const FCesiumVectorNode& InVectorNode,
+      ECesiumVectorPrimitiveType InType);
+};
+
+USTRUCT(BlueprintType)
+struct FCesiumCompositeCartographicPolygon {
+  GENERATED_BODY()
+
+  FCesiumCompositeCartographicPolygon(
+      const CesiumGeospatial::CompositeCartographicPolygon& polygon)
+      : _polygon(polygon) {}
+
+private:
+  CesiumGeospatial::CompositeCartographicPolygon _polygon;
+};
+
+UCLASS()
+class UCesiumVectorPrimitiveBlueprintLibrary
+    : public UBlueprintFunctionLibrary {
+  GENERATED_BODY()
+public:
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|Vector")
+  static ECesiumVectorPrimitiveType
+  GetPrimitiveType(const FCesiumVectorPrimitive& InPrimitive);
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector")
+  static FVector GetPrimitiveAsPoint(const FCesiumVectorPrimitive& InPrimitive);
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector")
+  static TArray<FVector>
+  GetPrimitiveAsLine(const FCesiumVectorPrimitive& InPrimitive);
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Vector")
+  static FCesiumCompositeCartographicPolygon
+  GetPrimitiveAsPolygon(const FCesiumVectorPrimitive& InPrimitive);
+};

--- a/Source/CesiumRuntime/Public/CesiumVectorNode.h
+++ b/Source/CesiumRuntime/Public/CesiumVectorNode.h
@@ -4,6 +4,7 @@
 
 #include "CesiumVectorData/VectorNode.h"
 #include "JsonObjectWrapper.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
 
 #include "CesiumVectorNode.generated.h"
 

--- a/Source/CesiumRuntime/Public/CesiumVectorNode.h
+++ b/Source/CesiumRuntime/Public/CesiumVectorNode.h
@@ -101,6 +101,12 @@ public:
   static FString GetIdAsString(const FCesiumVectorNode& InVectorNode);
 
   /**
+   * @brief Returns any child nodes of this vector node.
+   */
+  static TArray<FCesiumVectorNode>
+  GetChildren(const FCesiumVectorNode& InVectorNode);
+
+  /**
    * @brief Returns an array of primitives contained in this node.
    */
   UFUNCTION(BlueprintCallable, Category = "Cesium|Vector|Node")

--- a/Source/CesiumRuntime/Public/CesiumVectorNode.h
+++ b/Source/CesiumRuntime/Public/CesiumVectorNode.h
@@ -219,7 +219,7 @@ public:
   /**
    * @brief The Longitude-Latitude-Height points of this polygon.
    */
-  UPROPERTY(BlueprintReadOnly)
+  UPROPERTY(BlueprintReadOnly, Category = "Cesium|Vector|Polygon")
   TArray<FVector> Points;
 };
 


### PR DESCRIPTION
The companion to CesiumGS/cesium-native#1154. This PR adds blueprint functions for loading and interacting with GeoJSON data. In particular, it provides the ability to load GeoJSON from a string or from Cesium ion, the ability to query nodes, and the ability to obtain primitives as values usable in Unreal. 

One note is that access to the properties of a vector node requires blueprint functionality for interacting with JSON objects. I elected to push this responsibility onto the JSON Blueprint Utilities plugin, which is an official Unreal plugin but not enabled by default. Returning the `FJsonObjectWrapper` struct from a method is supported without this plugin enabled, but users will have to enable that plugin if they want to be able to do anything with it.