### PR TITLE
Use larger runners for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [push, workflow_dispatch]
 jobs:
   QuickChecks:
     name: "Quick Checks"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -12,7 +12,7 @@ jobs:
           npm install
           npm run format -- --dry-run -Werror
   Documentation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - name: Install Doxygen
         run: |
@@ -40,7 +40,7 @@ jobs:
     uses: ./.github/workflows/buildWindows.yml
     secrets: inherit
     with:
-      runner-label: "windows-2022"
+      runner-label: "windows-2022-l"
       unreal-engine-version: "5.6.0"
       unreal-engine-zip: "s3://cesium-unreal-engine/5.6.0/UE_5.6.zip"
       unreal-program-name: "UE_5.6"
@@ -57,7 +57,7 @@ jobs:
     uses: ./.github/workflows/testWindows.yml
     secrets: inherit
     with:
-      runner-label: windows-2022
+      runner-label: windows-2022-l
       unreal-engine-zip: "s3://cesium-unreal-engine/5.6.0/UE_5.6.zip"
       unreal-program-name: "UE_5.6"
       test-package-base-name: "CesiumForUnreal-56-windows"
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/buildAndroid.yml
     secrets: inherit
     with:
-      runner-label: windows-2022
+      runner-label: windows-2022-l
       unreal-engine-version: "5.6.0"
       unreal-engine-zip: "s3://cesium-unreal-engine/5.6.0/UE_5.6.zip"
       unreal-program-name: "UE_5.6"
@@ -75,7 +75,7 @@ jobs:
     uses: ./.github/workflows/buildLinux.yml
     secrets: inherit
     with:
-      runner-label: ubuntu-22.04
+      runner-label: ubuntu-latest-m
       unreal-engine-version: "5.6.0"
       unreal-engine-zip: "s3://cesium-unreal-engine/5.6.0/Linux_Unreal_Engine_5.6.0.zip"
       unreal-program-name: "UE_5.6"
@@ -92,7 +92,7 @@ jobs:
       upload-package-base-name: "CesiumForUnreal-56-apple"
       xcode-version: "16.1"
   Combine56:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     needs: [Windows56, Android56, Linux56, Apple56]
     steps:
       - name: Check out repository code
@@ -147,7 +147,7 @@ jobs:
     uses: ./.github/workflows/testPackageOnWindows.yml
     secrets: inherit
     with:
-      runner-label: windows-2022
+      runner-label: windows-2022-l
       unreal-engine-zip: "s3://cesium-unreal-engine/5.6.0/UE_5.6.zip"
       unreal-program-name: "UE_5.6"
       unreal-engine-association: "5.6"
@@ -158,7 +158,7 @@ jobs:
     uses: ./.github/workflows/buildWindows.yml
     secrets: inherit
     with:
-      runner-label: "windows-2022"
+      runner-label: "windows-2022-l"
       unreal-engine-version: "5.7.0"
       unreal-engine-zip: "s3://cesium-unreal-engine/5.7.0/UE_5.7.zip"
       unreal-program-name: "UE_5.7"
@@ -175,7 +175,7 @@ jobs:
     uses: ./.github/workflows/testWindows.yml
     secrets: inherit
     with:
-      runner-label: windows-2022
+      runner-label: windows-2022-l
       unreal-engine-zip: "s3://cesium-unreal-engine/5.7.0/UE_5.7.zip"
       unreal-program-name: "UE_5.7"
       test-package-base-name: "CesiumForUnreal-57-windows"
@@ -183,7 +183,7 @@ jobs:
     uses: ./.github/workflows/buildAndroid.yml
     secrets: inherit
     with:
-      runner-label: windows-2022
+      runner-label: windows-2022-l
       unreal-engine-version: "5.7.0"
       unreal-engine-zip: "s3://cesium-unreal-engine/5.7.0/UE_5.7.zip"
       unreal-program-name: "UE_5.7"
@@ -193,7 +193,7 @@ jobs:
     uses: ./.github/workflows/buildLinux.yml
     secrets: inherit
     with:
-      runner-label: ubuntu-22.04
+      runner-label: ubuntu-latest-m
       unreal-engine-version: "5.7.0"
       unreal-engine-zip: "s3://cesium-unreal-engine/5.7.0/Linux_Unreal_Engine_5.7.0.zip"
       unreal-program-name: "UE_5.7"
@@ -210,7 +210,7 @@ jobs:
       upload-package-base-name: "CesiumForUnreal-57-apple"
       xcode-version: "16.1"
   Combine57:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     needs: [Windows57, Android57, Linux57, Apple57]
     steps:
       - name: Check out repository code
@@ -265,7 +265,7 @@ jobs:
     uses: ./.github/workflows/testPackageOnWindows.yml
     secrets: inherit
     with:
-      runner-label: windows-2022
+      runner-label: windows-2022-l
       unreal-engine-zip: "s3://cesium-unreal-engine/5.7.0/UE_5.7.zip"
       unreal-program-name: "UE_5.7"
       unreal-engine-association: "5.7"
@@ -276,7 +276,7 @@ jobs:
     uses: ./.github/workflows/buildWindows.yml
     secrets: inherit
     with:
-      runner-label: "windows-2022"
+      runner-label: "windows-2022-l"
       unreal-engine-version: "5.8.0"
       unreal-engine-zip: "s3://cesium-unreal-engine/5.8.0/UE_5.8.zip"
       unreal-program-name: "UE_5.8"
@@ -293,7 +293,7 @@ jobs:
     uses: ./.github/workflows/testWindows.yml
     secrets: inherit
     with:
-      runner-label: windows-2022
+      runner-label: windows-2022-l
       unreal-engine-zip: "s3://cesium-unreal-engine/5.8.0/UE_5.8.zip"
       unreal-program-name: "UE_5.8"
       test-package-base-name: "CesiumForUnreal-58-windows"
@@ -301,7 +301,7 @@ jobs:
     uses: ./.github/workflows/buildAndroid.yml
     secrets: inherit
     with:
-      runner-label: windows-2022
+      runner-label: windows-2022-l
       unreal-engine-version: "5.8.0"
       unreal-engine-zip: "s3://cesium-unreal-engine/5.8.0/UE_5.8.zip"
       unreal-program-name: "UE_5.8"
@@ -311,7 +311,7 @@ jobs:
     uses: ./.github/workflows/buildLinux.yml
     secrets: inherit
     with:
-      runner-label: ubuntu-22.04
+      runner-label: ubuntu-latest-m
       unreal-engine-version: "5.8.0"
       unreal-engine-zip: "s3://cesium-unreal-engine/5.8.0/Linux_Unreal_Engine_5.8.0.zip"
       unreal-program-name: "UE_5.8"
@@ -328,7 +328,7 @@ jobs:
       upload-package-base-name: "CesiumForUnreal-58-apple"
       xcode-version: "16.1"
   Combine58:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     needs: [Windows58, Android58, Linux58, Apple58]
     steps:
       - name: Check out repository code
@@ -383,7 +383,7 @@ jobs:
     uses: ./.github/workflows/testPackageOnWindows.yml
     secrets: inherit
     with:
-      runner-label: windows-2022
+      runner-label: windows-2022-l
       unreal-engine-zip: "s3://cesium-unreal-engine/5.8.0/UE_5.8.zip"
       unreal-program-name: "UE_5.8"
       unreal-engine-association: "5.8"

--- a/.github/workflows/buildLinux.yml
+++ b/.github/workflows/buildLinux.yml
@@ -36,14 +36,6 @@ jobs:
           apt list --installed
           sudo dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n
           sudo snap list
-      - name: Removed unneeded packages to gain disk space
-        run: |
-          sudo apt update
-          sudo apt remove google-chrome-stable clang-13 clang-14 clang-15 clang-format-13 clang-format-14 clang-format-15 llvm-13-dev llvm-13-linker-tools llvm-13-runtime llvm-13-tools llvm-13 llvm-14-dev llvm-14-linker-tools llvm-14-runtime llvm-14-tools llvm-14 llvm-15-dev llvm-15-linker-tools llvm-15-runtime llvm-15-tools llvm-15 x11-common xserver-common aspnetcore-runtime-6.0 aspnetcore-runtime-7.0 aspnetcore-runtime-8.0 aspnetcore-runtime-9.0 aspnetcore-targeting-pack-6.0 aspnetcore-targeting-pack-7.0 aspnetcore-targeting-pack-8.0 aspnetcore-targeting-pack-9.0 docker-ce-cli docker-ce dotnet-apphost-pack-6.0 dotnet-apphost-pack-7.0 dotnet-apphost-pack-8.0 dotnet-apphost-pack-9.0 dotnet-host dotnet-hostfxr-6.0 dotnet-hostfxr-7.0 dotnet-hostfxr-8.0 dotnet-hostfxr-9.0 dotnet-runtime-6.0 dotnet-runtime-7.0 dotnet-runtime-8.0 dotnet-runtime-9.0 dotnet-runtime-deps-6.0 dotnet-runtime-deps-7.0 dotnet-runtime-deps-8.0 dotnet-runtime-deps-9.0 dotnet-sdk-6.0 dotnet-sdk-7.0 dotnet-sdk-8.0 dotnet-sdk-9.0 dotnet-targeting-pack-6.0 dotnet-targeting-pack-7.0 dotnet-targeting-pack-8.0 dotnet-targeting-pack-9.0 eatmydata emacsen-common firebird3.0-common-doc firebird3.0-common firefox kubectl mercurial-common mercurial microsoft-edge-stable mssql-tools mysql-client-8.0 mysql-client-core-8.0 mysql-client mysql-common mysql-server-8.0 php8.1 postgresql-14 azure-cli microsoft-edge-stable google-cloud-cli temurin-21-jdk temurin-17-jdk temurin-11-jdk temurin-8-jdk powershell mysql-server-core-8.0 containerd.io libllvm15 libllvm14 libllvm13 mono-devel libclang-common-15-dev libclang-common-14-dev libclang-common-13-dev apache2-bin apache2-data apache2-utils apache2 containerd.io cpp-9 cpp-10 cpp-11 cpp-12 cpp docker-ce-cli docker-ce emacsen-common g++-9 g++-10 g++-11 g++-12 g++ gcc-9-base gcc-10-base gcc-11-base gcc-9 gcc-10 gcc-11 gcc-12 gcc gfortran-9 gfortran-10 gfortran-11 gfortran-12 gfortran ruby-dev ruby-full ruby-net-telnet ruby-rubygems ruby-webrick ruby-xmlrpc ruby3.0-dev ruby3.0-doc ruby3.0 ruby rubygems-integration alsa-topology-conf alsa-ucm-conf ant byobu cifs-utils conmon crun debugedit dirmngr imagemagick-6.q16 imagemagick-6-common imagemagick golang-github-containernetworking-plugin-dnsname golang-github-containers-common golang-github-containers-image java-common javascript-common postgresql-client-14 postgresql-client-common postgresql-common vim vim-common vim-runtime vim-tiny tex-common texinfo
-          df -h
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /usr/share/dotnet || true
-          df -h
       - name: Create some space to work in /mnt
         run: |
           sudo mkdir /mnt/work


### PR DESCRIPTION
Pretty small PR. Just changes the labels of the runners used for CI to use the larger runners we have access to. This will hopefully make builds faster and less error-prone.