### PR TITLE
fix(GeoJSON): bounds MultiLineString iteration by line count

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGeoJsonObject.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGeoJsonObject.cpp
@@ -323,7 +323,7 @@ UCesiumGeoJsonObjectBlueprintLibrary::GetObjectAsMultiLineString(
 
   TArray<FCesiumGeoJsonLineString> Lines;
   Lines.Reserve(pMultiLineString->coordinates.size());
-  for (size_t i = 0; i < pMultiLineString->coordinates[i].size(); i++) {
+  for (size_t i = 0; i < pMultiLineString->coordinates.size(); i++) {
 
     TArray<FVector> Points;
     Points.Reserve(pMultiLineString->coordinates[i].size());


### PR DESCRIPTION
## Summary

fix(GeoJSON): bounds MultiLineString iteration by line count

## Changes

- GetObjectAsMultiLineString: outer loop uses coordinates.size() not coordinates[i].size()

Fixes #1870
