### PR TITLE
Fix crash on editor exit in UCesiumGaussianSplatSubsystem::Deinitialize

### DIFF
--- a/Source/CesiumRuntime/Private/CesiumGaussianSplatSubsystem.cpp
+++ b/Source/CesiumRuntime/Private/CesiumGaussianSplatSubsystem.cpp
@@ -122,6 +122,20 @@ void UCesiumGaussianSplatSubsystem::Initialize(
 void UCesiumGaussianSplatSubsystem::Deinitialize() {
   this->_isTickEnabled = false;
 
+  // The splat actor, its Niagara component, and the world they live in are
+  // owned elsewhere, and the raw pointers to them are invisible to the
+  // garbage collector. During engine shutdown the world and everything in it
+  // may already be destroyed by the time this function runs, leaving the
+  // pointers dangling and even IsValid() unsafe to call on them (#1879).
+  // Everything is being torn down anyway, so simply drop the references.
+  if (IsEngineExitRequested()) {
+    this->_pNiagaraActor = nullptr;
+    this->_pNiagaraComponent = nullptr;
+    this->_pLastCreatedWorld = nullptr;
+    this->SplatComponents.Empty();
+    return;
+  }
+
   if (IsValid(this->_pNiagaraActor)) {
     this->_pNiagaraActor->Destroy();
   }


### PR DESCRIPTION
Fixes #1879.

## Problem

The Unreal Editor crashes on every editor exit when Cesium for Unreal is enabled, even in sessions where no Gaussian splat content is loaded (see #1879 for full crash logs). Two crash flavors, same root cause:

- `Assertion failed: Index >= 0` in `FUObjectArray::IndexToObject`, from `IsValid(this->_pNiagaraActor)` at `CesiumGaussianSplatSubsystem.cpp:125`
- `EXCEPTION_ACCESS_VIOLATION` from `Deinitialize()` at line 129, via `reset()` → `makeInterfaceDirty()` → `getDataInterface()` dereferencing the dangling `_pNiagaraComponent`

## Root cause

The subsystem holds the Niagara actor/component and the world as **raw pointers**, which are invisible to the garbage collector. During engine shutdown, the editor world and the transient `ACesiumGaussianSplatActor` spawned into it are destroyed **before** the engine subsystem's `Deinitialize()` runs. Both `IsValid()` (which reads `InternalIndex` from potentially-freed memory) and `reset()` (which dereferences `_pNiagaraComponent` through `UNiagaraFunctionLibrary::GetDataInterface`) are then unsafe to call on the dangling pointers.

Since `Tick()` spawns the splat system actor unconditionally (even with zero splat tilesets), every editor session has an actor to dangle at exit - hence the 100% repro rate.

## Fix

Early-return from the cleanup when the engine is exiting. Everything the cleanup would touch is either already destroyed or about to be, so we simply drop the references without calling `IsValid()` or `reset()`. Non-shutdown paths (plugin unload, hot reload) keep the existing behavior with valid pointers.

## Alternatives considered

- **`TWeakObjectPtr` members** would be the more thorough fix, but requires touching ~20 usage sites across the file. Since this subsystem does not own the actor (the world does), weak pointers are the semantically correct long-term direction - happy to do that as a follow-up if preferred.
- **Lazy actor spawn** (only when the first splat component registers) would additionally avoid spawning the Niagara system in projects that never use splats, but that is a behavioral change beyond the scope of this crash fix (also mentioned in #1872).

## Testing

Not compiled locally (no UE 5.8 environment available to me); relying on CI and review. The change is confined to a single function and only adds a guard branch ahead of the existing logic.