### PR TITLE
Add support for `TRIANGLE_FAN` primitives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Add a missing include for `GEngine` when packaging from source, introduced in *v2.16.0*.
 - Fixed a bug in UCesiumFeaturesMetadataComponent where multiple references to same feature ID set would cause improper encoding of its feature IDs.
 - Removed an unnecessary copy operation that happened while constructing tile meshes.
+- Fixed a bug where indices would not be copied correctly for `TRIANGLE_FAN` primitives.
 
 ### v2.16.0 - 2025-05-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,16 @@
 
 ### ? - ?
 
+##### Additions :tada:
+
+- Added support for `TRIANGLE_FAN` primitives in tile meshes.
+
 ##### Fixes :wrench:
 
 - Worked around an Unreal Engine limitation that prevented collisions and line traces from working correctly for tilesets with a very small scale factor.
 - Add a missing include for `GEngine` when packaging from source, introduced in *v2.16.0*.
 - Fixed a bug in UCesiumFeaturesMetadataComponent where multiple references to same feature ID set would cause improper encoding of its feature IDs.
 - Removed an unnecessary copy operation that happened while constructing tile meshes.
-- Fixed a bug where indices would not be copied correctly for `TRIANGLE_FAN` primitives.
 
 ### v2.16.0 - 2025-05-01
 

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -1294,6 +1294,52 @@ struct PrimitiveModeLogger {
 };
 static PrimitiveModeLogger UnsupportedPrimitiveLogger;
 
+template <class TIndexAccessor>
+TArray<uint32>
+getIndices(const TIndexAccessor& indicesView, int32 primitiveMode) {
+  TArray<uint32> indices;
+
+  if (primitiveMode == CesiumGltf::MeshPrimitive::Mode::TRIANGLES ||
+      primitiveMode == CesiumGltf::MeshPrimitive::Mode::POINTS) {
+    TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::CopyIndices)
+    indices.SetNum(static_cast<TArray<uint32>::SizeType>(indicesView.size()));
+    for (int32 i = 0; i < indicesView.size(); ++i) {
+      indices[i] = indicesView[i];
+    }
+  } else if (primitiveMode == CesiumGltf::MeshPrimitive::Mode::TRIANGLE_STRIP) {
+    // The TRIANGLE_STRIP primitive mode cannot be enabled without creating a
+    // custom render proxy, so the geometry must be emulated through separate
+    // triangles.
+    TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::CopyTriangleStripIndices)
+    indices.SetNum(
+        static_cast<TArray<uint32>::SizeType>(3 * (indicesView.size() - 2)));
+    for (int32 i = 0; i < indicesView.size() - 2; ++i) {
+      if (i % 2) {
+        indices[3 * i] = indicesView[i];
+        indices[3 * i + 1] = indicesView[i + 2];
+        indices[3 * i + 2] = indicesView[i + 1];
+      } else {
+        indices[3 * i] = indicesView[i];
+        indices[3 * i + 1] = indicesView[i + 1];
+        indices[3 * i + 2] = indicesView[i + 2];
+      }
+    }
+  } else if (primitiveMode == CesiumGltf::MeshPrimitive::Mode::TRIANGLE_FAN) {
+    // The TRIANGLE_FAN primitive mode cannot be enabled without creating a
+    // custom render proxy, so the geometry must be emulated through separate
+    // triangles.
+    TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::CopyTriangleFanIndices)
+    indices.SetNum(
+        static_cast<TArray<uint32>::SizeType>(3 * (indicesView.size() - 2)));
+    for (int32 i = 2, j = 0; i < indicesView.size(); ++i, j += 3) {
+      indices[j] = indicesView[0];
+      indices[j + 1] = indicesView[i - 1];
+      indices[j + 2] = indicesView[i];
+    }
+  }
+
+  return indices;
+}
 } // namespace
 
 template <class TIndexAccessor>
@@ -1314,9 +1360,13 @@ static void loadPrimitive(
   CesiumGltf::MeshPrimitive& primitive =
       mesh.primitives[options.primitiveIndex];
 
-  if (primitive.mode != CesiumGltf::MeshPrimitive::Mode::TRIANGLES &&
-      primitive.mode != CesiumGltf::MeshPrimitive::Mode::TRIANGLE_STRIP &&
-      primitive.mode != CesiumGltf::MeshPrimitive::Mode::POINTS) {
+  switch (primitive.mode) {
+  case CesiumGltf::MeshPrimitive::Mode::POINTS:
+  case CesiumGltf::MeshPrimitive::Mode::TRIANGLES:
+  case CesiumGltf::MeshPrimitive::Mode::TRIANGLE_STRIP:
+  case CesiumGltf::MeshPrimitive::Mode::TRIANGLE_FAN:
+    break;
+  default:
     // TODO: add support for other primitive types.
     UnsupportedPrimitiveLogger.OnUnsupportedMode(primitive.mode);
     return;
@@ -1481,45 +1531,7 @@ static void loadPrimitive(
     RenderData->Bounds.SphereRadius = 0.0f;
   }
 
-  TArray<uint32> indices;
-  if (primitive.mode == CesiumGltf::MeshPrimitive::Mode::TRIANGLES ||
-      primitive.mode == CesiumGltf::MeshPrimitive::Mode::POINTS) {
-    TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::CopyIndices)
-    indices.SetNum(static_cast<TArray<uint32>::SizeType>(indicesView.size()));
-    for (int32 i = 0; i < indicesView.size(); ++i) {
-      indices[i] = indicesView[i];
-    }
-  } else if (primitive.mode == CesiumGltf::MeshPrimitive::Mode::TRIANGLE_FAN) {
-    // The TRIANGLE_FAN primitive mode cannot be enabled without creating a
-    // custom render proxy, so the geometry must be emulated through separate
-    // triangles.
-    TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::CopyTriangleFanIndices)
-    indices.SetNum(
-        static_cast<TArray<uint32>::SizeType>(3 * (indicesView.size() - 2)));
-    for (int64_t i = 2; i < indicesView.size(); ++i) {
-      indices[3 * i] = indicesView[0];
-      indices[3 * i + 1] = indicesView[i - 1];
-      indices[3 * i + 2] = indicesView[i];
-    }
-  } else {
-    // The TRIANGLE_STRIP primitive mode cannot be enabled without creating a
-    // custom render proxy, so the geometry must be emulated through separate
-    // triangles.
-    TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::CopyTriangleStripIndices)
-    indices.SetNum(
-        static_cast<TArray<uint32>::SizeType>(3 * (indicesView.size() - 2)));
-    for (int32 i = 0; i < indicesView.size() - 2; ++i) {
-      if (i % 2) {
-        indices[3 * i] = indicesView[i];
-        indices[3 * i + 1] = indicesView[i + 2];
-        indices[3 * i + 2] = indicesView[i + 1];
-      } else {
-        indices[3 * i] = indicesView[i];
-        indices[3 * i + 1] = indicesView[i + 1];
-        indices[3 * i + 2] = indicesView[i + 2];
-      }
-    }
-  }
+  TArray<uint32> indices = getIndices(indicesView, primitive.mode);
 
   // If we don't have normals, the gltf spec prescribes that the client
   // implementation must generate flat normals, which requires duplicating
@@ -1534,7 +1546,7 @@ static void loadPrimitive(
                       primitive.mode != CesiumGltf::MeshPrimitive::Mode::POINTS;
 
   uint32 numVertices =
-      duplicateVertices ? indices.Num() : static_cast<int>(positionView.size());
+      duplicateVertices ? uint32(indices.Num()) : uint32(positionView.size());
 
   FPositionVertexBuffer& positionBuffer =
       LODResources.VertexBuffers.PositionVertexBuffer;
@@ -1884,7 +1896,6 @@ static void loadPrimitive(
 
   auto positionAccessorIt =
       primitive.attributes.find(CesiumGltf::VertexAttributeSemantics::POSITION);
-
   if (positionAccessorIt == primitive.attributes.end()) {
     // This primitive doesn't have a POSITION semantic, ignore it.
     return;


### PR DESCRIPTION
## Description

Depends on #1673 so merge that first.

This PR adds support for `TRIANGLE_FAN` primitives.

This was actually an accident... I was trying to do some cleanup in `loadPrimitive` and saw that the `CopyIndices` scope didn't have a branch for `TRIANGLE_FAN`. I thought that was a bug, so I added the code in, but then I realized that we didn't support it in the first place. It was trivial enough to add, so why not :shrug: 

## Author checklist

- [X] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [X] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- ~[ ] I have added or updated unit tests to ensure consistent code coverage as necessary.~
- ~[ ] I have updated the documentation as necessary.~

## Testing plan

Test that this tileset loads (best viewed under a "True Origin" georeference): [MeshPrimitiveModes.zip](https://github.com/user-attachments/files/20353260/MeshPrimitiveModes.zip).

There should be a row of three hexagons.
![image](https://github.com/user-attachments/assets/ee978e12-9615-40a0-9590-1c9d1afad92e)