### PR TITLE
Add missing CesiumRuntime.h include for v2.18.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,9 @@
 
 ### ???
 
-- Add missing CesiumRuntime.h include in CesiumPropertyAttribute.cpp. Broke compilation of previous v2.18.0 release on Windows.
+##### Fixes :wrench:
+
+- Added a missing `CesiumRuntime.h` include in `CesiumPropertyAttribute.cpp` that broke compilation in v2.18.0 on Windows.
 
 ### v2.18.0 - 2025-08-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log {#changes}
 
+### ???
+
+- Add missing CesiumRuntime.h include in CesiumPropertyAttribute.cpp. Broke compilation of previous v2.18.0 release on Windows.
+
 ### v2.18.0 - 2025-08-01
 
 ##### Breaking Changes :mega:

--- a/Source/CesiumRuntime/Private/CesiumPropertyAttribute.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPropertyAttribute.cpp
@@ -1,8 +1,8 @@
 // Copyright 2020-2024 CesiumGS, Inc. and Contributors
 
 #include "CesiumPropertyAttribute.h"
-#include <CesiumGltf/PropertyAttributeView.h>
 #include "CesiumRuntime.h"
+#include <CesiumGltf/PropertyAttributeView.h>
 
 static FCesiumPropertyAttributeProperty EmptyPropertyAttributeProperty;
 

--- a/Source/CesiumRuntime/Private/CesiumPropertyAttribute.cpp
+++ b/Source/CesiumRuntime/Private/CesiumPropertyAttribute.cpp
@@ -2,6 +2,7 @@
 
 #include "CesiumPropertyAttribute.h"
 #include <CesiumGltf/PropertyAttributeView.h>
+#include "CesiumRuntime.h"
 
 static FCesiumPropertyAttributeProperty EmptyPropertyAttributeProperty;
 


### PR DESCRIPTION
## Description

Missing declaration of `LogCesium` in _CesiumPropertyAttribute.cpp_

## Issue number or link

Tell me if you want an issue linked, I'll open one.

## Author checklist

- [x] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [x] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [x] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [x] I have updated the documentation as necessary.

## Remaining Tasks

Setup a compilation CI in the sample project for example would avoid that kind of oversights.