### PR TITLE
Use `ProjectUserDir` instead of `EngineUserDir` for request cache path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - Fixed a linking issue introduced in *v2.15.0* in `GoogleTilesTestSetup`.
 - The "unsupported primitive mode" warning is now only logged once to avoid console spam.
+- Request cache will now use `FPaths::ProjectUserDir` instead of `FPaths::EngineUserDir` on non-Android and non-iOS platforms, fixing a permissions issue in Development builds.
 
 ### v2.15.0 - 2025-04-01
 

--- a/Source/CesiumRuntime/Private/CesiumRuntime.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRuntime.cpp
@@ -80,7 +80,7 @@ std::string getCacheDatabaseName() {
     IFileManager::Get().MakeDirectory(*BaseDirectory, true);
   }
 #else
-  FString BaseDirectory = FPaths::EngineUserDir();
+  FString BaseDirectory = FPaths::ProjectUserDir();
 #endif
 
   FString CesiumDBFile =


### PR DESCRIPTION
To quote @AlbanBERGERET-Epic in his message to us:
> One of our support team members just reported to me that one of our licensees was following your recommendation from [this post](https://community.cesium.com/t/ue-game-encounters-fatal-crash-when-game-directory-is-not-writable/22375/3), which is actually not accurate.
> 
> The best practice is to use `FPaths::ProjectUserDir` instead of `FPaths::EngineUserDir()`
> 
> - For a shipping build, both of these paths will redirect to C:\users\username\appdata, which is what we want.
> - For a development build, EngineUserDir will redirect to C:\Program Files, which is a problem if write-protected. But ProjectUserDir will use the local project folder, which should be good.
> 
> IDK if you're still using it in your latest plugin version (I did not check), but if so, you should rather use ProjectUserDir instead.