### PR TITLE
MetaData: Fixed wrong UV layer stored in map, when a same attribute is referenced multiple times

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Worked around an Unreal Engine limitation that prevented collisions and line traces from working correctly for tilesets with a very small scale factor.
 - Add a missing include for `GEngine` when packaging from source, introduced in *v2.16.0*.
+- Fixed a bug in UCesiumFeaturesMetadataComponent where multiple references to same feature ID set would cause improper encoding of its feature IDs.
 
 ### v2.16.0 - 2025-05-01
 

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -708,9 +708,8 @@ static void updateTextureCoordinatesForFeaturesMetadata(
 
       uint32_t textureCoordinateIndex = gltfToUnrealTexCoordMap.size();
 
-      // If the same attribute is referenced several times, only fill one UV
-      // layer with the latter (any UV layer duplicated here would be lost at
-      // the end when we transfer them to Unreal buffers).
+      // If the same attribute is referenced several times, this prevents
+      // it from replacing the existing texture coordinate index.
       auto insertedAccessor =
           gltfToUnrealTexCoordMap.try_emplace(accessor, textureCoordinateIndex);
       if (!insertedAccessor.second) {

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -782,8 +782,8 @@ static void updateTextureCoordinatesForFeaturesMetadata(
       // becomes possible to access the vertex ID through an Unreal material
       // node, this can be removed.
       uint32_t textureCoordinateIndex = gltfToUnrealTexCoordMap.size();
-      // Same remark as for feature ID attributes above: we can only store one
-      // UV layer here.
+      // Same remark as for feature ID attributes above: only assign a texture
+      // coordinate index the first time.
       auto insertedAccessor =
           gltfToUnrealTexCoordMap.try_emplace(-1, textureCoordinateIndex);
       if (!insertedAccessor.second) {


### PR DESCRIPTION
Issue related to **UCesiumFeaturesMetadataComponent**.

If a given per-primitive feature attribute (let's say _FEATURE_ID_0) is referenced by distinct metadata tables in the model, and we instantiate a _UCesiumFeaturesMetadataComponent_ component to bake the latter in UVs, the UV texture coordinate index stored in the dedicated map (gltfToUnrealTexCoordMap) is wrong, because only the 1st layer of UVs will be transferred at the end, and not the latest one.
Indeed, at the end, when we transfer the UVs to the Unreal buffers, we use the size of the map as number of UV layers (and the map does not grow if we try to insert a duplicated key ('accessor' here)).

This case does happen with the tilesets generated by iTwin Mesh Export Service, where the same primitive features _FEATURE_ID_0 are referencing several meta-data tables (one for Element, Model, Subcategory..., and one for material IDs)


<!--
Thanks for the Pull Request!

Please review the [Contributor Guide](https://cesium.com/learn/cesium-unreal/ref-doc/contributing-unreal.html) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://cesium.com/learn/cesium-unreal/ref-doc/contributing-unreal.html#opening-a-pull-request).

-->

## Description

<!-- Summarize the pull request. -- >

< !-- Provide context for the reviewer to understand the pull request. Include what changes were made and why. -->

<!-- Include screenshots if appropriate. -->

## Issue number or link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Author checklist

- [ ] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [ ] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [ ] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [ ] I have updated the documentation as necessary.

## Remaining Tasks

<!-- Are there any remaining tasks to do or blocking questions to answer before we can merge this? -->

<!-- If so, please convert this to a draft PR and let us know how we can help. Otherwise, you may remove this section. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

<!-- Include links to any required data or screenshots. Mention any edge cases such as user error, invalid data, etc. -->