### PR TITLE
Fix missing include that caused build failure

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGoogleMapTilesRasterOverlay.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGoogleMapTilesRasterOverlay.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020-2025 CesiumGS, Inc. and Contributors
 
 #include "CesiumGoogleMapTilesRasterOverlay.h"
+#include "CesiumRuntime.h"
 #include <Cesium3DTilesSelection/Tileset.h>
 #include <CesiumJsonReader/JsonObjectJsonHandler.h>
 #include <CesiumJsonReader/JsonReader.h>


### PR DESCRIPTION
We use `LogCesium` in this file without including `CesiumRuntime`. Thanks to the magic of Unity builds, this works until it doesn't - I ran into a build failure from this. 

We might want to try adding a CI job for a non-unity build to catch issues like this.