### PR TITLE
adding small function to control collision response by channel on Cesium3DTileset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Change Log {#changes}
 
+- adding a function to change the collision response of a Cesium3DTileset by collision channel.
+
 ### v2.20.0 - 2025-10-01
 
 ##### Additions :tada:

--- a/Source/CesiumRuntime/Public/Cesium3DTileset.h
+++ b/Source/CesiumRuntime/Public/Cesium3DTileset.h
@@ -138,6 +138,30 @@ public:
       const TArray<FVector>& LongitudeLatitudeHeightArray,
       FCesiumSampleHeightMostDetailedCallback OnHeightsSampled);
 
+  /**
+   * @brief Sets the collision response of this tileset to a specific collision
+   * channel at runtime. This updates the actor's BodyInstance for future-loaded
+   * tiles and propagates the change to all currently loaded tiles by refreshing
+   * their primitive components, ensuring consistent collision behavior for both
+   * queries and physics interactions.
+   *
+   * The change takes effect immediately after propagation, including recreation
+   * of physics states on existing primitives. This function is
+   * blueprint-callable and suitable for dynamic adjustments, such as toggling
+   * interactions with pawns or projectiles during gameplay. Note that tiles
+   * must have physics meshes enabled (via CreatePhysicsMeshes) for physical
+   * collisions to apply.
+   *
+   * @param Channel The collision channel to modify (e.g., ECC_Pawn,
+   * ECC_Visibility).
+   * @param NewResponse The new response for the channel (e.g., ECR_Block,
+   * ECR_Ignore).
+   */
+  UFUNCTION(BlueprintCallable, Category = "Cesium|Collision")
+  void SetCollisionResponseToChannel(
+      ECollisionChannel Channel,
+      ECollisionResponse NewResponse);
+
 private:
   /**
    * The designated georeference actor controlling how the actor's


### PR DESCRIPTION
## Description

Adds a very small function that allow the Cesium3DTileset to have the Collision response change per collision channel which is present in standard Unreal StaticMeshActors. 

This is extremely useful for changing the collision response for just pawns but still retain hit responses for other channels such as vehicles. An example use case is to set the Pawn collision response to ignore if the player pawn is within a small CartographicPolygon that would otherwise not have the partially clipped tile collisions removed. All other actors in the world will still have normal collision response to the tileset for game play purposes. 

<img width="561" height="242" alt="image" src="https://github.com/user-attachments/assets/4445d1ee-4e9f-41f8-b23e-4712dbfa80d6" />


## Issue number or link

Related to my question here about finding interior of CartographicPolygon: https://community.cesium.com/t/best-way-to-check-if-object-is-inside-or-outside-of-a-cartographicpolygon/42926?u=v2i

## Author checklist

- [ x ] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [ x ] I have done a full self-review of my code.
- [ x ] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [ x ] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [ x ] I have updated the documentation as necessary.

## Remaining Tasks

No remaining tasks that I know of.

## Testing plan

Can be called in C++ or Blueprint. Accepts array or single object reference. Tested with player Pawn and Vehicle channel dynamic response changes. 