### PR TITLE
Bump Windows SDK Version on UE 5.4 CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,9 +49,9 @@ jobs:
       # and using them ensures we're compiling our plugin in the exact same way that Unreal Engine itself is compiled.
       cmake-generator: "Visual Studio 17 2022"
       cmake-toolchain: "version=14.34"
-      cmake-platform: "x64,version=10.0.18362.0"
+      cmake-platform: "x64,version=10.0.19041.0"
       visual-studio-version: "2022"
-      visual-studio-components: "Microsoft.VisualStudio.Component.VC.14.34.17.4.x86.x64,Microsoft.VisualStudio.Component.Windows10SDK.18362"
+      visual-studio-components: "Microsoft.VisualStudio.Component.VC.14.34.17.4.x86.x64,Microsoft.VisualStudio.Component.Windows10SDK.19041"
   TestWindows54:
     needs: [Windows54]
     uses: ./.github/workflows/testWindows.yml


### PR DESCRIPTION
## Description

Windows SDK version `10.0.18362` is no longer supported as of version `20250811.1.0` on the Github Windows runner, which is the version that the Unreal 5.4 builds use. See https://github.com/actions/runner-images/issues/12776.

Although that version is the one officially used by Epic's build farm, the [release notes](https://dev.epicgames.com/documentation/en-us/unreal-engine/unreal-engine-5.4-release-notes?application_version=5.4) suggest it can still build with newer versions. So this bumps the version to the minimum version supported by the new runner image. The Windows UE 5.4 build passes and produces an artifact, and I haven't seen any unexpected behavior while going through the Cesium for Unreal Samples. So... maybe it's fine? 😁 