### PR TITLE
Fix crash that results from duplicating a georeference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@
 
 - Worked around an Unreal Engine limitation that prevented collisions and line traces from working correctly for tilesets with a very small scale factor.
 - Add a missing include for `GEngine` when packaging from source, introduced in *v2.16.0*.
-- Fixed a bug in UCesiumFeaturesMetadataComponent where multiple references to same feature ID set would cause improper encoding of its feature IDs.
+- Fixed a bug in `UCesiumFeaturesMetadataComponent` where multiple references to same feature ID set would cause improper encoding of its feature IDs.
+- Fixed a crash that would occur when duplicating an `ACesiumGeoreference`.
 
 ### v2.16.0 - 2025-05-01
 

--- a/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTileset.cpp
@@ -232,17 +232,20 @@ ACesiumGeoreference* ACesium3DTileset::ResolveGeoreference() {
         ACesiumGeoreference::GetDefaultGeoreferenceForActor(this);
   }
 
-  UCesium3DTilesetRoot* pRoot = Cast<UCesium3DTilesetRoot>(this->RootComponent);
-  if (pRoot) {
-    this->ResolvedGeoreference->OnGeoreferenceUpdated.AddUniqueDynamic(
-        pRoot,
-        &UCesium3DTilesetRoot::HandleGeoreferenceUpdated);
-    this->ResolvedGeoreference->OnEllipsoidChanged.AddUniqueDynamic(
-        this,
-        &ACesium3DTileset::HandleOnGeoreferenceEllipsoidChanged);
+  if (this->ResolvedGeoreference) {
+    UCesium3DTilesetRoot* pRoot =
+        Cast<UCesium3DTilesetRoot>(this->RootComponent);
+    if (pRoot) {
+      this->ResolvedGeoreference->OnGeoreferenceUpdated.AddUniqueDynamic(
+          pRoot,
+          &UCesium3DTilesetRoot::HandleGeoreferenceUpdated);
+      this->ResolvedGeoreference->OnEllipsoidChanged.AddUniqueDynamic(
+          this,
+          &ACesium3DTileset::HandleOnGeoreferenceEllipsoidChanged);
 
-    // Update existing tile positions, if any.
-    pRoot->HandleGeoreferenceUpdated();
+      // Update existing tile positions, if any.
+      pRoot->HandleGeoreferenceUpdated();
+    }
   }
 
   return this->ResolvedGeoreference;

--- a/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.cpp
@@ -18,6 +18,7 @@ void UCesium3DTilesetRoot::HandleGeoreferenceUpdated() {
       Verbose,
       TEXT("Called HandleGeoreferenceUpdated for tileset root %s"),
       *this->GetName());
+
   this->_updateTilesetToUnrealRelativeWorldTransform();
 }
 
@@ -62,10 +63,12 @@ void UCesium3DTilesetRoot::_updateAbsoluteLocation() {
 
 void UCesium3DTilesetRoot::_updateTilesetToUnrealRelativeWorldTransform() {
   ACesium3DTileset* pTileset = this->GetOwner<ACesium3DTileset>();
+  ACesiumGeoreference* pGeoreference = pTileset->ResolveGeoreference();
 
-  this->_tilesetToUnrealRelativeWorld = VecMath::createMatrix4D(
-      pTileset->ResolveGeoreference()
-          ->ComputeEarthCenteredEarthFixedToUnrealTransformation());
+  if (pGeoreference) {
+    this->_tilesetToUnrealRelativeWorld = VecMath::createMatrix4D(
+        pGeoreference->ComputeEarthCenteredEarthFixedToUnrealTransformation());
 
-  pTileset->UpdateTransformFromCesium();
+    pTileset->UpdateTransformFromCesium();
+  }
 }

--- a/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.cpp
+++ b/Source/CesiumRuntime/Private/Cesium3DTilesetRoot.cpp
@@ -18,7 +18,6 @@ void UCesium3DTilesetRoot::HandleGeoreferenceUpdated() {
       Verbose,
       TEXT("Called HandleGeoreferenceUpdated for tileset root %s"),
       *this->GetName());
-
   this->_updateTilesetToUnrealRelativeWorldTransform();
 }
 


### PR DESCRIPTION

## Description

This PR resolves a crash that happened while duplicating a CesiumGeoreference in the Unreal Editor.

## Issue number or link

Fixes #1354.

## Author checklist

- [X] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [X] I have done a full self-review of my code.
- [X] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
~- [ ] I have added or updated unit tests to ensure consistent code coverage as necessary.~
~- [ ] I have updated the documentation as necessary.~

## Testing plan

Simple to test, just duplicate or copy + paste a CesiumGeoreference and verify it won't crash. Also sanity check other operations like undo / redo, deleting, etc.