### PR TITLE
Fix Regression: null UWorld deref in CesiumGaussianSplatSubsystem::Tick

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Added missing includes that introduced compilation failures when building the plugin from source against UE 5.7's bundled clang 20.1.8 toolchain (introduced in v2.25.0 by #1685; binary plugin users were unaffected).
 - Fixed the case where glTF line primitives caused excessive log spam due to Chaos attempting to generate physics bodies for small non-triangle meshes.
 - Fixed an incorrect transform that reversed the appearance of data in box voxel tilesets.
+- Fixed a crash in `UCesiumGaussianSplatSubsystem::Tick` when `GetPrimaryWorld()` returns `nullptr` (e.g. between PIE shutdown and Standalone-Game launch, or on nDisplay secondary nodes during world bind-up). Restores the validity check ordering that shipped in v2.24.1 and was inadvertently inverted in v2.26.0 (#1841).
 
 ### v2.26.0 - 2026-05-01
 

--- a/Source/CesiumRuntime/Private/CesiumGaussianSplatSubsystem.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGaussianSplatSubsystem.cpp
@@ -229,19 +229,20 @@ void UCesiumGaussianSplatSubsystem::Tick(float DeltaTime) {
   }
 
   UWorld* pWorld = GetPrimaryWorld();
-  // Gaussian splats are purely visual, so we don't need to initialize them if
-  // we can't render anything. Besides, the Niagara component will fail to
-  // spawn if either of these conditions are false (they are checked in
-  // UNiagaraFunctionLibrary::CreateNiagaraSystem).
-  if (!FApp::CanEverRender() || pWorld->IsNetMode(NM_DedicatedServer)) {
-    return;
-  }
 
   if (!IsValid(pWorld)) {
     if (IsValid(this->_pNiagaraActor)) {
       this->_pNiagaraActor->Destroy();
     }
     this->reset();
+    return;
+  }
+
+  // Gaussian splats are purely visual, so we don't need to initialize them if
+  // we can't render anything. Besides, the Niagara component will fail to
+  // spawn if either of these conditions are false (they are checked in
+  // UNiagaraFunctionLibrary::CreateNiagaraSystem).
+  if (!FApp::CanEverRender() || pWorld->IsNetMode(NM_DedicatedServer)) {
     return;
   }
 


### PR DESCRIPTION
Moved IsValid(pWorld) above the IsNetMode(NM_DedicatedServer) deref so a null result from GetPrimaryWorld() no longer crashes InternalGetNetMode. Restores the v2.24.1 ordering inverted by commit 05fce68a.

Fixes #1841

## Description
Restore the `IsValid(pWorld)` check above the `pWorld->IsNetMode(NM_DedicatedServer)` deref in `UCesiumGaussianSplatSubsystem::Tick`. This is the ordering that shipped in 2.24.1 (UE 5.7 Marketplace) and was inadvertently regressed in  commit 05fce68a ("close to working [skip ci]") during the recent Niagara/Gaussian-splat refactor.

This fixes #1841 and also Play in Standalone in Unreal projects with Cesium enabled.

## Issue number or link

#1841 and also Play in Standalone crash in Unreal projects with Cesium enabled.

## Author checklist

- [x] I have submitted a [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) (only needed once).
- [x] I have done a full self-review of my code.
- [x]  I have updated `CHANGES.md` with a short summary of my change (for user-facing changes).
- ~~[ ]  I have added or updated unit tests to ensure consistent code coverage as necessary.~~
- ~~[ ]  I have updated the documentation as necessary.~~

## Remaining Tasks

NA

## Testing plan

- Make a fresh project in Unreal and enable CesiumForUnreal 
- Login to Cesium Ion
- Bring in the 3D tiles and start the project in Standalone.

## Reviewer checklist

Thank you for taking the time to review this PR. By approving a PR you are taking as much responsibility for these changes as the author.

As you review, please go through the checklist below:

- [x] Review and run all parts of the test plan on this branch and verify it matches expectations.
    - [x] If the issue is a bug please make sure you can reproduce the bug in the main branch and then checkout this branch to make sure it actually solved the issue.
- [x] Review the code and make sure you do not have any remaining questions or concerns. You should understand the code change and the chosen approach. If you are not confident or have doubts about the code, please do not hesitate to ask questions.
    - [x] Code should follow the [C++ Style Guide](https://cesium.com/learn/cesium-native/ref-doc/style-guide.html)
- [ ] Review the unit tests and make sure there are no missing tests or edge cases.
- [x] Review documentation changes and updates to `CHANGES.md` to make sure they accurately cover the work in this PR.
- [x] Verify that the [Contributor License Agreement](https://github.com/CesiumGS/community/tree/main/CLAs) has been submitted, if needed.