### PR TITLE
Added default UNREAL_ENGINE_ROOT value for MacOS

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -21,7 +21,7 @@ if (NOT UNREAL_ENGINE_ROOT)
   if (NOT EXISTS "${DEFAULT_UNREAL_INSTALLATION}")
      message(FATAL_ERROR "Please specify the root of your Unreal Engine installation, either by setting the UNREAL_ENGINE_ROOT environment variable or with -DUNREAL_ENGINE_ROOT=path on the cmake command-line.")
   else()
-    set(UNREAL_ENGINE_ROOT ${DEFAULT_UNREAL_INSTALLATION})
+    set(UNREAL_ENGINE_ROOT "${DEFAULT_UNREAL_INSTALLATION}")
   endif()
 endif()
 

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -11,12 +11,15 @@ if (DEFINED ENV{UNREAL_ENGINE_ROOT} AND NOT UNREAL_ENGINE_ROOT)
 endif()
 
 if (NOT UNREAL_ENGINE_ROOT)
-  # On Windows, try to use the default UE 5.4 location
-  set(WINDOWS_DEFAULT_UNREAL_INSTALLATION "C:/Program Files/Epic Games/UE_5.4")
-  if (WIN32 AND EXISTS "${WINDOWS_DEFAULT_UNREAL_INSTALLATION}")
-    set(UNREAL_ENGINE_ROOT "${WINDOWS_DEFAULT_UNREAL_INSTALLATION}")
-  else()
-    message(FATAL_ERROR "Please specify the root of your Unreal Engine installation, either by setting the UNREAL_ENGINE_ROOT environment variable or with -DUNREAL_ENGINE_ROOT=path on the cmake command-line.")
+  # On Windows and Mac, try to use the default UE 5.4 location
+  if (WIN32)
+     set(UNREAL_ENGINE_ROOT "C:/Program Files/Epic Games/UE_5.4")
+  elseif(APPLE)
+    set(UNREAL_ENGINE_ROOT "/Users/Shared/Epic Games/UE_5.4")
+  endif()
+
+  if (NOT EXISTS ${UNREAL_ENGINE_ROOT})
+     message(FATAL_ERROR "Please specify the root of your Unreal Engine installation, either by setting the UNREAL_ENGINE_ROOT environment variable or with -DUNREAL_ENGINE_ROOT=path on the cmake command-line.")
   endif()
 endif()
 

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -18,7 +18,7 @@ if (NOT UNREAL_ENGINE_ROOT)
     set(DEFAULT_UNREAL_INSTALLATION "/Users/Shared/Epic Games/UE_5.4")
   endif()
 
-  if (NOT EXISTS ${DEFAULT_UNREAL_INSTALLATION})
+  if (NOT EXISTS "${DEFAULT_UNREAL_INSTALLATION}")
      message(FATAL_ERROR "Please specify the root of your Unreal Engine installation, either by setting the UNREAL_ENGINE_ROOT environment variable or with -DUNREAL_ENGINE_ROOT=path on the cmake command-line.")
   else()
     set(UNREAL_ENGINE_ROOT ${DEFAULT_UNREAL_INSTALLATION})

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -13,13 +13,15 @@ endif()
 if (NOT UNREAL_ENGINE_ROOT)
   # On Windows and Mac, try to use the default UE 5.4 location
   if (WIN32)
-     set(UNREAL_ENGINE_ROOT "C:/Program Files/Epic Games/UE_5.4")
+     set(DEFAULT_UNREAL_INSTALLATION "C:/Program Files/Epic Games/UE_5.4")
   elseif(APPLE)
-    set(UNREAL_ENGINE_ROOT "/Users/Shared/Epic Games/UE_5.4")
+    set(DEFAULT_UNREAL_INSTALLATION "/Users/Shared/Epic Games/UE_5.4")
   endif()
 
-  if (NOT EXISTS ${UNREAL_ENGINE_ROOT})
+  if (NOT EXISTS ${DEFAULT_UNREAL_INSTALLATION})
      message(FATAL_ERROR "Please specify the root of your Unreal Engine installation, either by setting the UNREAL_ENGINE_ROOT environment variable or with -DUNREAL_ENGINE_ROOT=path on the cmake command-line.")
+  else()
+    set(UNREAL_ENGINE_ROOT ${DEFAULT_UNREAL_INSTALLATION})
   endif()
 endif()
 


### PR DESCRIPTION
## Description

Updated CMakeLists.txt to include default UNREAL_ENGINE_ROOT for MacOS. 

## Issue number or link

https://github.com/CesiumGS/cesium-unreal/issues/1715

## Author checklist

- [ ] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [X] I have done a full self-review of my code.
- [ ] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [ ] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [ ] I have updated the documentation as necessary.

## Testing plan

Tested building on Mac. 