### PR TITLE
Add iTwin support to Cesium for Unreal

### DIFF
--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -433,6 +433,24 @@ void ACesium3DTileset::SetIonAccessToken(const FString& InAccessToken) {
   }
 }
 
+void ACesium3DTileset::SetITwinCesiumContentID(int64 InContentID) {
+  if (InContentID >= 0 && InContentID != this->ITwinCesiumContentID) {
+    if (this->TilesetSource == ETilesetSource::FromITwinCesiumCuratedContent) {
+      this->DestroyTileset();
+    }
+    this->ITwinCesiumContentID = InContentID;
+  }
+}
+
+void ACesium3DTileset::SetITwinAccessToken(const FString& InAccessToken) {
+  if (this->ITwinAccessToken != InAccessToken) {
+    if (this->TilesetSource == ETilesetSource::FromITwinCesiumCuratedContent) {
+      this->DestroyTileset();
+    }
+    this->ITwinAccessToken = InAccessToken;
+  }
+}
+
 void ACesium3DTileset::SetCesiumIonServer(UCesiumIonServer* Server) {
   if (this->CesiumIonServer != Server) {
     if (this->TilesetSource == ETilesetSource::FromCesiumIon) {
@@ -1107,29 +1125,46 @@ void ACesium3DTileset::LoadTileset() {
         Log,
         TEXT("Loading tileset for asset ID %d"),
         this->IonAssetID);
-    FString token = this->IonAccessToken.IsEmpty()
-                        ? this->CesiumIonServer->DefaultIonAccessToken
-                        : this->IonAccessToken;
+    {
+      FString token = this->IonAccessToken.IsEmpty()
+                          ? this->CesiumIonServer->DefaultIonAccessToken
+                          : this->IonAccessToken;
 
 #if WITH_EDITOR
-    this->CesiumIonServer->ResolveApiUrl();
+      this->CesiumIonServer->ResolveApiUrl();
 #endif
 
-    std::string ionAssetEndpointUrl =
-        TCHAR_TO_UTF8(*this->CesiumIonServer->ApiUrl);
+      std::string ionAssetEndpointUrl =
+          TCHAR_TO_UTF8(*this->CesiumIonServer->ApiUrl);
 
-    if (!ionAssetEndpointUrl.empty()) {
-      // Make sure the URL ends with a slash
-      if (!ionAssetEndpointUrl.empty() && *ionAssetEndpointUrl.rbegin() != '/')
-        ionAssetEndpointUrl += '/';
+      if (!ionAssetEndpointUrl.empty()) {
+        // Make sure the URL ends with a slash
+        if (!ionAssetEndpointUrl.empty() &&
+            *ionAssetEndpointUrl.rbegin() != '/')
+          ionAssetEndpointUrl += '/';
 
-      this->_pTileset = MakeUnique<Cesium3DTilesSelection::Tileset>(
-          externals,
-          static_cast<uint32_t>(this->IonAssetID),
-          TCHAR_TO_UTF8(*token),
-          options,
-          ionAssetEndpointUrl);
+        this->_pTileset = MakeUnique<Cesium3DTilesSelection::Tileset>(
+            externals,
+            static_cast<uint32_t>(this->IonAssetID),
+            TCHAR_TO_UTF8(*token),
+            options,
+            ionAssetEndpointUrl);
+      }
     }
+    break;
+  case ETilesetSource::FromITwinCesiumCuratedContent:
+    UE_LOG(
+        LogCesium,
+        Log,
+        TEXT("Loading tileset for asset ID %d"),
+        this->ITwinCesiumContentID);
+
+    this->_pTileset = MakeUnique<Cesium3DTilesSelection::Tileset>(
+        externals,
+        Cesium3DTilesSelection::ITwinCesiumCuratedContentLoaderFactory(
+            static_cast<uint32_t>(this->ITwinCesiumContentID),
+            TCHAR_TO_UTF8(*this->ITwinAccessToken)),
+        options);
     break;
   }
 
@@ -1180,6 +1215,13 @@ void ACesium3DTileset::LoadTileset() {
         TEXT("Loading tileset for asset ID %d done"),
         this->IonAssetID);
     break;
+  case ETilesetSource::FromITwinCesiumCuratedContent:
+    UE_LOG(
+        LogCesium,
+        Log,
+        TEXT("Loading tileset for asset ID %d done"),
+        this->ITwinCesiumContentID);
+    break;
   }
 
   switch (ApplyDpiScaling) {
@@ -1220,6 +1262,13 @@ void ACesium3DTileset::DestroyTileset() {
         Verbose,
         TEXT("Destroying tileset for asset ID %d"),
         this->IonAssetID);
+    break;
+  case ETilesetSource::FromITwinCesiumCuratedContent:
+    UE_LOG(
+        LogCesium,
+        Verbose,
+        TEXT("Destroying tileset for asset ID %d"),
+        this->ITwinCesiumContentID);
     break;
   }
 
@@ -1273,6 +1322,13 @@ void ACesium3DTileset::DestroyTileset() {
         Verbose,
         TEXT("Destroying tileset for asset ID %d done"),
         this->IonAssetID);
+    break;
+  case ETilesetSource::FromITwinCesiumCuratedContent:
+    UE_LOG(
+        LogCesium,
+        Verbose,
+        TEXT("Destroying tileset for asset ID %d done"),
+        this->ITwinCesiumContentID);
     break;
   }
 }
@@ -2142,6 +2198,9 @@ void ACesium3DTileset::PostEditChangeProperty(
       PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, Url) ||
       PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, IonAssetID) ||
       PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, IonAccessToken) ||
+      PropName ==
+          GET_MEMBER_NAME_CHECKED(ACesium3DTileset, ITwinCesiumContentID) ||
+      PropName == GET_MEMBER_NAME_CHECKED(ACesium3DTileset, ITwinAccessToken) ||
       PropName ==
           GET_MEMBER_NAME_CHECKED(ACesium3DTileset, CreatePhysicsMeshes) ||
       PropName ==

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -1221,7 +1221,9 @@ void ACesium3DTileset::LoadTileset() {
         externals,
         Cesium3DTilesSelection::ITwinRealityDataContentLoaderFactory(
             TCHAR_TO_UTF8(*this->RealityDataID),
-            this->ITwinID.IsEmpty() ? std::nullopt : std::make_optional<std::string>(TCHAR_TO_UTF8(*this->ITwinID)),
+            this->ITwinID.IsEmpty() ? std::nullopt
+                                    : std::make_optional<std::string>(
+                                          TCHAR_TO_UTF8(*this->ITwinID)),
             TCHAR_TO_UTF8(*this->ITwinAccessToken)),
         options);
     break;

--- a/Source/CesiumRuntime/Private/CesiumITwinAPIBlueprintLibrary.cpp
+++ b/Source/CesiumRuntime/Private/CesiumITwinAPIBlueprintLibrary.cpp
@@ -1,5 +1,5 @@
 #include "CesiumITwinAPIBlueprintLibrary.h"
-
+#include "Async/Async.h"
 #include "CesiumITwinCesiumCuratedContentRasterOverlay.h"
 #include "CesiumRuntime.h"
 #include <CesiumUtility/Result.h>

--- a/Source/CesiumRuntime/Private/CesiumITwinAPIBlueprintLibrary.cpp
+++ b/Source/CesiumRuntime/Private/CesiumITwinAPIBlueprintLibrary.cpp
@@ -1,0 +1,203 @@
+#include "CesiumITwinAPIBlueprintLibrary.h"
+
+#include "CesiumRuntime.h"
+#include <CesiumUtility/Result.h>
+
+UCesiumITwinAPIAuthorizeAsyncAction*
+UCesiumITwinAPIAuthorizeAsyncAction::Authorize(const FString& ClientID) {
+  UCesiumITwinAPIAuthorizeAsyncAction* pAsyncAction =
+      NewObject<UCesiumITwinAPIAuthorizeAsyncAction>();
+  pAsyncAction->_clientId = ClientID;
+  return pAsyncAction;
+}
+
+void UCesiumITwinAPIAuthorizeAsyncAction::Activate() {
+  CesiumITwinClient::Connection::authorize(
+      getAsyncSystem(),
+      getAssetAccessor(),
+      "Cesium for Unreal",
+      TCHAR_TO_UTF8(*this->_clientId),
+      "/itwin/auth/redirect",
+      5081,
+      std::vector<std::string>{"itwin-platform", "offline_access"},
+      [&Callback = this->OnAuthorizationEvent](const std::string& url) {
+        Callback.Broadcast(
+            ECesiumITwinDelegateType::OpenUrl,
+            UTF8_TO_TCHAR(url.c_str()),
+            nullptr,
+            TArray<FString>());
+      })
+      .thenInMainThread([this](CesiumUtility::Result<
+                               CesiumITwinClient::Connection>&& connection) {
+        if (!IsValid(this)) {
+          UE_LOG(
+              LogCesium,
+              Warning,
+              TEXT(
+                  "Authorization finished but authorize async action is no longer valid."));
+          return;
+        }
+
+        if (!connection.value) {
+          TArray<FString> Errors;
+          for (const std::string& error : connection.errors.errors) {
+            Errors.Emplace(UTF8_TO_TCHAR(error.c_str()));
+          }
+
+          for (const std::string& warning : connection.errors.warnings) {
+            Errors.Emplace(UTF8_TO_TCHAR(warning.c_str()));
+          }
+
+          this->OnAuthorizationEvent.Broadcast(
+              ECesiumITwinDelegateType::Failure,
+              FString(),
+              nullptr,
+              Errors);
+        } else {
+          TSharedPtr<CesiumITwinClient::Connection> pInternalConnection =
+              MakeShared<CesiumITwinClient::Connection>(
+                  MoveTemp(*connection.value));
+          UCesiumITwinConnection* pConnection =
+              NewObject<UCesiumITwinConnection>();
+          pConnection->SetConnection(pInternalConnection);
+          this->OnAuthorizationEvent.Broadcast(
+              ECesiumITwinDelegateType::Success,
+              FString(),
+              pConnection,
+              TArray<FString>());
+          this->SetReadyToDestroy();
+        }
+      });
+}
+
+UCesiumITwinAPIGetProfileAsyncAction*
+UCesiumITwinAPIGetProfileAsyncAction::GetProfile(
+    UCesiumITwinConnection* pConnection) {
+  UCesiumITwinAPIGetProfileAsyncAction* pAsyncAction =
+      NewObject<UCesiumITwinAPIGetProfileAsyncAction>();
+  pAsyncAction->pConnection = pConnection->pConnection;
+  return pAsyncAction;
+}
+
+void UCesiumITwinAPIGetProfileAsyncAction::Activate() {
+  if (!this->pConnection) {
+    TArray<FString> Errors;
+    Errors.Push("No connection to iTwin.");
+    OnProfileResult.Broadcast(nullptr, Errors);
+    return;
+  }
+
+  this->pConnection->me().thenInMainThread([this](CesiumUtility::Result<
+                                                  CesiumITwinClient::
+                                                      UserProfile>&& result) {
+    if (!IsValid(this)) {
+      UE_LOG(
+          LogCesium,
+          Warning,
+          TEXT(
+              "Authorization finished but authorize async action is no longer valid."));
+      return;
+    }
+
+    if (!result.value) {
+      TArray<FString> Errors;
+      for (const std::string& error : result.errors.errors) {
+        Errors.Emplace(UTF8_TO_TCHAR(error.c_str()));
+      }
+
+      for (const std::string& warning : result.errors.warnings) {
+        Errors.Emplace(UTF8_TO_TCHAR(warning.c_str()));
+      }
+
+      OnProfileResult.Broadcast(nullptr, Errors);
+    } else {
+      UCesiumITwinUserProfile* pProfile = NewObject<UCesiumITwinUserProfile>();
+      pProfile->SetProfile(std::move(*result.value));
+      OnProfileResult.Broadcast(pProfile, TArray<FString>());
+    }
+  });
+}
+
+UCesiumITwinAPIGetResourcesAsyncAction*
+UCesiumITwinAPIGetResourcesAsyncAction::GetResources(
+    const UObject* WorldContextObject,
+    UCesiumITwinConnection* pConnection) {
+  UCesiumITwinAPIGetResourcesAsyncAction* pAsyncAction =
+      NewObject<UCesiumITwinAPIGetResourcesAsyncAction>(
+          WorldContextObject->GetWorld());
+  pAsyncAction->pConnection = pConnection->pConnection;
+  return pAsyncAction;
+}
+
+void UCesiumITwinAPIGetResourcesAsyncAction::Activate() {
+  if (!this->pConnection) {
+    TArray<FString> Errors;
+    Errors.Push("No connection to iTwin.");
+    OnResourcesEvent.Broadcast(
+        EGetResourcesCallbackType::Failure,
+        TArray<UCesiumITwinResource*>(),
+        0,
+        0,
+        Errors);
+    return;
+  }
+
+  this->pConnection
+      ->listAllAvailableResources([this](
+                                      const std::atomic_int& finished,
+                                      const std::atomic_int& total) {
+        AsyncTask(ENamedThreads::GameThread, [&finished, &total, this]() {
+          this->OnResourcesEvent.Broadcast(
+              EGetResourcesCallbackType::Status,
+              {},
+              finished.load(),
+              total.load(),
+              {});
+        });
+      })
+      .thenInMainThread([this](CesiumUtility::Result<
+                               std::vector<CesiumITwinClient::ITwinResource>>&&
+                                   result) {
+        if (!IsValid(this)) {
+          UE_LOG(
+              LogCesium,
+              Warning,
+              TEXT(
+                  "Authorization finished but authorize async action is no longer valid."));
+          return;
+        }
+
+        if (!result.value) {
+          TArray<FString> Errors;
+          for (const std::string& error : result.errors.errors) {
+            Errors.Emplace(UTF8_TO_TCHAR(error.c_str()));
+          }
+
+          for (const std::string& warning : result.errors.warnings) {
+            Errors.Emplace(UTF8_TO_TCHAR(warning.c_str()));
+          }
+
+          this->OnResourcesEvent
+              .Broadcast(EGetResourcesCallbackType::Failure, {}, 0, 0, Errors);
+        } else {
+          TArray<UCesiumITwinResource*> Resources;
+          Resources.Reserve(result.value->size());
+
+          for (const CesiumITwinClient::ITwinResource& resource :
+               *result.value) {
+            UCesiumITwinResource* pNewResource =
+                NewObject<UCesiumITwinResource>(GetWorld());
+            pNewResource->SetResource(resource);
+            pNewResource->SetConnection(this->pConnection);
+            Resources.Push(pNewResource);
+          }
+
+          this->OnResourcesEvent.Broadcast(
+              EGetResourcesCallbackType::Success,
+              Resources,
+              0,
+              0,
+              {});
+        }
+      });
+}

--- a/Source/CesiumRuntime/Private/CesiumITwinCesiumCuratedContentRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumITwinCesiumCuratedContentRasterOverlay.cpp
@@ -1,0 +1,30 @@
+// Copyright 2020-2024 CesiumGS, Inc. and Contributors
+
+#include "CesiumITwinCesiumCuratedContentRasterOverlay.h"
+#include "Cesium3DTilesSelection/Tileset.h"
+#include "CesiumActors.h"
+#include "CesiumCustomVersion.h"
+#include "CesiumIonServer.h"
+#include "CesiumRasterOverlays/ITwinCesiumCuratedContentRasterOverlay.h"
+#include "CesiumRuntime.h"
+#include "CesiumRuntimeSettings.h"
+
+#if WITH_EDITOR
+#include "FileHelpers.h"
+#endif
+
+std::unique_ptr<CesiumRasterOverlays::RasterOverlay>
+UCesiumITwinCesiumCuratedContentRasterOverlay::CreateOverlay(
+    const CesiumRasterOverlays::RasterOverlayOptions& options) {
+  if (this->AssetID <= 0) {
+    // Don't create an overlay for an invalid asset ID.
+    return nullptr;
+  }
+
+  return std::make_unique<
+      CesiumRasterOverlays::ITwinCesiumCuratedContentRasterOverlay>(
+      TCHAR_TO_UTF8(*this->MaterialLayerKey),
+      this->AssetID,
+      TCHAR_TO_UTF8(*this->ITwinAccessToken),
+      options);
+}

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -83,7 +83,14 @@ enum class ETilesetSource : uint8 {
   /**
    * The tileset will be loaded from the georeference ellipsoid.
    */
-  FromEllipsoid UMETA(DisplayName = "From Ellipsoid")
+  FromEllipsoid UMETA(DisplayName = "From Ellipsoid"),
+
+  /**
+   * The tileset will be loaded from the Bentley iTwin Cesium Curated Content
+   * API using the provided ITwinCesiumContentID and ITwinAccessToken.
+   */
+  FromITwinCesiumCuratedContent UMETA(
+      DisplayName = "From iTwin Cesium Curated Content"),
 };
 
 UENUM(BlueprintType)
@@ -765,6 +772,36 @@ private:
   UCesiumIonServer* CesiumIonServer;
 
   /**
+   * The ID of the iTwin Cesium Curated Content asset to use.
+   *
+   * This property is ignored if TilesetSource isn't set to "From iTwin Cesium
+   * Curated Content"
+   */
+  UPROPERTY(
+      EditAnywhere,
+      BlueprintGetter = GetITwinCesiumContentID,
+      BlueprintSetter = SetITwinCesiumContentID,
+      Category = "Cesium",
+      meta =
+          (EditCondition =
+               "TilesetSource==ETilesetSource::FromITwinCesiumCuratedContent",
+           ClampMin = 0))
+  int64 ITwinCesiumContentID;
+
+  /**
+   * The access token to use to access the iTwin resource.
+   */
+  UPROPERTY(
+      EditAnywhere,
+      BlueprintGetter = GetITwinAccessToken,
+      BlueprintSetter = SetITwinAccessToken,
+      Category = "Cesium",
+      meta =
+          (EditCondition =
+               "TilesetSource==ETilesetSource::FromITwinCesiumCuratedContent"))
+  FString ITwinAccessToken;
+
+  /**
    * Headers to be attached to each request made for this tileset.
    */
   UPROPERTY(
@@ -1037,6 +1074,18 @@ public:
 
   UFUNCTION(BlueprintGetter, Category = "Cesium")
   UCesiumIonServer* GetCesiumIonServer() const { return CesiumIonServer; }
+
+  UFUNCTION(BlueprintGetter, Category = "Cesium")
+  int64 GetITwinCesiumContentID() const { return ITwinCesiumContentID; }
+
+  UFUNCTION(BlueprintSetter, Category = "Cesium")
+  void SetITwinCesiumContentID(int64 InContentID);
+
+  UFUNCTION(BlueprintGetter, Category = "Cesium")
+  FString GetITwinAccessToken() const { return ITwinAccessToken; }
+
+  UFUNCTION(BlueprintSetter, Category = "Cesium")
+  void SetITwinAccessToken(const FString& InAccessToken);
 
   UFUNCTION(BlueprintGetter, Category = "VirtualTexture")
   TArray<URuntimeVirtualTexture*> GetRuntimeVirtualTextures() const {

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -91,6 +91,13 @@ enum class ETilesetSource : uint8 {
    */
   FromITwinCesiumCuratedContent UMETA(
       DisplayName = "From iTwin Cesium Curated Content"),
+
+  /**
+   * The tileset will be loaded from the iModel Mesh Export Service using the
+   * provided IModelID and ITwinAccessToken.
+   */
+  FromIModelMeshExportService UMETA(
+      DisplayName = "From iModel Mesh Export Service"),
 };
 
 UENUM(BlueprintType)
@@ -789,6 +796,23 @@ private:
   int64 ITwinCesiumContentID;
 
   /**
+   * The ID of the iModel to use when interacting with the iModel Mesh Export
+   * Service.
+   *
+   * This property is ignored if TilesetSource isn't set to "From iModel Mesh
+   * Export Service"
+   */
+  UPROPERTY(
+      EditAnywhere,
+      BlueprintGetter = GetIModelID,
+      BlueprintSetter = SetIModelID,
+      Category = "Cesium",
+      meta =
+          (EditCondition =
+               "TilesetSource==ETilesetSource::FromIModelMeshExportService"))
+  FString IModelID;
+
+  /**
    * The access token to use to access the iTwin resource.
    */
   UPROPERTY(
@@ -798,7 +822,7 @@ private:
       Category = "Cesium",
       meta =
           (EditCondition =
-               "TilesetSource==ETilesetSource::FromITwinCesiumCuratedContent"))
+               "TilesetSource==ETilesetSource::FromITwinCesiumCuratedContent || TilesetSource==ETilesetSource::FromIModelMeshExportService"))
   FString ITwinAccessToken;
 
   /**
@@ -1080,6 +1104,12 @@ public:
 
   UFUNCTION(BlueprintSetter, Category = "Cesium")
   void SetITwinCesiumContentID(int64 InContentID);
+
+  UFUNCTION(BlueprintGetter, Category = "Cesium")
+  FString GetIModelID() const { return IModelID; }
+
+  UFUNCTION(BlueprintSetter, Category = "Cesium")
+  void SetIModelID(const FString& InModelID);
 
   UFUNCTION(BlueprintGetter, Category = "Cesium")
   FString GetITwinAccessToken() const { return ITwinAccessToken; }

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -819,9 +819,11 @@ private:
   FString IModelID;
 
   /**
-   * The ID of the iTwin Reality Data to use when interacting with the Reality Data service.
+   * The ID of the iTwin Reality Data to use when interacting with the Reality
+   * Data service.
    *
-   * This property is ignored if TilesetSource isn't set to "From iTwin Reality Data"
+   * This property is ignored if TilesetSource isn't set to "From iTwin Reality
+   * Data"
    */
   UPROPERTY(
       EditAnywhere,

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -98,6 +98,12 @@ enum class ETilesetSource : uint8 {
    */
   FromIModelMeshExportService UMETA(
       DisplayName = "From iModel Mesh Export Service"),
+
+  /**
+   * The tileset will be loaded from the iModel Mesh Export Service using the
+   * provided RealityDataID and ITwinAccessToken.
+   */
+  FromITwinRealityData UMETA(DisplayName = "From iTwin Reality Data")
 };
 
 UENUM(BlueprintType)
@@ -813,6 +819,38 @@ private:
   FString IModelID;
 
   /**
+   * The ID of the iTwin Reality Data to use when interacting with the Reality Data service.
+   *
+   * This property is ignored if TilesetSource isn't set to "From iTwin Reality Data"
+   */
+  UPROPERTY(
+      EditAnywhere,
+      BlueprintGetter = GetRealityDataID,
+      BlueprintSetter = SetRealityDataID,
+      Category = "Cesium",
+      meta =
+          (EditCondition =
+               "TilesetSource==ETilesetSource::FromITwinRealityData"))
+  FString RealityDataID;
+
+  /**
+   * The ID of the iTwin to use when interacting with the Reality
+   * Data service.
+   *
+   * This property is ignored if TilesetSource isn't set to "From iTwin Reality
+   * Data"
+   */
+  UPROPERTY(
+      EditAnywhere,
+      BlueprintGetter = GetITwinID,
+      BlueprintSetter = SetITwinID,
+      Category = "Cesium",
+      meta =
+          (EditCondition =
+               "TilesetSource==ETilesetSource::FromITwinRealityData"))
+  FString ITwinID;
+
+  /**
    * The access token to use to access the iTwin resource.
    */
   UPROPERTY(
@@ -822,7 +860,7 @@ private:
       Category = "Cesium",
       meta =
           (EditCondition =
-               "TilesetSource==ETilesetSource::FromITwinCesiumCuratedContent || TilesetSource==ETilesetSource::FromIModelMeshExportService"))
+               "TilesetSource==ETilesetSource::FromITwinCesiumCuratedContent || TilesetSource==ETilesetSource::FromIModelMeshExportService || TilesetSource==ETilesetSource::FromITwinRealityData"))
   FString ITwinAccessToken;
 
   /**
@@ -1110,6 +1148,18 @@ public:
 
   UFUNCTION(BlueprintSetter, Category = "Cesium")
   void SetIModelID(const FString& InModelID);
+
+  UFUNCTION(BlueprintGetter, Category = "Cesium")
+  FString GetRealityDataID() const { return RealityDataID; }
+
+  UFUNCTION(BlueprintSetter, Category = "Cesium")
+  void SetRealityDataID(const FString& InModelID);
+
+  UFUNCTION(BlueprintGetter, Category = "Cesium")
+  FString GetITwinID() const { return ITwinID; }
+
+  UFUNCTION(BlueprintSetter, Category = "Cesium")
+  void SetITwinID(const FString& InITwinID);
 
   UFUNCTION(BlueprintGetter, Category = "Cesium")
   FString GetITwinAccessToken() const { return ITwinAccessToken; }

--- a/Source/CesiumRuntime/Public/CesiumITwinAPIBlueprintLibrary.h
+++ b/Source/CesiumRuntime/Public/CesiumITwinAPIBlueprintLibrary.h
@@ -111,44 +111,7 @@ public:
   }
 
   UFUNCTION(BlueprintCallable, Category = "Cesium|iTwin")
-  void Spawn() {
-    if (_resource.resourceType == CesiumITwinClient::ResourceType::Imagery) {
-      // TODO
-      return;
-    }
-
-    UWorld* pWorld = GetWorld();
-    check(pWorld);
-
-    ACesiumGeoreference* pParent =
-        ACesiumGeoreference::GetDefaultGeoreference(pWorld);
-
-    check(pParent);
-
-    ACesium3DTileset* pTileset = pWorld->SpawnActor<ACesium3DTileset>();
-    pTileset->AttachToActor(
-        pParent,
-        FAttachmentTransformRules::KeepRelativeTransform);
-
-    pTileset->SetITwinAccessToken(
-        UTF8_TO_TCHAR(this->_pConnection->getAccessToken().getToken().c_str()));
-
-    switch (_resource.source) {
-    case CesiumITwinClient::ResourceSource::CesiumCuratedContent:
-      pTileset->SetTilesetSource(ETilesetSource::FromITwinCesiumCuratedContent);
-      pTileset->SetITwinCesiumContentID(std::stoi(_resource.id));
-      break;
-    case CesiumITwinClient::ResourceSource::MeshExport:
-      pTileset->SetTilesetSource(ETilesetSource::FromIModelMeshExportService);
-      pTileset->SetIModelID(UTF8_TO_TCHAR(_resource.id.c_str()));
-      break;
-    case CesiumITwinClient::ResourceSource::RealityData:
-      pTileset->SetTilesetSource(ETilesetSource::FromITwinRealityData);
-      pTileset->SetITwinID(UTF8_TO_TCHAR(_resource.parentId->c_str()));
-      pTileset->SetRealityDataID(UTF8_TO_TCHAR(_resource.parentId->c_str()));
-      break;
-    }
-  }
+  void Spawn();
 
   void SetResource(const CesiumITwinClient::ITwinResource& resource) {
     this->_resource = resource;

--- a/Source/CesiumRuntime/Public/CesiumITwinAPIBlueprintLibrary.h
+++ b/Source/CesiumRuntime/Public/CesiumITwinAPIBlueprintLibrary.h
@@ -1,0 +1,271 @@
+// Copyright 2020-2025 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "Cesium3DTileset.h"
+#include "CesiumGeoreference.h"
+#include "Kismet/BlueprintAsyncActionBase.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "Templates/SharedPointer.h"
+#include "UObject/Object.h"
+#include "UObject/ObjectMacros.h"
+THIRD_PARTY_INCLUDES_START
+#include <CesiumITwinClient/Connection.h>
+THIRD_PARTY_INCLUDES_END
+
+#include "CesiumITwinAPIBlueprintLibrary.generated.h"
+
+UCLASS(BlueprintType)
+class UCesiumITwinUserProfile : public UObject {
+  GENERATED_BODY()
+public:
+  UCesiumITwinUserProfile() : UObject(), _profile() {}
+
+  UCesiumITwinUserProfile(CesiumITwinClient::UserProfile&& profile)
+      : UObject(), _profile(std::move(profile)) {}
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|iTwin")
+  FString GetID() { return UTF8_TO_TCHAR(_profile.id.c_str()); }
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|iTwin")
+  FString GetDisplayName() {
+    return UTF8_TO_TCHAR(_profile.displayName.c_str());
+  }
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|iTwin")
+  FString GetGivenName() { return UTF8_TO_TCHAR(_profile.givenName.c_str()); }
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|iTwin")
+  FString GetSurname() { return UTF8_TO_TCHAR(_profile.surname.c_str()); }
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|iTwin")
+  FString GetEmail() { return UTF8_TO_TCHAR(_profile.email.c_str()); }
+
+  void SetProfile(CesiumITwinClient::UserProfile&& profile) {
+    this->_profile = std::move(profile);
+  }
+
+private:
+  CesiumITwinClient::UserProfile _profile;
+};
+
+UCLASS(BlueprintType)
+class UCesiumITwinConnection : public UObject {
+  GENERATED_BODY()
+public:
+  UCesiumITwinConnection() : UObject(), pConnection(nullptr) {}
+
+  UCesiumITwinConnection(TSharedPtr<CesiumITwinClient::Connection> pConnection)
+      : UObject(), pConnection(MoveTemp(pConnection)) {}
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|iTwin")
+  bool IsValid() { return this->pConnection != nullptr; }
+
+  void SetConnection(TSharedPtr<CesiumITwinClient::Connection> pConnection) {
+    this->pConnection = pConnection;
+  }
+
+  TSharedPtr<CesiumITwinClient::Connection> pConnection;
+};
+
+UCLASS(BlueprintType)
+class UCesiumITwinResource : public UObject {
+  GENERATED_BODY()
+public:
+  UCesiumITwinResource() : UObject() {}
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|iTwin")
+  FString GetID() { return UTF8_TO_TCHAR(_resource.id.c_str()); }
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|iTwin")
+  FString GetDisplayName() {
+    return UTF8_TO_TCHAR(_resource.displayName.c_str());
+  }
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|iTwin")
+  FString GetSource() {
+    switch (_resource.source) {
+    case CesiumITwinClient::ResourceSource::CesiumCuratedContent:
+      return FString(TEXT("Cesium Curated Content"));
+    case CesiumITwinClient::ResourceSource::MeshExport:
+      return FString(TEXT("Mesh Export"));
+    case CesiumITwinClient::ResourceSource::RealityData:
+      return FString(TEXT("Reality Data"));
+    }
+
+    return FString(TEXT("Unknown"));
+  }
+
+  UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Cesium|iTwin")
+  FString GetType() {
+    switch (_resource.resourceType) {
+    case CesiumITwinClient::ResourceType::Tileset:
+      return FString(TEXT("Tileset"));
+    case CesiumITwinClient::ResourceType::Imagery:
+      return FString(TEXT("Imagery"));
+    case CesiumITwinClient::ResourceType::Terrain:
+      return FString(TEXT("Terrain"));
+    }
+
+    return FString(TEXT("Unknown"));
+  }
+
+  UFUNCTION(BlueprintCallable, Category = "Cesium|iTwin")
+  void Spawn() {
+    if (_resource.resourceType == CesiumITwinClient::ResourceType::Imagery) {
+      // TODO
+      return;
+    }
+
+    UWorld* pWorld = GetWorld();
+    check(pWorld);
+
+    ACesiumGeoreference* pParent =
+        ACesiumGeoreference::GetDefaultGeoreference(pWorld);
+
+    check(pParent);
+
+    ACesium3DTileset* pTileset = pWorld->SpawnActor<ACesium3DTileset>();
+    pTileset->AttachToActor(
+        pParent,
+        FAttachmentTransformRules::KeepRelativeTransform);
+
+    pTileset->SetITwinAccessToken(
+        UTF8_TO_TCHAR(this->_pConnection->getAccessToken().getToken().c_str()));
+
+    switch (_resource.source) {
+    case CesiumITwinClient::ResourceSource::CesiumCuratedContent:
+      pTileset->SetTilesetSource(ETilesetSource::FromITwinCesiumCuratedContent);
+      pTileset->SetITwinCesiumContentID(std::stoi(_resource.id));
+      break;
+    case CesiumITwinClient::ResourceSource::MeshExport:
+      pTileset->SetTilesetSource(ETilesetSource::FromIModelMeshExportService);
+      pTileset->SetIModelID(UTF8_TO_TCHAR(_resource.id.c_str()));
+      break;
+    case CesiumITwinClient::ResourceSource::RealityData:
+      pTileset->SetTilesetSource(ETilesetSource::FromITwinRealityData);
+      pTileset->SetITwinID(UTF8_TO_TCHAR(_resource.parentId->c_str()));
+      pTileset->SetRealityDataID(UTF8_TO_TCHAR(_resource.parentId->c_str()));
+      break;
+    }
+  }
+
+  void SetResource(const CesiumITwinClient::ITwinResource& resource) {
+    this->_resource = resource;
+  }
+
+  void SetConnection(TSharedPtr<CesiumITwinClient::Connection> pConnection) {
+    this->_pConnection = pConnection;
+  }
+
+private:
+  CesiumITwinClient::ITwinResource _resource;
+  TSharedPtr<CesiumITwinClient::Connection> _pConnection;
+};
+
+UENUM(BlueprintType)
+enum class ECesiumITwinDelegateType : uint8 {
+  Invalid = 0,
+  OpenUrl = 1,
+  Failure = 2,
+  Success = 3
+};
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_FourParams(
+    FCesiumITwinAuthorizationDelegate,
+    ECesiumITwinDelegateType,
+    Type,
+    const FString&,
+    Url,
+    UCesiumITwinConnection*,
+    Connection,
+    const TArray<FString>&,
+    Errors);
+
+UCLASS()
+class CESIUMRUNTIME_API UCesiumITwinAPIAuthorizeAsyncAction
+    : public UBlueprintAsyncActionBase {
+  GENERATED_BODY()
+
+public:
+  UFUNCTION(
+      BlueprintCallable,
+      Category = "Cesium|iTwin",
+      meta = (BlueprintInternalUseOnly = true))
+  static UCesiumITwinAPIAuthorizeAsyncAction*
+  Authorize(const FString& ClientID);
+
+  UPROPERTY(BlueprintAssignable)
+  FCesiumITwinAuthorizationDelegate OnAuthorizationEvent;
+
+  virtual void Activate() override;
+
+private:
+  FString _clientId;
+};
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(
+    FCesiumITwinGetProfileDelegate,
+    UCesiumITwinUserProfile*,
+    Profile,
+    const TArray<FString>&,
+    Errors);
+
+UCLASS()
+class CESIUMRUNTIME_API UCesiumITwinAPIGetProfileAsyncAction
+    : public UBlueprintAsyncActionBase {
+  GENERATED_BODY()
+public:
+  UFUNCTION(
+      BlueprintCallable,
+      Category = "Cesium|iTwin",
+      meta = (BlueprintInternalUseOnly = true))
+  static UCesiumITwinAPIGetProfileAsyncAction*
+  GetProfile(UCesiumITwinConnection* pConnection);
+
+  UPROPERTY(BlueprintAssignable)
+  FCesiumITwinGetProfileDelegate OnProfileResult;
+
+  virtual void Activate() override;
+
+  TSharedPtr<CesiumITwinClient::Connection> pConnection;
+};
+
+UENUM(BlueprintType)
+enum class EGetResourcesCallbackType : uint8 { Status, Success, Failure };
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_FiveParams(
+    FCesiumITwinGetResourcesDelegate,
+    EGetResourcesCallbackType,
+    Type,
+    const TArray<UCesiumITwinResource*>&,
+    Resources,
+    int32,
+    FinishedRequests,
+    int32,
+    TotalRequests,
+    const TArray<FString>&,
+    Errors);
+
+UCLASS()
+class CESIUMRUNTIME_API UCesiumITwinAPIGetResourcesAsyncAction
+    : public UBlueprintAsyncActionBase {
+  GENERATED_BODY()
+public:
+  UFUNCTION(
+      BlueprintCallable,
+      Category = "Cesium|iTwin",
+      meta =
+          (BlueprintInternalUseOnly = true,
+           WorldContext = "WorldContextObject"))
+  static UCesiumITwinAPIGetResourcesAsyncAction* GetResources(
+      const UObject* WorldContextObject,
+      UCesiumITwinConnection* pConnection);
+
+  UPROPERTY(BlueprintAssignable)
+  FCesiumITwinGetResourcesDelegate OnResourcesEvent;
+
+  virtual void Activate() override;
+
+  TSharedPtr<CesiumITwinClient::Connection> pConnection;
+};

--- a/Source/CesiumRuntime/Public/CesiumITwinCesiumCuratedContentRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumITwinCesiumCuratedContentRasterOverlay.h
@@ -1,0 +1,37 @@
+// Copyright 2020-2024 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "CesiumRasterOverlay.h"
+#include "CoreMinimal.h"
+#include "CesiumITwinCesiumCuratedContentRasterOverlay.generated.h"
+
+/**
+ * A raster overlay that uses an IMAGERY asset from iTwin Cesium Curated
+ * Content.
+ */
+UCLASS(
+    DisplayName = "iTwin Cesium Curated Content Raster Overlay",
+    ClassGroup = (Cesium),
+    meta = (BlueprintSpawnableComponent))
+class CESIUMRUNTIME_API UCesiumITwinCesiumCuratedContentRasterOverlay
+    : public UCesiumRasterOverlay {
+  GENERATED_BODY()
+
+public:
+  /**
+   * The ID of the Cesium Curated Content asset to use.
+   */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
+  int64 AssetID;
+
+  /**
+   * The access token to use to access the Cesium Curated Content resource.
+   */
+  UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cesium")
+  FString ITwinAccessToken;
+
+protected:
+  virtual std::unique_ptr<CesiumRasterOverlays::RasterOverlay> CreateOverlay(
+      const CesiumRasterOverlays::RasterOverlayOptions& options = {}) override;
+};


### PR DESCRIPTION
This PR adds support for the iTwin functionality added to Cesium Native last month (almost two months ago at this point!). It adds support for loading tilesets from iTwin Cesium Curated Content, Reality Data, and the Mesh Export service, as well as raster overlays from the iTwin Cesium Curated Content. It also adds blueprint functionality for interacting with the iTwin API.