### PR TITLE
Support Materials, not just MaterialInstances, and fix normal flip when computing tangents

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -3149,9 +3149,8 @@ static void loadPrimitiveGameThreadPart(
 #if PLATFORM_MAC
   // TODO: figure out why water material crashes mac
   UMaterialInterface* pUserDesignatedMaterial =
-      is_in_blend_mode(loadResult)
-                                          ? pGltf->BaseMaterialWithTranslucency
-                                          : pGltf->BaseMaterial;
+      is_in_blend_mode(loadResult) ? pGltf->BaseMaterialWithTranslucency
+                                   : pGltf->BaseMaterial;
 #else
   UMaterialInterface* pUserDesignatedMaterial;
   if (loadResult.onlyWater || !loadResult.onlyLand) {

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -3148,7 +3148,8 @@ static void loadPrimitiveGameThreadPart(
 
 #if PLATFORM_MAC
   // TODO: figure out why water material crashes mac
-  UMaterialInterface* pBaseMaterial = is_in_blend_mode(loadResult)
+  UMaterialInterface* pUserDesignatedMaterial =
+      is_in_blend_mode(loadResult)
                                           ? pGltf->BaseMaterialWithTranslucency
                                           : pGltf->BaseMaterial;
 #else

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -643,6 +643,7 @@ static void mikkSetTSpaceBasic(
 
   TangentX.Y = -TangentX.Y;
   TangentY.Y = -TangentY.Y;
+  TangentZ.Y = -TangentZ.Y;
 
   vertexBuffer.SetVertexTangents(vertexIndex, TangentX, TangentY, TangentZ);
 }

--- a/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfComponent.cpp
@@ -3151,79 +3151,83 @@ static void loadPrimitiveGameThreadPart(
                                           ? pGltf->BaseMaterialWithTranslucency
                                           : pGltf->BaseMaterial;
 #else
-  UMaterialInterface* pBaseMaterial;
+  UMaterialInterface* pUserDesignatedMaterial;
   if (loadResult.onlyWater || !loadResult.onlyLand) {
-    pBaseMaterial = pGltf->BaseMaterialWithWater;
+    pUserDesignatedMaterial = pGltf->BaseMaterialWithWater;
   } else {
-    pBaseMaterial = is_in_blend_mode(loadResult)
-                        ? pGltf->BaseMaterialWithTranslucency
-                        : pGltf->BaseMaterial;
+    pUserDesignatedMaterial = is_in_blend_mode(loadResult)
+                                  ? pGltf->BaseMaterialWithTranslucency
+                                  : pGltf->BaseMaterial;
   }
 #endif
 
-  UMaterialInstanceDynamic* pMaterial;
+  UMaterialInstanceDynamic* pMaterialForGltfPrimitive;
   {
     TRACE_CPUPROFILER_EVENT_SCOPE(Cesium::SetupMaterial)
 
-    UMaterialInstanceDynamic* pBaseAsMaterialInstanceDynamic =
-        Cast<UMaterialInstanceDynamic>(pBaseMaterial);
-    UMaterialInstance* pParentMaterialInstance =
-        Cast<UMaterialInstance>(pBaseMaterial);
+    UMaterialInstanceDynamic* pUserDesignatedMaterialAsDynamic =
+        Cast<UMaterialInstanceDynamic>(pUserDesignatedMaterial);
 
-    // If the base material is a UMaterialInstanceDynamic, Create() will
-    // reject it as a valid instance parent.  Defer to its non-dynamic parent
-    // instead.
-    if (pBaseAsMaterialInstanceDynamic) {
-      pParentMaterialInstance =
-          Cast<UMaterialInstance>(pParentMaterialInstance->Parent.Get());
-    }
+    // If the user-designated material is a UMaterialInstanceDynamic, Create()
+    // will reject it as a valid instance parent.  Defer to its non-dynamic
+    // parent instead.
+    UMaterialInterface* pBaseMaterial =
+        pUserDesignatedMaterialAsDynamic
+            ? pUserDesignatedMaterialAsDynamic->Parent.Get()
+            : pUserDesignatedMaterial;
 
-    pMaterial = UMaterialInstanceDynamic::Create(
-        pParentMaterialInstance,
+    pMaterialForGltfPrimitive = UMaterialInstanceDynamic::Create(
+        pBaseMaterial,
         nullptr,
         ImportedSlotName);
 
-    pMaterial->SetFlags(
+    pMaterialForGltfPrimitive->SetFlags(
         RF_Transient | RF_DuplicateTransient | RF_TextExportTransient);
     SetGltfParameterValues(
         model,
         loadResult,
         material,
         pbr,
-        pMaterial,
+        pMaterialForGltfPrimitive,
         EMaterialParameterAssociation::GlobalParameter,
         INDEX_NONE);
     SetWaterParameterValues(
         model,
         loadResult,
-        pMaterial,
+        pMaterialForGltfPrimitive,
         EMaterialParameterAssociation::GlobalParameter,
         INDEX_NONE);
 
+    // The base material might be a Material, or it might be a MaterialInstance.
+    // Only MaterialInstances can use the material layer system, so only
+    // MaterialInstances will have UCesiumMaterialUserData.
+    UMaterialInstance* pBaseAsMaterialInstance =
+        Cast<UMaterialInstance>(pBaseMaterial);
+
     UCesiumMaterialUserData* pCesiumData =
-        pParentMaterialInstance
-            ? pParentMaterialInstance
+        pBaseAsMaterialInstance
+            ? pBaseAsMaterialInstance
                   ->GetAssetUserData<UCesiumMaterialUserData>()
             : nullptr;
 
     // If possible and necessary, attach the CesiumMaterialUserData now.
 #if WITH_EDITORONLY_DATA
-    if (pParentMaterialInstance && !pCesiumData) {
+    if (pBaseAsMaterialInstance && !pCesiumData) {
       const FStaticParameterSet& parameters =
-          pParentMaterialInstance->GetStaticParameters();
+          pBaseAsMaterialInstance->GetStaticParameters();
 
       bool hasLayers = parameters.bHasMaterialLayers;
       if (hasLayers) {
 #if WITH_EDITOR
         FScopedTransaction transaction(
             FText::FromString("Add Cesium User Data to Material"));
-        pParentMaterialInstance->Modify();
+        pBaseAsMaterialInstance->Modify();
 #endif
         pCesiumData = NewObject<UCesiumMaterialUserData>(
-            pParentMaterialInstance,
+            pBaseAsMaterialInstance,
             NAME_None,
             RF_Transactional);
-        pParentMaterialInstance->AddAssetUserData(pCesiumData);
+        pBaseAsMaterialInstance->AddAssetUserData(pCesiumData);
         pCesiumData->PostEditChangeOwner();
       }
     }
@@ -3232,11 +3236,13 @@ static void loadPrimitiveGameThreadPart(
     // If CesiumMaterialUserData was not attached (e.g., material was
     // dynamically created at runtime), then walk the parent chain of the
     // material to find it.
-    while (pParentMaterialInstance && !pCesiumData) {
-      pParentMaterialInstance =
-          Cast<UMaterialInstance>(pParentMaterialInstance->Parent.Get());
-      pCesiumData =
-          pParentMaterialInstance->GetAssetUserData<UCesiumMaterialUserData>();
+    while (pBaseAsMaterialInstance && !pCesiumData) {
+      pBaseAsMaterialInstance =
+          Cast<UMaterialInstance>(pBaseAsMaterialInstance->Parent.Get());
+      if (pBaseAsMaterialInstance) {
+        pCesiumData = pBaseAsMaterialInstance
+                          ->GetAssetUserData<UCesiumMaterialUserData>();
+      }
     }
 
     if (pCesiumData) {
@@ -3245,7 +3251,7 @@ static void loadPrimitiveGameThreadPart(
           loadResult,
           material,
           pbr,
-          pMaterial,
+          pMaterialForGltfPrimitive,
           EMaterialParameterAssociation::LayerParameter,
           0);
 
@@ -3253,13 +3259,13 @@ static void loadPrimitiveGameThreadPart(
       // are off.
       int fadeLayerIndex = pCesiumData->LayerNames.Find("DitherFade");
       if (fadeLayerIndex >= 0) {
-        pMaterial->SetScalarParameterValueByInfo(
+        pMaterialForGltfPrimitive->SetScalarParameterValueByInfo(
             FMaterialParameterInfo(
                 "FadePercentage",
                 EMaterialParameterAssociation::LayerParameter,
                 fadeLayerIndex),
             1.0f);
-        pMaterial->SetScalarParameterValueByInfo(
+        pMaterialForGltfPrimitive->SetScalarParameterValueByInfo(
             FMaterialParameterInfo(
                 "FadingType",
                 EMaterialParameterAssociation::LayerParameter,
@@ -3273,7 +3279,7 @@ static void loadPrimitiveGameThreadPart(
         SetWaterParameterValues(
             model,
             loadResult,
-            pMaterial,
+            pMaterialForGltfPrimitive,
             EMaterialParameterAssociation::LayerParameter,
             waterIndex);
       }
@@ -3286,7 +3292,7 @@ static void loadPrimitiveGameThreadPart(
             model,
             *pGltf,
             loadResult,
-            pMaterial,
+            pMaterialForGltfPrimitive,
             EMaterialParameterAssociation::LayerParameter,
             featuresMetadataIndex);
       } else if (metadataIndex >= 0) {
@@ -3295,42 +3301,43 @@ static void loadPrimitiveGameThreadPart(
             model,
             *pGltf,
             loadResult,
-            pMaterial,
+            pMaterialForGltfPrimitive,
             EMaterialParameterAssociation::LayerParameter,
             metadataIndex);
       }
     }
 
-    if (pBaseAsMaterialInstanceDynamic) {
+    if (pUserDesignatedMaterialAsDynamic) {
       // Ensure any parameters on the original UMaterialInstanceDynamic are
       // transferred to the copy.
-      for (auto& it : pBaseAsMaterialInstanceDynamic->ScalarParameterValues) {
-        pMaterial->SetScalarParameterValueByInfo(
+      for (auto& it : pUserDesignatedMaterialAsDynamic->ScalarParameterValues) {
+        pMaterialForGltfPrimitive->SetScalarParameterValueByInfo(
             it.ParameterInfo,
             it.ParameterValue);
       }
 
-      for (auto& it : pBaseAsMaterialInstanceDynamic->VectorParameterValues) {
-        pMaterial->SetVectorParameterValueByInfo(
+      for (auto& it : pUserDesignatedMaterialAsDynamic->VectorParameterValues) {
+        pMaterialForGltfPrimitive->SetVectorParameterValueByInfo(
             it.ParameterInfo,
             it.ParameterValue);
       }
 
       for (auto& it :
-           pBaseAsMaterialInstanceDynamic->DoubleVectorParameterValues) {
-        pMaterial->SetVectorParameterValueByInfo(
+           pUserDesignatedMaterialAsDynamic->DoubleVectorParameterValues) {
+        pMaterialForGltfPrimitive->SetVectorParameterValueByInfo(
             it.ParameterInfo,
             it.ParameterValue);
       }
 
-      for (auto& it : pBaseAsMaterialInstanceDynamic->TextureParameterValues) {
-        pMaterial->SetTextureParameterValueByInfo(
+      for (auto& it :
+           pUserDesignatedMaterialAsDynamic->TextureParameterValues) {
+        pMaterialForGltfPrimitive->SetTextureParameterValueByInfo(
             it.ParameterInfo,
             it.ParameterValue);
       }
 
-      for (auto& it : pBaseAsMaterialInstanceDynamic->FontParameterValues) {
-        pMaterial->SetFontParameterValue(
+      for (auto& it : pUserDesignatedMaterialAsDynamic->FontParameterValues) {
+        pMaterialForGltfPrimitive->SetFontParameterValue(
             it.ParameterInfo,
             it.FontValue,
             it.FontPage);
@@ -3361,9 +3368,9 @@ static void loadPrimitiveGameThreadPart(
 
   PRAGMA_ENABLE_DEPRECATION_WARNINGS
 
-  pMaterial->TwoSided = true;
+  pMaterialForGltfPrimitive->TwoSided = true;
 
-  pStaticMesh->AddMaterial(pMaterial);
+  pStaticMesh->AddMaterial(pMaterialForGltfPrimitive);
 
   pStaticMesh->SetLightingGuid();
 


### PR DESCRIPTION
Fixes #1686 
Fixes #1688

The modifications to support dynamic material instances also inadvertently broke the case where the user-provided material is not a material instance at all.

Also, the restructuring of the mesh creation introduced a bug where the Y component of the normals was inadvertently flipped when computing tangents.

No changelog entry because this is a regression since the last release.

I'll be merging this myself because we need to fix these two regressions for today's release.