### PR TITLE
Fix ellipsoid loading bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log {#changes}
 
+### v2.19.1 - 2025-09-02
+
+##### Fixes :wrench:
+
+- Fixed a bug that could cause incorrect ellipsoid parameters to be used when loading a level.
+
 ### v2.19.0 - 2025-09-02
 
 ##### Additions :tada:

--- a/CesiumForUnreal.uplugin
+++ b/CesiumForUnreal.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 79,
-	"VersionName": "2.19.0",
+	"Version": 80,
+	"VersionName": "2.19.1",
 	"FriendlyName": "Cesium for Unreal",
 	"Description": "Unlock the 3D geospatial ecosystem in Unreal Engine with real-world 3D content and a high accuracy full-scale WGS84 globe.",
 	"Category": "Geospatial",

--- a/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoreference.cpp
@@ -564,11 +564,6 @@ void ACesiumGeoreference::Serialize(FArchive& Ar) {
   Super::Serialize(Ar);
 
   Ar.UsingCustomVersion(FCesiumCustomVersion::GUID);
-
-  // Recompute derived values on load.
-  if (Ar.IsLoading()) {
-    this->_updateCoordinateSystem();
-  }
 }
 
 void ACesiumGeoreference::BeginPlay() {
@@ -604,6 +599,8 @@ void ACesiumGeoreference::OnConstruction(const FTransform& Transform) {
 
 void ACesiumGeoreference::PostLoad() {
   Super::PostLoad();
+
+  this->_updateCoordinateSystem();
 
 #if WITH_EDITOR
   if (GEditor && IsValid(this->GetWorld()) &&

--- a/Source/CesiumRuntime/Private/Tests/CesiumSceneGeneration.cpp
+++ b/Source/CesiumRuntime/Private/Tests/CesiumSceneGeneration.cpp
@@ -19,7 +19,7 @@
 namespace Cesium {
 
 FString SceneGenerationContext::testIonToken(
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJhOTM5MjkzMi05NWFkLTQwNjktYmI4MS0yZTA0ODJjNjlkN2YiLCJpZCI6MjU5LCJpYXQiOjE3NTQwMTM5MTJ9.xajFDEmv1qzdOlOVqwKDc9SRZ7GhVgMdlBhNB7VHzCw");
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJmNmFkMTRiYi1hZTUyLTQ1NzYtODRmMi02NDQ5MzM0MWRiZmEiLCJpZCI6MjU5LCJpYXQiOjE3NTY3NzM2NjJ9._U3nPF9OReR3A0u2TrOYeVf_uIKUWpfYTacHGDVOnVA");
 
 void SceneGenerationContext::setCommonProperties(
     const FVector& origin,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium-unreal",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "description": "Cesium for Unreal",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
The work-in-progress Moon and Mars level in the Samples was exhibiting some really dodgy behavior, and I eventually tracked it down to incorrect ellipsoid values. The problem was that during load the CesiumGeoreference was creating its coordinate system in the `Serialize` method. When this is called, Unreal ensures that all of _that_ object's values are loaded, but it makes no guarantees about any other linked objects. So in this particular level, the Moon `UCesiumEllipsoid` hadn't actually been loaded by the time the coordinate system was created. That meant its radii were all zeros, and the conversion ended up using a very small ellipsoid instead.

In this PR, I fixed this problem by doing the coordinate system creation in `PostLoad` instead of `Serialize`. This is risky. It basically undoes the change made in this commit:
https://github.com/CesiumGS/cesium-unreal/commit/5cbe3f89efe92c0f8d3e7f81d6d13e5cdab874af

But doing this work in `Serialize` simply isn't viable since we introduced configurable ellipsoids. So we have little choice but to move it to `PostLoad` and then deal with any fallout.

But I wasn't able to identify any fallout. All the tests still pass, and all the CesiumGeoreference things I tried, including with sub-levels, still seem to work well.

I'm going to merge this once CI passes and do a patch release.