### PR TITLE
Solution to https://community.cesium.com/t/it-took-more-than-ten-seconds-to-exit/23354 problem

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -48,6 +48,7 @@
 #include "StereoRendering.h"
 #include "UnrealPrepareRendererResources.h"
 #include "VecMath.h"
+#include "UnrealAssetAccessor.h"
 #include <glm/gtc/matrix_inverse.hpp>
 #include <memory>
 #include <spdlog/spdlog.h>
@@ -2293,6 +2294,27 @@ void ACesium3DTileset::BeginDestroy() {
 
 bool ACesium3DTileset::IsReadyForFinishDestroy() {
   bool ready = AActor::IsReadyForFinishDestroy();
+
+  	//If the request has not ended yet, actively cancel the request
+	{
+		FScopeLock lock(&UnrealAssetAccessor::_pendingRequestsLock);
+		for (const TSharedRef<IHttpRequest, ESPMode::ThreadSafe>& pRequest : UnrealAssetAccessor::_pendingRequests) {
+			EHttpRequestStatus::Type status = pRequest->GetStatus();
+			if (status == EHttpRequestStatus::NotStarted || status == EHttpRequestStatus::Processing) {
+				const FString& requestUrl = pRequest->GetURL();
+				UE_LOG(LogTemp, Log, TEXT("3DTiles URL = %s, Request URL = %s"), *this->Url, *requestUrl);
+				if (this->TilesetSource == ETilesetSource::FromCesiumIon && requestUrl.Contains("CesiumWorldTerrain"))
+					pRequest->CancelRequest();
+				else if (this->TilesetSource == ETilesetSource::FromUrl) {
+					FString originUrl = this->Url;
+					originUrl.RemoveFromEnd(TEXT("tileset.json"));
+					if (requestUrl.Contains(UCesiumRasterOverlay::ExtractCleanBaseUrl(originUrl)))
+						pRequest->CancelRequest();
+				}
+			}
+		}
+	}
+
   ready &= this->_tilesetsBeingDestroyed == 0;
 
   if (!ready) {

--- a/Source/CesiumRuntime/Private/CesiumBingMapsRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumBingMapsRasterOverlay.cpp
@@ -45,3 +45,8 @@ UCesiumBingMapsRasterOverlay::CreateOverlay(
       "",
       options);
 }
+
+bool UCesiumBingMapsRasterOverlay::IsReadyForFinishDestroy() {
+  this->SetUrl(TEXT("https://dev.virtualearth.net"));
+  return Super::IsReadyForFinishDestroy();
+}

--- a/Source/CesiumRuntime/Private/CesiumIonServer.cpp
+++ b/Source/CesiumRuntime/Private/CesiumIonServer.cpp
@@ -194,3 +194,8 @@ CesiumAsync::Future<void> UCesiumIonServer::ResolveApiUrl() {
       });
 }
 #endif
+
+bool UCesiumIonRasterOverlay::IsReadyForFinishDestroy() {
+  this->SetUrl(this->CesiumIonServer->ApiUrl);
+  return Super::IsReadyForFinishDestroy();
+}

--- a/Source/CesiumRuntime/Private/CesiumTileMapServiceRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumTileMapServiceRasterOverlay.cpp
@@ -33,3 +33,8 @@ UCesiumTileMapServiceRasterOverlay::CreateOverlay(
       tmsOptions,
       options);
 }
+
+bool UCesiumTileMapServiceRasterOverlay::IsReadyForFinishDestroy() {
+  this->SetUrl(this->Url);
+  return Super::IsReadyForFinishDestroy();
+}

--- a/Source/CesiumRuntime/Private/CesiumUrlTemplateRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumUrlTemplateRasterOverlay.cpp
@@ -70,3 +70,8 @@ UCesiumUrlTemplateRasterOverlay::CreateOverlay(
       urlTemplateOptions,
       options);
 }
+
+bool UCesiumUrlTemplateRasterOverlay::IsReadyForFinishDestroy() {
+  this->SetUrl(this->TemplateUrl);
+  return Super::IsReadyForFinishDestroy();
+}

--- a/Source/CesiumRuntime/Private/CesiumWebMapServiceRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumWebMapServiceRasterOverlay.cpp
@@ -37,3 +37,8 @@ UCesiumWebMapServiceRasterOverlay::CreateOverlay(
       wmsOptions,
       options);
 }
+
+bool UCesiumWebMapServiceRasterOverlay::IsReadyForFinishDestroy() {
+  this->SetUrl(this->BaseUrl);
+  return Super::IsReadyForFinishDestroy();
+}

--- a/Source/CesiumRuntime/Private/CesiumWebMapTileServiceRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumWebMapTileServiceRasterOverlay.cpp
@@ -119,3 +119,8 @@ UCesiumWebMapTileServiceRasterOverlay::CreateOverlay(
       wmtsOptions,
       options);
 }
+
+bool UCesiumWebMapTileServiceRasterOverlay::IsReadyForFinishDestroy() {
+  this->SetUrl(this->BaseUrl);
+  return Super::IsReadyForFinishDestroy();
+}

--- a/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
+++ b/Source/CesiumRuntime/Private/UnrealAssetAccessor.cpp
@@ -176,6 +176,9 @@ void rejectPromiseOnUnsuccessfulConnection(
 
 } // namespace
 
+TSet<TSharedRef<IHttpRequest, ESPMode::ThreadSafe>> UnrealAssetAccessor::_pendingRequests;
+FCriticalSection UnrealAssetAccessor::_pendingRequestsLock;
+
 CesiumAsync::Future<std::shared_ptr<CesiumAsync::IAssetRequest>>
 UnrealAssetAccessor::get(
     const CesiumAsync::AsyncSystem& asyncSystem,
@@ -211,6 +214,12 @@ UnrealAssetAccessor::get(
 
         pRequest->AppendToHeader(TEXT("User-Agent"), userAgent);
 
+        // Add to the pending list when initiating a request
+        {
+          FScopeLock lock(&UnrealAssetAccessor::_pendingRequestsLock);
+          UnrealAssetAccessor::_pendingRequests.Add(pRequest);
+        }
+
         pRequest->OnProcessRequestComplete().BindLambda(
             [promise, CESIUM_TRACE_LAMBDA_CAPTURE_TRACK()](
                 FHttpRequestPtr pRequest,
@@ -218,6 +227,17 @@ UnrealAssetAccessor::get(
                 bool connectedSuccessfully) mutable {
               CESIUM_TRACE_USE_CAPTURED_TRACK();
               CESIUM_TRACE_END_IN_TRACK("requestAsset");
+
+              // Request to end removal
+              {
+                FScopeLock lock(&UnrealAssetAccessor::_pendingRequestsLock);
+                for (auto It = UnrealAssetAccessor::_pendingRequests.CreateIterator(); It; ++It) {
+                  if (&(It->Get()) == pRequest.Get()) {
+                    It.RemoveCurrent();
+                    break;
+                  }
+                }
+              }
 
               if (connectedSuccessfully) {
                 promise.resolve(
@@ -268,6 +288,12 @@ UnrealAssetAccessor::request(
 
         pRequest->AppendToHeader(TEXT("User-Agent"), userAgent);
 
+        // Add to the pending list when initiating a request
+        {
+          FScopeLock lock(&UnrealAssetAccessor::_pendingRequestsLock);
+          UnrealAssetAccessor::_pendingRequests.Add(pRequest);
+        }
+
         pRequest->SetContent(TArray<uint8>(
             reinterpret_cast<const uint8*>(contentPayload.data()),
             contentPayload.size()));
@@ -277,6 +303,18 @@ UnrealAssetAccessor::request(
                 FHttpRequestPtr pRequest,
                 FHttpResponsePtr pResponse,
                 bool connectedSuccessfully) {
+
+              // Request to end removal
+              {
+                FScopeLock lock(&UnrealAssetAccessor::_pendingRequestsLock);
+                for (auto It = UnrealAssetAccessor::_pendingRequests.CreateIterator(); It; ++It) {
+                  if (&(It->Get()) == pRequest.Get()) {
+                    It.RemoveCurrent();
+                    break;
+                  }
+                }
+              }
+
               if (connectedSuccessfully) {
                 promise.resolve(
                     std::make_unique<UnrealAssetRequest>(pRequest, pResponse));

--- a/Source/CesiumRuntime/Public/CesiumBingMapsRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumBingMapsRasterOverlay.h
@@ -40,6 +40,7 @@ public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
   EBingMapsStyle MapStyle = EBingMapsStyle::Aerial;
 
+  virtual bool IsReadyForFinishDestroy() override;
 protected:
   virtual std::unique_ptr<CesiumRasterOverlays::RasterOverlay> CreateOverlay(
       const CesiumRasterOverlays::RasterOverlayOptions& options = {}) override;

--- a/Source/CesiumRuntime/Public/CesiumIonRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumIonRasterOverlay.h
@@ -64,6 +64,7 @@ public:
   // UActorComponent overrides
   virtual void PostLoad() override;
 
+  virtual bool IsReadyForFinishDestroy() override;
 protected:
   virtual std::unique_ptr<CesiumRasterOverlays::RasterOverlay> CreateOverlay(
       const CesiumRasterOverlays::RasterOverlayOptions& options = {}) override;

--- a/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
@@ -166,6 +166,7 @@ public:
   virtual void OnComponentDestroyed(bool bDestroyingHierarchy) override;
   virtual bool IsReadyForFinishDestroy() override;
 
+  static FString ExtractCleanBaseUrl(const FString& InUrl);
 protected:
   /**
    * The maximum number of pixels of error when rendering this overlay.
@@ -257,4 +258,5 @@ protected:
 private:
   CesiumRasterOverlays::RasterOverlay* _pOverlay;
   int32 _overlaysBeingDestroyed;
+  FString _url;
 };

--- a/Source/CesiumRuntime/Public/CesiumTileMapServiceRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumTileMapServiceRasterOverlay.h
@@ -58,6 +58,7 @@ public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
   TMap<FString, FString> RequestHeaders;
 
+  virtual bool IsReadyForFinishDestroy() override;
 protected:
   virtual std::unique_ptr<CesiumRasterOverlays::RasterOverlay> CreateOverlay(
       const CesiumRasterOverlays::RasterOverlayOptions& options = {}) override;

--- a/Source/CesiumRuntime/Public/CesiumUrlTemplateRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumUrlTemplateRasterOverlay.h
@@ -226,6 +226,7 @@ public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
   TMap<FString, FString> RequestHeaders;
 
+  virtual bool IsReadyForFinishDestroy() override;
 protected:
   virtual std::unique_ptr<CesiumRasterOverlays::RasterOverlay> CreateOverlay(
       const CesiumRasterOverlays::RasterOverlayOptions& options = {}) override;

--- a/Source/CesiumRuntime/Public/CesiumWebMapServiceRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumWebMapServiceRasterOverlay.h
@@ -81,6 +81,7 @@ public:
   UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
   TMap<FString, FString> RequestHeaders;
 
+  virtual bool IsReadyForFinishDestroy() override;
 protected:
   virtual std::unique_ptr<CesiumRasterOverlays::RasterOverlay> CreateOverlay(
       const CesiumRasterOverlays::RasterOverlayOptions& options = {}) override;

--- a/Source/CesiumRuntime/Public/CesiumWebMapTileServiceRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumWebMapTileServiceRasterOverlay.h
@@ -275,6 +275,7 @@ public:
 
   virtual void Serialize(FArchive& Ar) override;
 
+  virtual bool IsReadyForFinishDestroy() override;
 protected:
   virtual std::unique_ptr<CesiumRasterOverlays::RasterOverlay> CreateOverlay(
       const CesiumRasterOverlays::RasterOverlayOptions& options = {}) override;

--- a/Source/CesiumRuntime/Public/UnrealAssetAccessor.h
+++ b/Source/CesiumRuntime/Public/UnrealAssetAccessor.h
@@ -9,6 +9,7 @@
 #include "HAL/Platform.h"
 #include <cstddef>
 
+class IHttpRequest;
 class CESIUMRUNTIME_API UnrealAssetAccessor
     : public CesiumAsync::IAssetAccessor {
 public:
@@ -30,6 +31,8 @@ public:
 
   virtual void tick() noexcept override;
 
+  static TSet<TSharedRef<IHttpRequest, ESPMode::ThreadSafe>> _pendingRequests;
+  static FCriticalSection _pendingRequestsLock;
 private:
   CesiumAsync::Future<std::shared_ptr<CesiumAsync::IAssetRequest>> getFromFile(
       const CesiumAsync::AsyncSystem& asyncSystem,


### PR DESCRIPTION
Dear Cesium Official Team,

Hello!

This pull request primarily addresses the issue discussed on the Cesium forum regarding this link [It took more than ten seconds to exit](https://community.cesium.com/t/it-took-more-than-ten-seconds-to-exit/23354).

The approach is as follows: it tracks all pending requests made by the UnrealAssetAccessor class, and when a UCesiumRasterOverlay or Cesium3DTileset instance is destroyed, it simultaneously cancels all pending requests associated with that instance.

Its limitation: for Cesium Ion map resources, it determines this in a hard-coded manner (e.g., for Bing Maps or Cesium World Terrain).

For a large open-source repository, this code is not particularly perfect. I do not have high expectations for the acceptance of this pull request, but I hope my approach is helpful to you, and I hope you will pay attention to this issue. This would make it more friendly for developers in regions with poor network conditions or those facing network instability.

Best regards.