### PR TITLE
Don't crash when undoing/redoing raster overlay deletion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Added a missing `CesiumRuntime.h` include in `CesiumPropertyAttribute.cpp` that broke compilation in v2.18.0 on Windows.
 - Fixed a bug in `FCesiumVectorStyle` that made polygons use the color mode from `LineStyle` instead of `PolygonStyle`.
+- Fixed a bug that could cause a crash when undoing and redoing deletion of a `CesiumRasterOverlay` component.
 
 ### v2.18.0 - 2025-08-01
 

--- a/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRasterOverlay.cpp
@@ -126,7 +126,7 @@ void UCesiumRasterOverlay::RemoveFromTileset() {
 
   this->OnRemove(pTileset, this->_pOverlay);
   pTileset->getOverlays().remove(this->_pOverlay);
-  this->_pOverlay = nullptr;
+  this->_pOverlay.reset();
 }
 
 void UCesiumRasterOverlay::Refresh() {

--- a/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
+++ b/Source/CesiumRuntime/Public/CesiumRasterOverlay.h
@@ -4,6 +4,7 @@
 
 #include "CesiumRasterOverlayLoadFailureDetails.h"
 #include "CesiumRasterOverlays/RasterOverlay.h"
+#include "CesiumUtility/IntrusivePointer.h"
 #include "Components/ActorComponent.h"
 #include "CoreMinimal.h"
 #include "Engine/Texture.h"
@@ -255,6 +256,7 @@ protected:
       CesiumRasterOverlays::RasterOverlay* pOverlay) {}
 
 private:
-  CesiumRasterOverlays::RasterOverlay* _pOverlay;
+  CesiumUtility::IntrusivePointer<CesiumRasterOverlays::RasterOverlay>
+      _pOverlay;
   int32 _overlaysBeingDestroyed;
 };


### PR DESCRIPTION
1. Add a polygon raster overlay to Google Photorealistic 3D Tiles (probably any tileset will work) and point it to an actual Cartographic Polygon so that a rectangle is clipped out.
2. Delete the `CesiumPolygonRasterOverlay` from the tileset. The polygon cutout should disappear.
3. Press Ctrl-Z to undo the deletion. The polygon cutout should reappear.
4. Press Ctrl-Y to redo the deletion. CRASH!

The problem is that `UCesiumRasterOverlay` just holds a raw pointer to the underlying cesium-native `RasterOverlay`. In the specific scenario described above, the `Tileset` gets destroyed, which destroys the raster overlays, without the `UCesiumRasterOverlay` knowing about it. That leaves the `UCesiumRasterOverlay` holding a pointer to a deleted object.

I looked into fixing this, but it's not straightforward. On undo/redo, we destroy the `Tileset` purposely, which is reasonable enough to make sure we pick up any (unknown) changes that resulted from the undo/redo. But at the moment that happens, the deleted component is no longer associated with the `ACesium3DTileset` (it's not returned by `GetComponents`) and yet it has not actually been destroyed yet. The lack of association means we don't know to call `RemoveFromTileset`, which is what would otherwise zero out that raw pointer to the cesium-native `RasterOverlay` before it is destroyed.

The fix implemented here is to hold an `IntrusivePointer` to the cesium-native `RasterOverlay` instead of a raw pointer.