### PR TITLE
Update x64-windows-unreal.cmake to read toolset version from environment

### DIFF
--- a/extern/vcpkg-overlays/triplets/x64-windows-unreal.cmake
+++ b/extern/vcpkg-overlays/triplets/x64-windows-unreal.cmake
@@ -27,6 +27,11 @@ list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_MSVC_RUNTIME_LIBRARY:STRING=M
 list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_FLAGS_DEBUG:STRING=/MD /Z7 /Ob0 /Od /RTC1")
 list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_C_FLAGS_DEBUG:STRING=/MD /Z7 /Ob0 /Od /RTC1")
 
+# Use the MSVC toolset version defined on the environment variable
+#if (DEFINED ENV{VCPKG_PLATFORM_TOOLSET_VERSION})
+  set(VCPKG_PLATFORM_TOOLSET_VERSION "$ENV{VCPKG_PLATFORM_TOOLSET_VERSION}")
+#endif()
+
 # When building official binaries on CI, use a very specific MSVC toolset version (which must be installed).
 # When building locally, use the default.
 if(DEFINED ENV{CI})


### PR DESCRIPTION
Let `x64-windows-unreal.cmake` retrieve the MSVC toolset version from an env var instead of requiring developers to patch this file to hardcode the desired version, as originally stated in:
https://cesium.com/learn/cesium-unreal/ref-doc/developer-setup-windows-gotchas.html

<!--
Thanks for the Pull Request!

Please review the [Contributor Guide](https://cesium.com/learn/cesium-unreal/ref-doc/contributing-unreal.html) before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our [Pull Request Guidelines](https://cesium.com/learn/cesium-unreal/ref-doc/contributing-unreal.html#opening-a-pull-request).

-->

## Description

<!-- Summarize the pull request. -- >

Updated `extern\vcpkg-overlays\triplets\x64-windows-unreal.cmake` to check if environment variable `VCPKG_PLATFORM_TOOLSET_VERSION` has been defined and then initialize the MSVC toolset version with its value.

< !-- Provide context for the reviewer to understand the pull request. Include what changes were made and why. -->

Sometimes projects that rely on cesium-unreal usualy have their own build scripts to automate the build process. In scenarios where it is essential to use a specific MSVC toolset and custom build parameters, cesium-unreal CMake files make it impossible for the correct propagation of parameters along the build chain causing linker issues with 3rd-party libraries such as `ada.lib`, `ktx.lib`, `spdlog.lib`, and others, as we can see below:
```
[60/62] Link [x64] UnrealEditor-CesiumEditor.dll
   Creating library C:\UE_Projects\Stargate\Plugins\cesium-unreal\Intermediate\Build\Win64\x64\UnrealEditor\Development\CesiumEditor\UnrealEditor-CesiumEditor.sup.lib and object C:\UE_Projects\Stargate\Plugins\cesium-unreal\Intermediate\Build\Win64\x64\UnrealEditor\Development\CesiumEditor\UnrealEditor-CesiumEditor.sup.exp
ada.lib(ada.cpp.obj) : error LNK2019: unresolved external symbol __std_find_last_trivial_1 referenced in function "char const * __cdecl std::_Find_last_vectorized<char const ,char>(char const * const,char const * const,char)" (??$_Find_last_vectorized@$$CBDD@std@@YAPEBDQEBD0D@Z)
ada.lib(ada.cpp.obj) : error LNK2019: unresolved external symbol __std_find_first_of_trivial_1 referenced in function "char const * __cdecl std::_Find_first_of_vectorized<char const ,char const >(char const * const,char const * const,char const * const,char const * const)" (??$_Find_first_of_vectorized@$$CBD$$CBD@std@@YAPEBDQEBD000@Z)
ada.lib(ada.cpp.obj) : error LNK2019: unresolved external symbol __std_search_1 referenced in function "char const * __cdecl std::_Search_vectorized<char const ,char const >(char const * const,char const * const,char const * const,unsigned __int64)" (??$_Search_vectorized@$$CBD$$CBD@std@@YAPEBDQEBD00_K@Z)
C:\UE_Projects\Stargate\Plugins\cesium-unreal\Binaries\Win64\UnrealEditor-CesiumEditor.dll : fatal error LNK1120: 3 unresolved externals
[61/62] Link [x64] UnrealEditor-CesiumRuntime.dll
   Creating library C:\UE_Projects\Stargate\Plugins\cesium-unreal\Intermediate\Build\Win64\x64\UnrealEditor\Development\CesiumRuntime\UnrealEditor-CesiumRuntime.sup.lib and object C:\UE_Projects\Stargate\Plugins\cesium-unreal\Intermediate\Build\Win64\x64\UnrealEditor\Development\CesiumRuntime\UnrealEditor-CesiumRuntime.sup.exp
ktx.lib(basisu_comp.cpp.obj) : error LNK2019: unresolved external symbol __std_find_last_trivial_1 referenced in function "char const * __cdecl std::_Find_last_vectorized<char const ,char>(char const * const,char const * const,char)" (??$_Find_last_vectorized@$$CBDD@std@@YAPEBDQEBD0D@Z)
ktx.lib(basisu_gpu_texture.cpp.obj) : error LNK2001: unresolved external symbol __std_find_last_trivial_1
ada.lib(ada.cpp.obj) : error LNK2001: unresolved external symbol __std_find_last_trivial_1
spdlog.lib(spdlog.cpp.obj) : error LNK2019: unresolved external symbol __std_find_first_of_trivial_1 referenced in function "char const * __cdecl std::_Find_first_of_vectorized<char const ,char const >(char const * const,char const * const,char const * const,char const * const)" (??$_Find_first_of_vectorized@$$CBD$$CBD@std@@YAPEBDQEBD000@Z)
ada.lib(ada.cpp.obj) : error LNK2001: unresolved external symbol __std_find_first_of_trivial_1
spdlog.lib(spdlog.cpp.obj) : error LNK2019: unresolved external symbol __std_find_last_of_trivial_pos_1 referenced in function "unsigned __int64 __cdecl std::_Find_last_of_pos_vectorized<char,char>(char const * const,unsigned __int64,char const * const,unsigned __int64)" (??$_Find_last_of_pos_vectorized@DD@std@@YA_KQEBD_K01@Z)
absl_string_view.lib(string_view.cc.obj) : error LNK2019: unresolved external symbol __std_find_end_1 referenced in function "char const * __cdecl std::_Find_end_vectorized<char const ,char const >(char const * const,char const * const,char const * const,unsigned __int64)" (??$_Find_end_vectorized@$$CBD$$CBD@std@@YAPEBDQEBD00_K@Z)
ada.lib(ada.cpp.obj) : error LNK2019: unresolved external symbol __std_search_1 referenced in function "char const * __cdecl std::_Search_vectorized<char const ,char const >(char const * const,char const * const,char const * const,unsigned __int64)" (??$_Search_vectorized@$$CBD$$CBD@std@@YAPEBDQEBD00_K@Z)
C:\UE_Projects\Stargate\Plugins\cesium-unreal\Binaries\Win64\UnrealEditor-CesiumRuntime.dll : fatal error LNK1120: 5 unresolved externals
```

The current approach recommended by maintainers is to manually patch cesium-unreal CMake files to force the adoption of a specific MSVC toolset (as stated of the documentation below) which is far from ideal:
https://cesium.com/learn/cesium-unreal/ref-doc/developer-setup-windows-gotchas.html

This PR fixes that limitation by letting users set `VCPKG_PLATFORM_TOOLSET_VERSION` in their build environments so that the build process of cesium-native is able to respect this user preference and correctly propagate it along the build chain.  This is a small step towards supporting a more flexible and customizable build system for cesium-unreal.

<!-- Include screenshots if appropriate. -->

## Issue number or link

<!-- If it fixes an open issue, link to the issue here -->

<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Author checklist

- [X ] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [ X] I have done a full self-review of my code.
- [ ] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [ ] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [ ] I have updated the documentation as necessary.

## Remaining Tasks

<!-- Are there any remaining tasks to do or blocking questions to answer before we can merge this? -->

<!-- If so, please convert this to a draft PR and let us know how we can help. Otherwise, you may remove this section. -->

## Testing plan

<!-- Describe in detail how you tested your changes. If this fixes a bug, list the steps to reproduce the original issue. -->

<!-- Include links to any required data or screenshots. Mention any edge cases such as user error, invalid data, etc. -->