### PR TITLE
Optimize globe anchor transform updates in nested hierarchies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@
 - Added `UCesiumGlobeAnchorComponent::HeightUpdateInterval` to specify how often the actor's height is updated when `HeightReference` is `Tileset`.
 - Added `ReceiveDecals` property to `ACesium3DTileset` to allow toggling decal reception per tileset.
 
+##### Fixes :wrench:
+
+- Fixed coordinate anomalies in nested `UCesiumGlobeAnchorComponent` instances when Cesium origin coordinates change. Added a parent actor check to avoid redundant transform updates when a parent actor already has a `UCesiumGlobeAnchorComponent`.
+
 ### v2.24.1 - 2026-03-02
 
 ##### Fixes :wrench:

--- a/Source/CesiumRuntime/Private/CesiumGlobeAnchorComponent.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGlobeAnchorComponent.cpp
@@ -839,6 +839,23 @@ void UCesiumGlobeAnchorComponent::_updateFromNativeGlobeAnchor(
       VecMath::createMatrix(nativeAnchor.getAnchorToFixedTransform());
   this->_actorToECEFIsValid = true;
 
+  // Check if this actor is attached to a parent actor that also has a UCesiumGlobeAnchorComponent.
+  // If so, return early because the parent's globe anchor will handle the transform update
+  // for the entire hierarchy. This avoids redundant transform calculations and potential
+  // conflicts between multiple globe anchors in the same hierarchy.
+  USceneComponent* pOwnerRoot = this->_getRootComponent(true);
+  if (!IsValid(pOwnerRoot)) {
+    return;
+  }
+
+  AActor* pParent = pOwnerRoot->GetAttachParentActor();
+  while (IsValid(pParent)) {
+    if (pParent->FindComponent<UCesiumGlobeAnchorComponent>() != nullptr) {
+      return;
+    }
+    pParent = pParent->GetAttachParentActor();
+  }
+
   // Update the Unreal relative transform
   ACesiumGeoreference* pGeoreference = this->ResolveGeoreference();
   if (IsValid(pGeoreference)) {


### PR DESCRIPTION
Add parent actor check in _updateFromNativeGlobeAnchor to avoid redundant transform calculations when a parent actor already has a UCesiumGlobeAnchorComponent. This optimization reduces unnecessary computations and potential transform conflicts in complex actor hierarchies while maintaining ECEF matrix updates for all anchors.

Added comprehensive documentation comments explaining the purpose of this change.

<!--
Thanks for the Pull Request!

Please review the `https://cesium.com/learn/cesium-unreal/ref-doc/contributing-unreal.html`  before opening your first Pull Request.

To ensure your Pull Request is reviewed and accepted quickly, please refer to our `https://cesium.com/learn/cesium-unreal/ref-doc/contributing-unreal.html#opening-a-pull-request` .
-->

## Description

This change adds a parent actor check to the `_updateFromNativeGlobeAnchor` method of `UCesiumGlobeAnchorComponent` to avoid redundant transform updates when an actor is attached to a parent actor that already has a `UCesiumGlobeAnchorComponent`.

The optimization addresses an issue where nested globe anchors would experience coordinate anomalies when Cesium origin coordinates change. By ensuring only the top-level globe anchor in a hierarchy handles transform updates, we prevent multiple independent transform calculations that could lead to position errors.

### What Changed
- Added a parent actor traversal in `_updateFromNativeGlobeAnchor` to check if any parent actor has a `UCesiumGlobeAnchorComponent`
- If a parent with a globe anchor is found, the method returns early to avoid redundant transform calculations
- Added comprehensive documentation comments explaining the purpose of this optimization

### Why This Change
When actors with `UCesiumGlobeAnchorComponent` are nested in a hierarchy, each globe anchor was previously updating its own transform independently. This could lead to:
1. **Coordinate anomalies**: When Cesium origin coordinates change, nested globe anchors would experience position errors due to multiple independent transform updates
2. **Redundant calculations**: Multiple globe anchors in the same hierarchy performing similar transform calculations
3. **Potential conflicts**: Different globe anchors in the hierarchy potentially fighting over transform updates
4. **Performance overhead**: Unnecessary calculations in complex actor hierarchies

### Implementation Details
The change:
1. Updates the ECEF matrix for the current globe anchor
2. Traverses up the actor hierarchy to check for parent actors with `UCesiumGlobeAnchorComponent`
3. If a parent with a globe anchor is found, returns early without updating the relative transform
4. If no parent with a globe anchor is found, continues with the normal transform update process

## Issue number or link

<!-- If it fixes an open issue, link to the issue here -->
<!-- Consider: If suggesting a new feature or change, discuss it in an issue first. -->

## Author checklist

- [ ] I have submitted a `https://github.com/CesiumGS/community/tree/main/CLAs`  (only needed once).
- [x] I have done a full self-review of my code.
- [x] I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- [ ] I have added or updated unit tests to ensure consistent code coverage as necessary.
- [x] I have updated the documentation as necessary.

## Remaining Tasks

<!-- Are there any remaining tasks to do or blocking questions to answer before we can merge this? -->
<!-- If so, please convert this to a draft PR and let us know how we can help. Otherwise, you may remove this section. -->

## Testing plan

This change has been tested with:

1. **Simple actor hierarchies**: Parent actor with globe anchor, child actor with globe anchor
2. **Complex actor hierarchies**: Multiple levels of nested actors with globe anchors
3. **Actors without parent anchors**: Verify no regression in transform updates
4. **Cesium origin coordinate changes**: Verify that nested globe anchors maintain correct positions when Cesium origin coordinates change

The optimization should be transparent to users and maintain the same visual behavior while improving performance in nested hierarchies. Most importantly, it resolves the coordinate anomaly issue when Cesium origin coordinates change.

## Reviewer checklist

Thank you for taking the time to review this PR. By approving a PR you are taking as much responsibility for these changes as the author.

As you review, please go through the checklist below:

- [ ] Review and run all parts of the test plan on this branch and verify it matches expectations.
    - [ ] If the issue is a bug please make sure you can reproduce the bug in the main branch and then checkout this branch to make sure it actually solved the issue.
- [ ] Review the code and make sure you do not have any remaining questions or concerns. You should understand the code change and the chosen approach. If you are not confident or have doubts about the code, please do not hesitate to ask questions.
    - [ ] Code should follow the `https://cesium.com/learn/cesium-native/ref-doc/style-guide.html`  
- [ ] Review the unit tests and make sure there are no missing tests or edge cases.
- [ ] Review documentation changes and updates to `CHANGES.md` to make sure they accurately cover the work in this PR.
- [ ] Verify that the `https://github.com/CesiumGS/community/tree/main/CLAs`  has been submitted, if needed.