### PR TITLE
Add Clear Request Cache button to Project Settings -> Plugins -> Cesium

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ##### Additions :tada:
 
-- Added a "Clear Request Cache" button to `UCesiumRuntimeSettings` (Project Settings -> Plugins -> Cesium) that clears all entries from the SQLite request cache database.
+- Added a "Clear Request Cache" Blueprint-callable function to `UCesiumRuntimeSettings` and a button to Project Settings -> Plugins -> Cesium that clears all entries from the SQLite request cache database.
 
 ### v2.25.0 - 2026-04-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log {#changes}
 
+### ? - ?
+
+##### Additions :tada:
+
+- Added a "Clear Request Cache" button to `UCesiumRuntimeSettings` (Project Settings -> Plugins -> Cesium) that clears all entries from the SQLite request cache database.
+
 ### v2.25.0 - 2026-04-01
 
 ##### Additions :tada:

--- a/Source/CesiumEditor/Private/CesiumEditor.cpp
+++ b/Source/CesiumEditor/Private/CesiumEditor.cpp
@@ -15,6 +15,7 @@
 #include "CesiumMetadataValueCustomization.h"
 #include "CesiumPanel.h"
 #include "CesiumRuntime.h"
+#include "CesiumRuntimeSettingsCustomization.h"
 #include "CesiumSunSky.h"
 #include "CesiumVoxelShaderBuilder.h"
 #include "Editor.h"
@@ -122,6 +123,7 @@ void registerDetailCustomization() {
   FCesiumGlobeAnchorCustomization::Register(PropertyEditorModule);
   FCesium3DTilesetCustomization::Register(PropertyEditorModule);
   FCesiumMetadataValueCustomization::Register(PropertyEditorModule);
+  FCesiumRuntimeSettingsCustomization::Register(PropertyEditorModule);
 
   PropertyEditorModule.NotifyCustomizationModuleChanged();
 }
@@ -139,6 +141,7 @@ void unregisterDetailCustomization() {
     FCesiumGlobeAnchorCustomization::Unregister(PropertyEditorModule);
     FCesium3DTilesetCustomization::Unregister(PropertyEditorModule);
     FCesiumMetadataValueCustomization::Unregister(PropertyEditorModule);
+    FCesiumRuntimeSettingsCustomization::Unregister(PropertyEditorModule);
   }
 }
 

--- a/Source/CesiumEditor/Private/CesiumRuntimeSettingsCustomization.cpp
+++ b/Source/CesiumEditor/Private/CesiumRuntimeSettingsCustomization.cpp
@@ -1,0 +1,45 @@
+// Copyright 2020-2025 CesiumGS, Inc. and Contributors
+
+#include "CesiumRuntimeSettingsCustomization.h"
+#include "CesiumCustomization.h"
+#include "CesiumRuntimeSettings.h"
+#include "DetailCategoryBuilder.h"
+#include "DetailLayoutBuilder.h"
+
+FName FCesiumRuntimeSettingsCustomization::RegisteredLayoutName;
+
+void FCesiumRuntimeSettingsCustomization::Register(
+    FPropertyEditorModule& PropertyEditorModule) {
+  RegisteredLayoutName = UCesiumRuntimeSettings::StaticClass()->GetFName();
+  PropertyEditorModule.RegisterCustomClassLayout(
+      RegisteredLayoutName,
+      FOnGetDetailCustomizationInstance::CreateStatic(
+          &FCesiumRuntimeSettingsCustomization::MakeInstance));
+}
+
+void FCesiumRuntimeSettingsCustomization::Unregister(
+    FPropertyEditorModule& PropertyEditorModule) {
+  PropertyEditorModule.UnregisterCustomClassLayout(RegisteredLayoutName);
+}
+
+TSharedRef<IDetailCustomization>
+FCesiumRuntimeSettingsCustomization::MakeInstance() {
+  return MakeShareable(new FCesiumRuntimeSettingsCustomization);
+}
+
+void FCesiumRuntimeSettingsCustomization::CustomizeDetails(
+    IDetailLayoutBuilder& DetailBuilder) {
+  IDetailCategoryBuilder& CacheCategory =
+      DetailBuilder.EditCategory("Cache");
+
+  UFunction* ClearFunction =
+      UCesiumRuntimeSettings::StaticClass()->FindFunctionByName(
+          GET_FUNCTION_NAME_CHECKED(UCesiumRuntimeSettings, ClearRequestCache));
+
+  TSharedPtr<CesiumButtonGroup> ButtonGroup =
+      CesiumCustomization::CreateButtonGroup();
+  ButtonGroup->AddButtonForUFunction(
+      ClearFunction,
+      NSLOCTEXT("CesiumEditor", "ClearRequestCache", "Clear Request Cache"));
+  ButtonGroup->Finish(DetailBuilder, CacheCategory);
+}

--- a/Source/CesiumEditor/Private/CesiumRuntimeSettingsCustomization.cpp
+++ b/Source/CesiumEditor/Private/CesiumRuntimeSettingsCustomization.cpp
@@ -29,8 +29,7 @@ FCesiumRuntimeSettingsCustomization::MakeInstance() {
 
 void FCesiumRuntimeSettingsCustomization::CustomizeDetails(
     IDetailLayoutBuilder& DetailBuilder) {
-  IDetailCategoryBuilder& CacheCategory =
-      DetailBuilder.EditCategory("Cache");
+  IDetailCategoryBuilder& CacheCategory = DetailBuilder.EditCategory("Cache");
 
   UFunction* ClearFunction =
       UCesiumRuntimeSettings::StaticClass()->FindFunctionByName(

--- a/Source/CesiumEditor/Private/CesiumRuntimeSettingsCustomization.h
+++ b/Source/CesiumEditor/Private/CesiumRuntimeSettingsCustomization.h
@@ -1,0 +1,23 @@
+// Copyright 2020-2025 CesiumGS, Inc. and Contributors
+
+#pragma once
+
+#include "IDetailCustomization.h"
+#include "PropertyEditorModule.h"
+
+/**
+ * An implementation of IDetailCustomization that adds interactive buttons
+ * (e.g. "Clear Request Cache") to the UCesiumRuntimeSettings details view
+ * shown in Project Settings -> Plugins -> Cesium.
+ */
+class FCesiumRuntimeSettingsCustomization : public IDetailCustomization {
+public:
+  virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+
+  static void Register(FPropertyEditorModule& PropertyEditorModule);
+  static void Unregister(FPropertyEditorModule& PropertyEditorModule);
+
+  static TSharedRef<IDetailCustomization> MakeInstance();
+
+  static FName RegisteredLayoutName;
+};

--- a/Source/CesiumRuntime/Private/CesiumRuntimeSettings.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRuntimeSettings.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020-2024 CesiumGS, Inc. and Contributors
 
 #include "CesiumRuntimeSettings.h"
+#include "CesiumAsync/SqliteCache.h"
 #include "CesiumRuntime.h"
 
 UCesiumRuntimeSettings::UCesiumRuntimeSettings(
@@ -9,7 +10,7 @@ UCesiumRuntimeSettings::UCesiumRuntimeSettings(
   CategoryName = FName(TEXT("Plugins"));
 }
 
-void UCesiumRuntimeSettings::ClearRequestCache() {
+/*static*/ void UCesiumRuntimeSettings::ClearRequestCache() {
   getCacheDatabase()->clearAll();
-  UE_LOG(LogCesium, Info, TEXT("Cesium request cache cleared."));
+  UE_LOG(LogCesium, Display, TEXT("Cesium request cache cleared."));
 }

--- a/Source/CesiumRuntime/Private/CesiumRuntimeSettings.cpp
+++ b/Source/CesiumRuntime/Private/CesiumRuntimeSettings.cpp
@@ -1,9 +1,15 @@
 // Copyright 2020-2024 CesiumGS, Inc. and Contributors
 
 #include "CesiumRuntimeSettings.h"
+#include "CesiumRuntime.h"
 
 UCesiumRuntimeSettings::UCesiumRuntimeSettings(
     const FObjectInitializer& ObjectInitializer)
     : Super(ObjectInitializer) {
   CategoryName = FName(TEXT("Plugins"));
+}
+
+void UCesiumRuntimeSettings::ClearRequestCache() {
+  getCacheDatabase()->clearAll();
+  UE_LOG(LogCesium, Info, TEXT("Cesium request cache cleared."));
 }

--- a/Source/CesiumRuntime/Public/CesiumRuntimeSettings.h
+++ b/Source/CesiumRuntime/Public/CesiumRuntimeSettings.h
@@ -70,6 +70,6 @@ public:
   /**
    * Clears all entries from the request cache database.
    */
-  UFUNCTION()
-  void ClearRequestCache();
+  UFUNCTION(BlueprintCallable, Category = "Cesium")
+  static void ClearRequestCache();
 };

--- a/Source/CesiumRuntime/Public/CesiumRuntimeSettings.h
+++ b/Source/CesiumRuntime/Public/CesiumRuntimeSettings.h
@@ -66,4 +66,10 @@ public:
       Category = "Cache",
       meta = (ConfigRestartRequired = true))
   int MaxCacheItems = 4096;
+
+  /**
+   * Clears all entries from the request cache database.
+   */
+  UFUNCTION()
+  void ClearRequestCache();
 };


### PR DESCRIPTION
It's sometimes useful to clear Cesium's request cache. You can do this by closing the Editor and deleting the .sqlite file (once you find it), but that's a hassle. This PR adds a button for it under Project Settings -> Plugins -> Cesium. The function is also Blueprint-callable for use at runtime.

Sadly, tagging a UFUNCTION with CallInEditor on `UCesiumRuntimeSettings` makes the button appear in the UI, but clicking it does nothing. Hence the the new "customization" class.

This is something I've low-key wanted to do for awhile, and I was reminded of it today by [this community forum post](https://community.cesium.com/t/google-3d-tiles-switching-to-various-map-versions-in-cesium-unreal/45890), which it might be helpful for. It was never a very difficult thing to do, but Copilot made it pretty much trivial.