### PR TITLE
Basic support for glTF LINES primitive mode

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGltfPointsComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGltfPointsComponent.cpp
@@ -18,7 +18,7 @@ FPrimitiveSceneProxy* UCesiumGltfPointsComponent::CreateSceneProxy() {
   }
 
   FCesiumGltfPointsSceneProxy* Proxy =
-      new FCesiumGltfPointsSceneProxy(this, GetScene()->GetFeatureLevel());
+      new FCesiumGltfPointsSceneProxy(this, GetScene()->GetFeatureLevel(), bLinesList);
 
   FCesiumGltfPointsSceneProxyTilesetData TilesetData;
   TilesetData.UpdateFromComponent(this);

--- a/Source/CesiumRuntime/Private/CesiumGltfPointsComponent.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfPointsComponent.h
@@ -28,6 +28,8 @@ public:
   // error.
   glm::vec3 Dimensions;
 
+  bool bLinesList = false;
+
   // Override UPrimitiveComponent interface.
   virtual FPrimitiveSceneProxy* CreateSceneProxy() override;
 };

--- a/Source/CesiumRuntime/Private/CesiumGltfPointsSceneProxy.h
+++ b/Source/CesiumRuntime/Private/CesiumGltfPointsSceneProxy.h
@@ -19,6 +19,7 @@ struct FCesiumGltfPointsSceneProxyTilesetData {
   bool UsesAdditiveRefinement;
   float GeometricError;
   glm::vec3 Dimensions;
+  bool bLinesList;
 
   FCesiumGltfPointsSceneProxyTilesetData();
 
@@ -36,7 +37,8 @@ public:
 
   FCesiumGltfPointsSceneProxy(
       UCesiumGltfPointsComponent* InComponent,
-      ERHIFeatureLevel::Type InFeatureLevel);
+      ERHIFeatureLevel::Type InFeatureLevel,
+      bool bLinesList);
 
   virtual ~FCesiumGltfPointsSceneProxy();
 


### PR DESCRIPTION
This is the result of hacking quick support for these lines in order to test a model I really wanted to see but that only had lines in it... ,^^
But I'm opening a draft PR in order to get feedback already, because I found it almost suspicious that lines weren't supported if it were that easy! Anything I'm missing?
I find this feature useful even without attenuation support, what do you think? I won't have much more time to work on this as it was never really part of my assignments...

TODO:
  - [ ] Only LINES for the moment, _ie_ lists of segments: wouldn't be hard to support glTF line loops and strips I guess, but I'd need a dataset to test that.
  - [ ] "Basic support" = no support for rendering with "attenuation" like point clouds: haven't looked at the custom vertex factory and shader yet to see how hard it would be to support lines?
  - [ ] Probably need to change the name of CesiumGltfPointsComponent and proxy, unless it makes more sense to duplicate them.
  - [ ] Update `CHANGES.md`

Sample result: no screen capture because this is user data, sorry! Will try to find lines in one of our own models.